### PR TITLE
pi: 0.75.3 -> 0.75.4

### DIFF
--- a/packages/pi/hashes.json
+++ b/packages/pi/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.75.3",
-  "sourceHash": "sha256-aZLAoy8BhRJuJVHsrK54K2It75QiAhui5+91OBt0Fow=",
-  "npmDepsHash": "sha256-SAF9D2gROIZO9ssL95YXf03ASUQUAJlacvOnrq7zIYg="
+  "version": "0.75.4",
+  "sourceHash": "sha256-12e1dKKCSyy2dee6hT7Wo9hNw36DUCviKxSuubgY1pc=",
+  "npmDepsHash": "sha256-Sen38ht+nMHCQjTMTrTz3ujBXlC/w50Z9Pn9j6QcInU="
 }

--- a/packages/pi/package-lock.json
+++ b/packages/pi/package-lock.json
@@ -1,51 +1,51 @@
 {
 	"name": "@earendil-works/pi-coding-agent",
-	"version": "0.75.3",
+	"version": "0.75.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@earendil-works/pi-coding-agent",
-			"version": "0.75.3",
+			"version": "0.75.4",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.75.3",
-				"@earendil-works/pi-ai": "^0.75.3",
-				"@earendil-works/pi-tui": "^0.75.3",
-				"@silvia-odwyer/photon-node": "^0.3.4",
-				"chalk": "^5.5.0",
-				"cross-spawn": "^7.0.6",
-				"diff": "^8.0.2",
-				"glob": "^13.0.1",
-				"highlight.js": "^10.7.3",
-				"hosted-git-info": "^9.0.2",
-				"ignore": "^7.0.5",
-				"jiti": "^2.7.0",
-				"minimatch": "^10.2.3",
-				"proper-lockfile": "^4.1.2",
-				"typebox": "^1.1.24",
-				"undici": "^8.3.0",
-				"yaml": "^2.8.2"
+				"@earendil-works/pi-agent-core": "^0.75.4",
+				"@earendil-works/pi-ai": "^0.75.4",
+				"@earendil-works/pi-tui": "^0.75.4",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"typebox": "1.1.38",
+				"undici": "8.3.0",
+				"yaml": "2.9.0"
 			},
 			"bin": {
 				"pi": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@types/cross-spawn": "^6.0.6",
-				"@types/diff": "^7.0.2",
-				"@types/hosted-git-info": "^3.0.5",
-				"@types/ms": "^2.1.0",
-				"@types/node": "^24.3.0",
-				"@types/proper-lockfile": "^4.1.4",
-				"shx": "^0.4.0",
-				"typescript": "^5.7.3",
-				"vitest": "^3.2.4"
+				"@types/cross-spawn": "6.0.6",
+				"@types/diff": "7.0.2",
+				"@types/hosted-git-info": "3.0.5",
+				"@types/ms": "2.1.0",
+				"@types/node": "24.12.4",
+				"@types/proper-lockfile": "4.1.4",
+				"shx": "0.4.0",
+				"typescript": "5.9.3",
+				"vitest": "3.2.4"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			},
 			"optionalDependencies": {
-				"@mariozechner/clipboard": "^0.3.6"
+				"@mariozechner/clipboard": "0.3.6"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -157,17 +157,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"version": "3.974.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
+			"integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws-sdk/types": "^3.973.9",
+				"@aws-sdk/xml-builder": "^3.972.25",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.2",
+				"@smithy/core": "^3.24.3",
 				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -176,15 +176,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
+			"integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -192,17 +192,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
+			"integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/fetch-http-handler": "^5.4.2",
-				"@smithy/node-http-handler": "^4.7.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
+				"@smithy/node-http-handler": "^4.7.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -210,23 +210,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
+			"integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/credential-provider-env": "^3.972.37",
-				"@aws-sdk/credential-provider-http": "^3.972.39",
-				"@aws-sdk/credential-provider-login": "^3.972.41",
-				"@aws-sdk/credential-provider-process": "^3.972.37",
-				"@aws-sdk/credential-provider-sso": "^3.972.41",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/credential-provider-env": "^3.972.39",
+				"@aws-sdk/credential-provider-http": "^3.972.41",
+				"@aws-sdk/credential-provider-login": "^3.972.43",
+				"@aws-sdk/credential-provider-process": "^3.972.39",
+				"@aws-sdk/credential-provider-sso": "^3.972.43",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
 				"@smithy/credential-provider-imds": "^4.3.2",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -234,16 +234,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
+			"integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -251,21 +251,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.42",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
+			"integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.37",
-				"@aws-sdk/credential-provider-http": "^3.972.39",
-				"@aws-sdk/credential-provider-ini": "^3.972.41",
-				"@aws-sdk/credential-provider-process": "^3.972.37",
-				"@aws-sdk/credential-provider-sso": "^3.972.41",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
+				"@aws-sdk/credential-provider-env": "^3.972.39",
+				"@aws-sdk/credential-provider-http": "^3.972.41",
+				"@aws-sdk/credential-provider-ini": "^3.972.43",
+				"@aws-sdk/credential-provider-process": "^3.972.39",
+				"@aws-sdk/credential-provider-sso": "^3.972.43",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
 				"@smithy/credential-provider-imds": "^4.3.2",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -273,15 +273,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
+			"integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -289,17 +289,34 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
+			"integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/token-providers": "3.1048.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/token-providers": "3.1052.0",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1052.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
+			"integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -307,16 +324,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
+			"integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/nested-clients": "^3.997.9",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -324,14 +341,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"version": "3.972.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
+			"integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -339,14 +356,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.12",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
+			"integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -354,17 +371,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"version": "3.972.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
+			"integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/fetch-http-handler": "^5.4.2",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
 				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -372,20 +389,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"version": "3.997.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
+			"integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.11",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
-				"@smithy/fetch-http-handler": "^5.4.2",
-				"@smithy/node-http-handler": "^4.7.2",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.28",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
+				"@smithy/node-http-handler": "^4.7.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -393,15 +410,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.27",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"version": "3.996.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
+			"integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/core": "^3.24.2",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
 				"@smithy/signature-v4": "^5.4.2",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -426,12 +443,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"version": "3.973.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+			"integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -451,13 +468,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
+			"integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@nodable/entities": "2.1.0",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
@@ -484,35 +501,35 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.3.tgz",
-			"integrity": "sha512-azg09GSrckQa3ffbH09YEZC7DyHgmNSX+vmWEoEhQvp4icbzqbqLfIeMayMNEK/aGusm1SghZC4bPlDdagDALg==",
+			"version": "0.75.4",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
+			"integrity": "sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.75.3",
-				"ignore": "^7.0.5",
-				"typebox": "^1.1.24",
-				"yaml": "^2.8.2"
+				"@earendil-works/pi-ai": "^0.75.4",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.3.tgz",
-			"integrity": "sha512-UKccS+ADlkSVJ49a00346jUfXmUi6zzzB+pPWotsyA6SxhKr2ejjkGQksGyR1DyNVrsEP/WWlsOSTUUwVlzNaA==",
+			"version": "0.75.4",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
+			"integrity": "sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.1",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
 				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"typebox": "^1.1.24"
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
 			},
 			"bin": {
 				"pi-ai": "dist/cli.js"
@@ -522,19 +539,19 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.3.tgz",
-			"integrity": "sha512-UbhtCsae+b3Y8/ZxtBPhiOrkD66gOHvJbfvLZwhBBsNtQuvUkZY5t9MQwmb8QcDYkFRnXHaq3FcEy1hjRSfj6w==",
+			"version": "0.75.4",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.4.tgz",
+			"integrity": "sha512-PDhKU7u6fmEcvHUFHzrRwGc/Ytokj/hO+X4RPf+MWKEGpvg3B1vHv88Ee+Dy33004tYkQF5YeXV4btJZcp5x1g==",
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12"
+				"get-east-asian-width": "1.6.0",
+				"marked": "15.0.12"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			},
 			"optionalDependencies": {
-				"koffi": "^2.9.0"
+				"koffi": "2.16.2"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1284,9 +1301,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
@@ -1724,9 +1741,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.24.3",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"version": "3.24.4",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
+			"integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
@@ -1738,12 +1755,12 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
+			"integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.3",
+				"@smithy/core": "^3.24.4",
 				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
@@ -1752,12 +1769,12 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
+			"integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.3",
+				"@smithy/core": "^3.24.4",
 				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
@@ -1778,12 +1795,12 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
+			"integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.3",
+				"@smithy/core": "^3.24.4",
 				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
@@ -1792,12 +1809,12 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
+			"integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.3",
+				"@smithy/core": "^3.24.4",
 				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
@@ -2908,9 +2925,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.4.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
-			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"version": "11.5.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+			"integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -3240,9 +3257,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -3260,7 +3277,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -3289,16 +3306,16 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-			"integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+			"integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
 				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
 				"@protobufjs/inquire": "^1.1.2",

--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -22,6 +22,7 @@ let
         hash = versionData.sourceHash;
       }
     } -C $out --strip-components=1
+    rm -f $out/npm-shrinkwrap.json
     cp ${./package-lock.json} $out/package-lock.json
   '';
 in

--- a/packages/pi/update.py
+++ b/packages/pi/update.py
@@ -45,7 +45,7 @@ def main() -> None:
     source_hash = calculate_url_hash(tarball_url)
 
     if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
-        return
+        sys.exit(1)
 
     # Update hashes.json
     data = {
@@ -64,7 +64,7 @@ def main() -> None:
         save_hashes(HASHES_FILE, data)
     except (ValueError, NixCommandError) as e:
         print(f"Error: {e}")
-        return
+        sys.exit(1)
 
     print(f"Updated to {latest}")
 

--- a/scripts/updater/npm.py
+++ b/scripts/updater/npm.py
@@ -1,11 +1,35 @@
 """NPM package utilities for Nix package updates."""
 
+import json
 import os
 import subprocess
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import Any
 from urllib.request import urlretrieve
+
+
+def _can_prefetch_npm_lockfile(lockfile: Path) -> bool:
+    """Return whether the lockfile has enough metadata for Nix prefetching."""
+    data: dict[str, Any] = json.loads(lockfile.read_text())
+    packages = data.get("packages", {})
+    if not isinstance(packages, dict):
+        return True
+
+    for package_path, package_data in packages.items():
+        if package_path == "" or not isinstance(package_data, dict):
+            continue
+
+        resolved = package_data.get("resolved")
+        if not isinstance(resolved, str) or resolved.startswith("git+"):
+            continue
+
+        if "integrity" not in package_data:
+            print(f"Skipping npm-shrinkwrap.json; missing integrity for {package_path}")
+            return False
+
+    return True
 
 
 def extract_or_generate_lockfile(
@@ -14,10 +38,10 @@ def extract_or_generate_lockfile(
     *,
     env: dict[str, str] | None = None,
 ) -> bool:
-    """Extract package-lock.json from npm tarball or generate it.
+    """Extract an npm lockfile from npm tarball or generate it.
 
-    Downloads the npm tarball, checks if it contains a package-lock.json,
-    and either extracts it or generates one using npm.
+    Downloads the npm tarball, checks if it contains package-lock.json or
+    npm-shrinkwrap.json, and either extracts it or generates one using npm.
 
     Args:
         tarball_url: URL to the npm package tarball
@@ -40,6 +64,7 @@ def extract_or_generate_lockfile(
 
         package_dir = tmpdir_path / "package"
         package_lock_src = package_dir / "package-lock.json"
+        shrinkwrap_src = package_dir / "npm-shrinkwrap.json"
 
         # Check if lockfile exists in tarball
         if package_lock_src.exists():
@@ -47,13 +72,26 @@ def extract_or_generate_lockfile(
             print("Updated package-lock.json from tarball")
             return True
 
+        # npm-shrinkwrap.json uses the same lockfile format and is published to
+        # npm tarballs. Prefer it over regenerating a less exact lockfile when
+        # it has enough metadata for Nix's npm dependency prefetcher.
+        if shrinkwrap_src.exists() and _can_prefetch_npm_lockfile(shrinkwrap_src):
+            output_path.write_text(shrinkwrap_src.read_text())
+            print("Updated package-lock.json from npm-shrinkwrap.json in tarball")
+            return True
+
         # Generate if not in tarball
-        print("No package-lock.json in tarball, generating...")
+        print("No npm lockfile in tarball, generating package-lock.json...")
         if not (package_dir / "package.json").exists():
             print("ERROR: No package.json found!")
             return False
 
         run_env = {**os.environ, **(env or {})}
+
+        # npm updates npm-shrinkwrap.json instead of creating package-lock.json
+        # when shrinkwrap is present. Remove it when falling back to generation.
+        if shrinkwrap_src.exists():
+            shrinkwrap_src.unlink()
 
         subprocess.run(
             ["npm", "install", "--package-lock-only", "--ignore-scripts"],


### PR DESCRIPTION
## Summary

- teach the npm updater to handle published `npm-shrinkwrap.json` files, falling back to generated `package-lock.json` when shrinkwrap entries lack integrity metadata for Nix prefetching
- remove upstream `npm-shrinkwrap.json` from the `pi` source wrapper so `buildNpmPackage` uses the generated lockfile
- update `pi` from 0.75.3 to 0.75.4

## Testing

- `nix shell --inputs-from .# nixpkgs#python3 --command python3 ./packages/pi/update.py`
- `nix build --accept-flake-config .#pi`
- `nix fmt`
- `python3 -m py_compile scripts/updater/npm.py packages/pi/update.py`
