### PR TITLE
oh-my-codex: init at 0.11.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>oh-my-codex</strong> - Multi-agent orchestration layer for OpenAI Codex CLI</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/Yeachan-Heo/oh-my-codex
+- **Usage**: `nix run github:numtide/llm-agents.nix#oh-my-codex -- --help`
+- **Nix**: [packages/oh-my-codex/package.nix](packages/oh-my-codex/package.nix)
+
+</details>
+<details>
 <summary><strong>oh-my-opencode</strong> - The Best AI Agent Harness - Multi-Model Orchestration for OpenCode</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,6 +87,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 25645555;
         name = "Pieter Pel";
       };
+      smdex = {
+        github = "smdex";
+        githubId = 105790745;
+        name = "Sergii Maksymov";
+      };
     };
   }
 )

--- a/packages/oh-my-codex/default.nix
+++ b/packages/oh-my-codex/default.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  perSystem,
+  flake,
+  ...
+}:
+let
+  npmPackumentSupport = pkgs.callPackage ../../lib/fetch-npm-deps.nix { };
+in
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (npmPackumentSupport) fetchNpmDepsWithPackuments npmConfigHook;
+  codex = perSystem.self.codex;
+}

--- a/packages/oh-my-codex/hashes.json
+++ b/packages/oh-my-codex/hashes.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.11.12",
+  "hash": "sha256-VcaAh0J1Iloxj89R2/UVy1NJNLkD3rK8GUTtYU0nSRI=",
+  "cargoHash": "sha256-BuA54daR1pIaVEkOVmYk6B54gVl3Flu4sVtWKZnsuHo=",
+  "npmDepsHash": "sha256-or53akxqVQt7zTghO/i4Yv7uHDV7l7no0cp5Hg8QY9Q="
+}

--- a/packages/oh-my-codex/package.nix
+++ b/packages/oh-my-codex/package.nix
@@ -14,17 +14,21 @@
 }:
 
 let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   pname = "oh-my-codex";
-  version = "0.11.12";
+  inherit (versionData)
+    version
+    hash
+    cargoHash
+    npmDepsHash
+    ;
 
   src = fetchFromGitHub {
     owner = "Yeachan-Heo";
     repo = "oh-my-codex";
     rev = "v${version}";
-    hash = "sha256-VcaAh0J1Iloxj89R2/UVy1NJNLkD3rK8GUTtYU0nSRI=";
+    inherit hash;
   };
-
-  cargoHash = "sha256-BuA54daR1pIaVEkOVmYk6B54gVl3Flu4sVtWKZnsuHo=";
 
   nodePlatformMap = {
     x86_64-linux = "linux";
@@ -90,7 +94,7 @@ buildNpmPackage (finalAttrs: {
   npmDeps = fetchNpmDepsWithPackuments {
     inherit (finalAttrs) src;
     name = "${pname}-${version}-npm-deps";
-    hash = "sha256-or53akxqVQt7zTghO/i4Yv7uHDV7l7no0cp5Hg8QY9Q=";
+    hash = npmDepsHash;
     fetcherVersion = 2;
   };
 
@@ -121,14 +125,14 @@ buildNpmPackage (finalAttrs: {
     install -Dm755 ${exploreHarness}/bin/omx-explore-harness \
       $root/bin/omx-explore-harness
 
-    cat > $root/bin/omx-explore-harness.meta.json <<EOF
+    cat > $root/bin/omx-explore-harness.meta.json <<META
     {
       "binaryName": "omx-explore-harness",
       "platform": "${nodePlatform}",
       "arch": "${nodeArch}",
       "strategy": "nix-packaged"
     }
-    EOF
+    META
 
     install -Dm755 ${sparkShell}/bin/omx-sparkshell \
       $root/bin/native/${nodePlatform}-${nodeArch}/omx-sparkshell

--- a/packages/oh-my-codex/package.nix
+++ b/packages/oh-my-codex/package.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  flake,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDepsWithPackuments,
+  npmConfigHook,
+  rustPlatform,
+  makeWrapper,
+  nodejs,
+  codex,
+  versionCheckHook,
+}:
+
+let
+  pname = "oh-my-codex";
+  version = "0.11.12";
+
+  src = fetchFromGitHub {
+    owner = "Yeachan-Heo";
+    repo = "oh-my-codex";
+    rev = "v${version}";
+    hash = "sha256-VcaAh0J1Iloxj89R2/UVy1NJNLkD3rK8GUTtYU0nSRI=";
+  };
+
+  cargoHash = "sha256-BuA54daR1pIaVEkOVmYk6B54gVl3Flu4sVtWKZnsuHo=";
+
+  nodePlatformMap = {
+    x86_64-linux = "linux";
+    aarch64-linux = "linux";
+    x86_64-darwin = "darwin";
+    aarch64-darwin = "darwin";
+  };
+
+  nodeArchMap = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+    aarch64-darwin = "arm64";
+  };
+
+  system = stdenv.hostPlatform.system;
+  nodePlatform = nodePlatformMap.${system} or (throw "Unsupported system for ${pname}: ${system}");
+  nodeArch = nodeArchMap.${system} or (throw "Unsupported architecture for ${pname}: ${system}");
+
+  mkNativeBinary =
+    cargoPackage: binaryName:
+    rustPlatform.buildRustPackage {
+      pname = binaryName;
+      inherit version src cargoHash;
+
+      cargoBuildFlags = [
+        "--package"
+        cargoPackage
+      ];
+
+      cargoInstallFlags = [
+        "--path"
+        "."
+        "--bin"
+        binaryName
+      ];
+
+      doCheck = false;
+
+      meta = with lib; {
+        description = "Native sidecar for ${pname}";
+        homepage = "https://github.com/Yeachan-Heo/oh-my-codex";
+        changelog = "https://github.com/Yeachan-Heo/oh-my-codex/releases/tag/v${version}";
+        license = licenses.mit;
+        sourceProvenance = with sourceTypes; [ fromSource ];
+        maintainers = with flake.lib.maintainers; [ smdex ];
+        mainProgram = binaryName;
+        platforms = platforms.unix;
+      };
+    };
+
+  exploreHarness = mkNativeBinary "omx-explore-harness" "omx-explore-harness";
+  sparkShell = mkNativeBinary "omx-sparkshell" "omx-sparkshell";
+in
+buildNpmPackage (finalAttrs: {
+  inherit
+    npmConfigHook
+    pname
+    version
+    src
+    ;
+
+  npmDeps = fetchNpmDepsWithPackuments {
+    inherit (finalAttrs) src;
+    name = "${pname}-${version}-npm-deps";
+    hash = "sha256-or53akxqVQt7zTghO/i4Yv7uHDV7l7no0cp5Hg8QY9Q=";
+    fetcherVersion = 2;
+  };
+
+  makeCacheWritable = true;
+  npmFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+    npm run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    root=$out/share/oh-my-codex
+    mkdir -p $out/bin $root $root/src
+
+    cp -r dist skills prompts templates package.json Cargo.toml Cargo.lock crates $root/
+    cp -r src/scripts $root/src/
+
+    npm prune --omit=dev
+    cp -r node_modules $root/
+    patchShebangs $root
+
+    install -Dm755 ${exploreHarness}/bin/omx-explore-harness \
+      $root/bin/omx-explore-harness
+
+    cat > $root/bin/omx-explore-harness.meta.json <<EOF
+    {
+      "binaryName": "omx-explore-harness",
+      "platform": "${nodePlatform}",
+      "arch": "${nodeArch}",
+      "strategy": "nix-packaged"
+    }
+    EOF
+
+    install -Dm755 ${sparkShell}/bin/omx-sparkshell \
+      $root/bin/native/${nodePlatform}-${nodeArch}/omx-sparkshell
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/omx \
+      --add-flags "$root/dist/cli/omx.js" \
+      --prefix PATH : ${lib.makeBinPath [ codex ]}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    category = "AI Coding Agents";
+    native = {
+      inherit exploreHarness sparkShell;
+    };
+  };
+
+  meta = with lib; {
+    description = "Multi-agent orchestration layer for OpenAI Codex CLI";
+    homepage = "https://github.com/Yeachan-Heo/oh-my-codex";
+    changelog = "https://github.com/Yeachan-Heo/oh-my-codex/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "omx";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/packages/oh-my-codex/update.py
+++ b/packages/oh-my-codex/update.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for oh-my-codex package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+
+def main() -> None:
+    """Update the oh-my-codex package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("Yeachan-Heo", "oh-my-codex")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url = f"https://github.com/Yeachan-Heo/oh-my-codex/archive/refs/tags/v{latest}.tar.gz"
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(url, unpack=True)
+
+    data = {
+        "version": latest,
+        "hash": source_hash,
+        "cargoHash": DUMMY_SHA256_HASH,
+        "npmDepsHash": load_hashes(HASHES_FILE)["npmDepsHash"],
+    }
+    save_hashes(HASHES_FILE, data)
+
+    try:
+        cargo_hash = calculate_dependency_hash(
+            ".#oh-my-codex.native.exploreHarness",
+            "cargoHash",
+            HASHES_FILE,
+            data,
+        )
+        data["cargoHash"] = cargo_hash
+        save_hashes(HASHES_FILE, data)
+
+        data["npmDepsHash"] = DUMMY_SHA256_HASH
+        save_hashes(HASHES_FILE, data)
+
+        npm_deps_hash = calculate_dependency_hash(
+            ".#oh-my-codex",
+            "npmDepsHash",
+            HASHES_FILE,
+            data,
+        )
+        data["npmDepsHash"] = npm_deps_hash
+        save_hashes(HASHES_FILE, data)
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        return
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/oh-my-codex/update.py
+++ b/packages/oh-my-codex/update.py
@@ -34,7 +34,9 @@ def main() -> None:
         print("Already up to date")
         return
 
-    url = f"https://github.com/Yeachan-Heo/oh-my-codex/archive/refs/tags/v{latest}.tar.gz"
+    url = (
+        f"https://github.com/Yeachan-Heo/oh-my-codex/archive/refs/tags/v{latest}.tar.gz"
+    )
 
     print("Calculating source hash...")
     source_hash = calculate_url_hash(url, unpack=True)


### PR DESCRIPTION
## Summary

Add **oh-my-codex** - Multi-agent orchestration layer for OpenAI Codex CLI

- **Source**: source
- **License**: MIT
- **Homepage**: https://github.com/Yeachan-Heo/oh-my-codex
- **Usage**: `nix run github:numtide/llm-agents.nix#oh-my-codex -- --help`
- **Nix**: [packages/oh-my-codex/package.nix](packages/oh-my-codex/package.nix)

## Test plan

The package is built, and tested, and the automated update works.

- [x] `nix build .#oh-my-codex` succeeds
- [x] Package has a custom `update.py`

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
