### PR TITLE
gnhf: 0.1.41 -> 0.1.42, migrate npm to pnpm

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -64,7 +64,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -139,7 +139,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/packages/gnhf/default.nix
+++ b/packages/gnhf/default.nix
@@ -7,4 +7,5 @@
 pkgs.callPackage ./package.nix {
   inherit flake;
   inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
+
 }

--- a/packages/gnhf/package.nix
+++ b/packages/gnhf/package.nix
@@ -3,22 +3,37 @@
   flake,
   buildNpmPackage,
   fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
   versionCheckHook,
   versionCheckHomeHook,
 }:
 
 buildNpmPackage rec {
   pname = "gnhf";
-  version = "0.1.41";
+  version = "0.1.42";
 
   src = fetchFromGitHub {
     owner = "kunchenguid";
     repo = "gnhf";
     rev = "gnhf-v${version}";
-    hash = "sha256-ajm9YU26Yf1RzE3dHD1GoUX55UXqgbwT2kUsNvtPjks=";
+    hash = "sha256-8dTfXCULAoXMJwb38bEMCazT7jzT130rzpLivVkx3Wc=";
   };
 
-  npmDepsHash = "sha256-QvU0AbTEbdylqUcrPEdQrO2DbF99qncsMBH3qdXCuSc=";
+  npmDeps = null;
+  pnpmDeps = fetchPnpmDeps {
+    inherit pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-sqLCB3xSsd+eIbwFh2JrXUDYVt9Y5TCPKV5eBaBrZxs=";
+  };
+
+  nativeBuildInputs = [ pnpm ];
+  npmConfigHook = pnpmConfigHook;
+
+  # npm prune hangs forever in pnpm-managed node_modules
+  dontNpmPrune = true;
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [


### PR DESCRIPTION
Upstream switched from npm to pnpm. Use fetchPnpmDeps + pnpmConfigHook instead of npmDepsHash.

Fixes update CI failure: `No lock file!` error because package-lock.json no longer exists.