### PR TITLE
Add new package: reasonix at version 0.49.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/qwen-code/package.nix](packages/qwen-code/package.nix)
 
 </details>
+<details>
+<summary><strong>reasonix</strong> - DeepSeek-native AI coding agent for your terminal</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/esengine/DeepSeek-Reasonix
+- **Usage**: `nix run github:numtide/llm-agents.nix#reasonix -- --help`
+- **Nix**: [packages/reasonix/package.nix](packages/reasonix/package.nix)
+
+</details>
 
 ### AI Assistants
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -127,6 +127,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 2153;
         name = "Ben Vinegar";
       };
+      arch-fan = {
+        github = "arch-fan";
+        githubId = 55891793;
+        name = "arch-fan";
+      };
     };
   }
 )

--- a/packages/reasonix/default.nix
+++ b/packages/reasonix/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/reasonix/default.nix
+++ b/packages/reasonix/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
+  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/reasonix/nix-update-args
+++ b/packages/reasonix/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/reasonix/package.nix
+++ b/packages/reasonix/package.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  flake,
   versionCheckHook,
   versionCheckHomeHook,
   ...
@@ -22,6 +23,10 @@ pkgs.buildNpmPackage rec {
 
   npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
+  # Skip node-gyp rebuild of dev-only tree-sitter-typescript native addon;
+  # runtime uses web-tree-sitter (WASM) instead.
+  npmFlags = [ "--ignore-scripts" ];
+
   dontCheckForBrokenSymlinks = true;
 
   doInstallCheck = true;
@@ -34,9 +39,9 @@ pkgs.buildNpmPackage rec {
     description = "DeepSeek-native AI coding agent for your terminal";
     homepage = "https://github.com/esengine/DeepSeek-Reasonix";
     license = lib.licenses.mit;
-    changelog = "https://github.com/esengine/DeepSeek-Reasonix/releases";
+    changelog = "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with lib.maintainers; [ arch-fan ];
+    maintainers = with flake.lib.maintainers; [ arch-fan ];
     mainProgram = "reasonix";
     platforms = lib.platforms.unix;
   };

--- a/packages/reasonix/package.nix
+++ b/packages/reasonix/package.nix
@@ -1,0 +1,47 @@
+{
+  pkgs,
+  lib,
+  versionCheckHook,
+  versionCheckHomeHook,
+  ...
+}:
+pkgs.buildNpmPackage rec {
+  pname = "reasonix";
+  version = "0.49.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "esengine";
+    repo = "DeepSeek-Reasonix";
+    rev = "v${version}";
+    hash = "sha256-msfAkLH/yReZiun6MCqNxcFRfnlVdWmHo6bofz1FBSA=";
+  };
+
+  npmDeps = pkgs.importNpmLock {
+    npmRoot = src;
+  };
+
+  npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+
+  dontCheckForBrokenSymlinks = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  meta = {
+    description = "DeepSeek-native AI coding agent for your terminal";
+    homepage = "https://github.com/esengine/DeepSeek-Reasonix";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/esengine/DeepSeek-Reasonix/releases";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ arch-fan ];
+    mainProgram = "reasonix";
+    platforms = lib.platforms.unix;
+  };
+
+  passthru = {
+    category = "AI Coding Agents";
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new package for Reasonix at version 0.49.0.
The update flow is set up to use nix-update with package-specific args so it follows the intended tag stream.

## Test plan

<!-- How did you test this change? -->
- Built the package locally:
  - nix build --accept-flake-config .#reasonix
- Verified repository checks:
  - nix flake check
- Verified update path:
  - nix-update works for this package with packages/reasonix/nix-update-args

- [X] `nix build .#<package>` succeeds
- [X] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work