### PR TITLE
fix(openspecui): strip workspace devDependencies when generating lockfile

### DIFF
--- a/packages/openspecui/update.py
+++ b/packages/openspecui/update.py
@@ -44,7 +44,14 @@ def main() -> None:
     print("Calculating source hash...")
     source_hash = calculate_url_hash(tarball_url)
 
-    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
+    # openspecui is published from a workspace; its devDependencies use the
+    # workspace:* protocol that npm cannot resolve here. package.nix strips
+    # them via `del(.devDependencies)`, so do the same when generating the lock.
+    if not extract_or_generate_lockfile(
+        tarball_url,
+        SCRIPT_DIR / "package-lock.json",
+        strip_dev_dependencies=True,
+    ):
         return
 
     # Update hashes.json

--- a/scripts/updater/npm.py
+++ b/scripts/updater/npm.py
@@ -37,6 +37,7 @@ def extract_or_generate_lockfile(
     output_path: Path,
     *,
     env: dict[str, str] | None = None,
+    strip_dev_dependencies: bool = False,
 ) -> bool:
     """Extract an npm lockfile from npm tarball or generate it.
 
@@ -47,6 +48,11 @@ def extract_or_generate_lockfile(
         tarball_url: URL to the npm package tarball
         output_path: Path where package-lock.json should be written
         env: Optional environment variables to pass to npm install
+        strip_dev_dependencies: Drop devDependencies from package.json before
+            generating the lockfile. Needed for packages published from a
+            workspace whose devDependencies use the ``workspace:*`` protocol,
+            which npm cannot resolve outside the monorepo. Mirror this with a
+            matching ``del(.devDependencies)`` in the package's derivation.
 
     Returns:
         True if lockfile was successfully extracted or generated, False otherwise
@@ -82,9 +88,16 @@ def extract_or_generate_lockfile(
 
         # Generate if not in tarball
         print("No npm lockfile in tarball, generating package-lock.json...")
-        if not (package_dir / "package.json").exists():
+        package_json = package_dir / "package.json"
+        if not package_json.exists():
             print("ERROR: No package.json found!")
             return False
+
+        if strip_dev_dependencies:
+            manifest = json.loads(package_json.read_text())
+            if manifest.pop("devDependencies", None) is not None:
+                package_json.write_text(json.dumps(manifest, indent=2) + "\n")
+                print("Stripped devDependencies before generating lockfile")
 
         run_env = {**os.environ, **(env or {})}
 


### PR DESCRIPTION
## Problem

`openspecui` has been silently stuck at its init version (`2.3.5`, merged April) — the daily updater has never bumped it, with no failing PR to signal why.

Root cause: the openspecui npm tarball ships **no `package-lock.json`**, so `extract_or_generate_lockfile` (`scripts/updater/npm.py`) falls back to `npm install --package-lock-only`. The package's `devDependencies` use the `workspace:*` protocol (`@openspecui/server`, `@openspecui/web`), which npm cannot resolve outside the monorepo:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

`update.py` then crashes on the `CalledProcessError`, so no update PR is ever opened.

`package.nix` already works around this for the **build** (`srcWithLock` does `jq 'del(.devDependencies)'`) — but the **updater** generates its lockfile from the raw, unstripped `package.json`. The two disagreed.

## Fix

- Add a `strip_dev_dependencies` option to `extract_or_generate_lockfile`. When set, it drops `devDependencies` from the extracted `package.json` before generating the lockfile. Generic — reusable by any package published from an npm workspace.
- Use it from `packages/openspecui/update.py`, mirroring `package.nix`. Safe: the tarball ships a prebuilt `dist/` and the derivation sets `dontNpmBuild = true`, so devDeps are never needed.

Bumps `openspecui` `2.3.5` → `3.7.2`.

## Verification

- `python3 update.py` now completes: regenerates `package-lock.json` + `hashes.json` for 3.7.2.
- `nix build .#openspecui` succeeds.
- `openspecui --version` → `3.7.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)