### PR TITLE
opencode: add libstdc++ NEEDED for @parcel/watcher native addon

### DIFF
--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -80,6 +80,15 @@ stdenv.mkDerivation {
     stdenv.cc.cc.lib
   ];
 
+  # @parcel/watcher's native .node addon is dlopen'd from bun's virtual
+  # filesystem at runtime.  wrapBuddy cannot patch it, but if libstdc++
+  # is already loaded in the process the linker resolves it from there.
+  # Inject libstdc++.so.6 as a DT_NEEDED entry via wrapBuddy so it's
+  # loaded before the addon (see #5170).
+  wrapBuddyExtraNeeded = lib.optionals stdenv.hostPlatform.isLinux [
+    "libstdc++.so.6"
+  ];
+
   dontConfigure = true;
   dontBuild = true;
   # otherwise strip will remove the compressed typescript code

--- a/packages/wrapBuddy/package.nix
+++ b/packages/wrapBuddy/package.nix
@@ -15,8 +15,8 @@ let
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "wrap-buddy";
-    rev = "v${version}";
-    hash = "sha256-kZfaqMDKV0zyw8OP2HWJgGEHnbIXPUz2yI6Yl9MlilU=";
+    rev = "ba5ab56ddc572482c26b2cf08414befc5f66ad40";
+    hash = "sha256-NlBlJbQsFKDgUtawzAEGF0iIO/xON2LXGw/axFOU4g8=";
   };
 
   # Get interpreter info from stdenv attributes (avoids IFD)


### PR DESCRIPTION
@parcel/watcher's native `.node` addon is dlopen'd from bun's virtual
filesystem at runtime. It requires `libstdc++.so.6` but wrapBuddy cannot
patch the addon since it never exists on disk.

Add `libstdc++.so.6` as a NEEDED dependency on the main binary via
patchelf so the dynamic linker loads it at process start. wrapBuddy
already includes gcc-lib in its library search path (from `buildInputs`),
so the library resolves without any `LD_LIBRARY_PATH`.

Closes #5170