### PR TITLE
antigravity: init at 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>antigravity</strong> - CLI for Google Antigravity, an agentic development platform</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://antigravity.google/
+- **Usage**: `nix run github:numtide/llm-agents.nix#antigravity -- --help`
+- **Nix**: [packages/antigravity/package.nix](packages/antigravity/package.nix)
+
+</details>
+<details>
 <summary><strong>bernstein</strong> - Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents</summary>
 
 - **Source**: source

--- a/packages/antigravity/default.nix
+++ b/packages/antigravity/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook wrapBuddy;
+}

--- a/packages/antigravity/default.nix
+++ b/packages/antigravity/default.nix
@@ -4,5 +4,5 @@
   ...
 }:
 pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) versionCheckHomeHook wrapBuddy;
+  inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/antigravity/hashes.json
+++ b/packages/antigravity/hashes.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "urls": {
+    "x86_64-linux": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/linux-x64/cli_linux_x64.tar.gz",
+    "aarch64-linux": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/linux-arm/cli_linux_arm64.tar.gz",
+    "x86_64-darwin": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/darwin-x64/cli_mac_x64.tar.gz",
+    "aarch64-darwin": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/darwin-arm/cli_mac_arm64.tar.gz"
+  },
+  "hashes": {
+    "x86_64-linux": "sha512-XM3MAfuGPH6OVkc8bJXbp1/tT9KiQiANgM/Ex/q4Ebcz9af6slMyEwqtKY5yYn4QGOaRGlZY9PBZ724BnyEZcg==",
+    "aarch64-linux": "sha512-l5fHlV0OB/xXYF+B+rFt/S85DUOyUIrzyml7HPpJjjfkOjqaVa2LJusTU9gLvsUi0QjrdaDrDrAOl5y1edbidw==",
+    "x86_64-darwin": "sha512-ZqhAWODDXkKoNiMk4j+QbOSThkcETQcSBc4yIEdvYpmLu2GbBMQA3g8Wx9G0BQxHaEAjaEODoJkmN91LuI2sqg==",
+    "aarch64-darwin": "sha512-zkzZNFQ4cHBBAmD91XrZg56K6gMaazStajPMbWdyREZ4RU25hQ2xdtM6ZzOkn0HloqUJJ1wTXMdBsyfpee7/4g=="
+  }
+}

--- a/packages/antigravity/package.nix
+++ b/packages/antigravity/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version urls hashes;
+
+  platform = stdenv.hostPlatform.system;
+in
+stdenv.mkDerivation {
+  pname = "antigravity";
+  inherit version;
+
+  src = fetchurl {
+    url = urls.${platform} or (throw "Unsupported system: ${platform}");
+    hash = hashes.${platform} or (throw "Unsupported system: ${platform}");
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 antigravity $out/bin/agy
+    ln -s agy $out/bin/antigravity
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "CLI for Google Antigravity, an agentic development platform";
+    homepage = "https://antigravity.google/";
+    changelog = "https://antigravity.google/cli";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "agy";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/antigravity/package.nix
+++ b/packages/antigravity/package.nix
@@ -37,9 +37,17 @@ stdenv.mkDerivation {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [
-    versionCheckHook
     versionCheckHomeHook
-  ];
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [ versionCheckHook ];
+
+  installCheckPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
+    runHook preInstallCheck
+
+    $out/bin/agy --help >/dev/null
+
+    runHook postInstallCheck
+  '';
 
   passthru.category = "AI Coding Agents";
 
@@ -49,7 +57,7 @@ stdenv.mkDerivation {
     changelog = "https://antigravity.google/cli";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "agy";
     platforms = [
       "x86_64-linux"

--- a/packages/antigravity/package.nix
+++ b/packages/antigravity/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  wrapBuddy,
+  autoPatchelfHook,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -22,7 +22,13 @@ stdenv.mkDerivation {
     hash = hashes.${platform} or (throw "Unsupported system: ${platform}");
   };
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  dontStrip = true;
 
   sourceRoot = ".";
 

--- a/packages/antigravity/update.py
+++ b/packages/antigravity/update.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for Antigravity CLI."""
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    fetch_json,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import hex_to_sri
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+MANIFEST_BASE = (
+    "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests"
+)
+PLATFORMS = {
+    "x86_64-linux": "linux_amd64",
+    "aarch64-linux": "linux_arm64",
+    "x86_64-darwin": "darwin_amd64",
+    "aarch64-darwin": "darwin_arm64",
+}
+
+
+def fetch_manifest(platform: str) -> dict[str, str]:
+    """Fetch a platform release manifest."""
+    result = fetch_json(f"{MANIFEST_BASE}/{platform}.json")
+    manifest = cast("dict[str, Any]", result)
+    return {
+        "version": str(manifest["version"]),
+        "url": str(manifest["url"]),
+        "sha512": str(manifest["sha512"]),
+    }
+
+
+def main() -> None:
+    """Update the Antigravity package."""
+    data = load_hashes(HASHES_FILE)
+    current = str(data["version"])
+    first_manifest = fetch_manifest(PLATFORMS["x86_64-linux"])
+    latest = first_manifest["version"]
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    urls = {}
+    hashes = {}
+    manifests = {"x86_64-linux": first_manifest}
+
+    for nix_platform, manifest_platform in PLATFORMS.items():
+        manifest = manifests.get(nix_platform) or fetch_manifest(manifest_platform)
+        if manifest["version"] != latest:
+            msg = f"{nix_platform} has version {manifest['version']}, expected {latest}"
+            raise RuntimeError(msg)
+
+        urls[nix_platform] = manifest["url"]
+        hashes[nix_platform] = hex_to_sri(manifest["sha512"], "sha512")
+        print(f"  {nix_platform}: {hashes[nix_platform]}")
+
+    save_hashes(
+        HASHES_FILE,
+        {
+            "version": latest,
+            "urls": urls,
+            "hashes": hashes,
+        },
+    )
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a package for Google Antigravity CLI at 1.0.0. The package uses the official per-platform release manifests and installs the upstream binary as agy, with antigravity as a convenience symlink.

## What Changed

- Added packages/antigravity with fixed manifest URLs and SHA512 hashes for Linux and Darwin on x86_64/aarch64.
- Added a custom updater that reads the upstream manifest endpoint.
- Regenerated the README package list.

## Testing

- nix fmt -- packages/antigravity
- nix build --accept-flake-config path:.#antigravity
- nix run --accept-flake-config path:.#antigravity -- --version
- ./result/bin/agy --version
- ./result/bin/antigravity --version
- uv run python packages/antigravity/update.py
- nix build --accept-flake-config --dry-run --system x86_64-linux path:.#antigravity
