### PR TITLE
gastown: init at 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>gastown</strong> - Gas Town - multi-agent workspace manager</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/gastownhall/gastown
+- **Usage**: `nix run github:numtide/llm-agents.nix#gastown -- --help`
+- **Nix**: [packages/gastown/package.nix](packages/gastown/package.nix)
+
+</details>
+<details>
 <summary><strong>gemini-cli</strong> - AI agent that brings the power of Gemini directly into your terminal</summary>
 
 - **Source**: source

--- a/packages/gastown/default.nix
+++ b/packages/gastown/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) beads;
+}

--- a/packages/gastown/package.nix
+++ b/packages/gastown/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  beads,
+  dolt,
+  gitMinimal,
+  sqlite,
+  tmux,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "gastown";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "gastownhall";
+    repo = "gastown";
+    rev = "v${version}";
+    hash = "sha256-AZ36s/YXR271/BCrNkz5SRrWd4GwrHUOr480prZegiU=";
+  };
+
+  vendorHash = "sha256-PQT/Xq9na3vI8Oy9INBYJf3GsiN5IxAVCxrNLhyIpO8=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  subPackages = [ "cmd/gt" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/steveyegge/gastown/internal/cmd.Version=${version}"
+    "-X=github.com/steveyegge/gastown/internal/cmd.Build=release"
+    "-X=github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/gt \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          beads
+          dolt
+          gitMinimal
+          sqlite
+          tmux
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Gas Town - multi-agent workspace manager";
+    homepage = "https://github.com/gastownhall/gastown";
+    changelog = "https://github.com/gastownhall/gastown/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ zaninime ];
+    mainProgram = "gt";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary

Adds [gastown](https://github.com/gastownhall/gastown) to the list of packaged tools.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work