### PR TITLE
apm: init at 0.8.9

### DIFF
--- a/packages/apm/default.nix
+++ b/packages/apm/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/apm/package.nix
+++ b/packages/apm/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchPypi,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  azure-ai-inference = python3.pkgs.buildPythonPackage rec {
+    pname = "azure-ai-inference";
+    version = "1.0.0b9";
+    pyproject = true;
+
+    src = fetchPypi {
+      pname = "azure_ai_inference";
+      inherit version;
+      hash = "sha256-H+tJa9hLAe4mkb78BDWPol18NE2CiOmTZEOIWa181aQ=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+    ];
+
+    dependencies = with python3.pkgs; [
+      azure-core
+      isodate
+      typing-extensions
+    ];
+
+    pythonImportsCheck = [ "azure.ai.inference" ];
+
+    # Tests require network access and Azure credentials
+    doCheck = false;
+
+    meta = with lib; {
+      description = "Microsoft Azure AI Inference Client Library for Python";
+      homepage = "https://github.com/Azure/azure-sdk-for-python";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  llm-github-models = python3.pkgs.buildPythonPackage rec {
+    pname = "llm-github-models";
+    version = "0.18.0";
+    pyproject = true;
+
+    src = fetchPypi {
+      pname = "llm_github_models";
+      inherit version;
+      hash = "sha256-t3iqb6Q+U+yzuGj8+YdbwOdgp3Sh+tduqQeiaVgqIEM=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+    ];
+
+    dependencies = with python3.pkgs; [
+      llm
+      aiohttp
+      azure-ai-inference
+    ];
+
+    pythonImportsCheck = [ "llm_github_models" ];
+
+    # Tests require GitHub API token
+    doCheck = false;
+
+    meta = with lib; {
+      description = "LLM plugin for GitHub Models";
+      homepage = "https://github.com/tonybaloney/llm-github-models";
+      license = licenses.asl20;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+in
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "apm";
+  version = "0.8.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "apm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kYAuCc//7bGw7LY3XrR385zHzfh8b5lTgJ9LyMXLr1Y=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  dependencies = with python3.pkgs; [
+    click
+    colorama
+    gitpython
+    llm
+    llm-github-models
+    python-frontmatter
+    pyyaml
+    requests
+    rich
+    rich-click
+    toml
+    watchdog
+  ];
+
+  pythonImportsCheck = [ "apm_cli" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "Agent Package Manager — dependency manager for AI agents";
+    homepage = "https://github.com/microsoft/apm";
+    changelog = "https://github.com/microsoft/apm/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    platforms = platforms.all;
+    mainProgram = "apm";
+  };
+})


### PR DESCRIPTION
## Summary

apm: init at 0.8.9

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
