### PR TITLE
flake: drop bun2nix staging-2.1.0 branch pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,16 +39,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1778445566,
+        "lastModified": 1778446047,
         "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "2499dedd70744dba1815875b854818a3019e9e4c",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "staging-2.1.0",
         "repo": "bun2nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,9 +22,7 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
     bun2nix = {
-      # TODO(#4001): drop the branch pin once catalog support
-      # (nix-community/bun2nix#86) reaches the default branch.
-      url = "github:nix-community/bun2nix/staging-2.1.0";
+      url = "github:nix-community/bun2nix";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
       inputs.treefmt-nix.follows = "treefmt-nix";


### PR DESCRIPTION
nix-community/bun2nix#86 (catalog: support) has been merged and the
staging-2.1.0 branch is now identical to master (2.1.0 release). Point
the input back at the default branch and drop the TODO.

Closes #4001
