### PR TITLE
herdr: build libghostty-vt with baseline CPU

### DIFF
--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -61,9 +61,13 @@ let
     # build.rs passes an explicit -Dtarget that zig treats as a cross target,
     # so build-time helper executables (uucode_build_tables) get linked against
     # the FHS dynamic loader path which doesn't exist in the sandbox.  Drop the
-    # flag so zig uses the native target and picks up the wrapped libc paths.
+    # flag so zig uses the native target and picks up the wrapped libc paths,
+    # but keep Zig's CPU baseline explicit to avoid build-host CPU features
+    # leaking into the output.
     postPatch = ''
       substituteInPlace build.rs \
+        --replace-fail '.arg("build")' '.arg("build")
+            .arg("-Dcpu=baseline")' \
         --replace-fail '.arg(format!("-Dtarget={zig_target}"))' ""
     '';
 


### PR DESCRIPTION
## Summary

  - pass `-Dcpu=baseline` to the vendored `libghostty-vt` Zig build used by `herdr`
  - keep the existing `-Dtarget` removal needed for sandboxed source builds
  - avoid leaking build-host CPU features such as AVX-512 into the Linux output

  ## Rationale

  `herdr` builds vendored `libghostty-vt` through `build.rs`, so the normal Zig setup hook defaults do not apply to that nested `zig build` invocation. Without an explicit CPU baseline, Zig can emit instructions supported by the builder CPU but not by all target x86_64 machines, causing runtime `SIGILL` failures.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
