### PR TITLE
oh-my-opencode: build and ship ast_grep / lsp MCP servers

### DIFF
--- a/packages/oh-my-opencode/hashes.json
+++ b/packages/oh-my-opencode/hashes.json
@@ -1,4 +1,5 @@
 {
   "version": "4.4.0",
-  "hash": "sha256-LpXlTW+c6tsgl1RJ1lQ3GQ2qogaZqjEu95pZimSh5CM="
+  "hash": "sha256-cAYD3RH5b9YeSj8TJfBObLL9y1D1jXyoMMRjd3HER3Q=",
+  "lspToolsMcpNpmHash": "sha256-P2xzDhZg8DslkajX+eI7OeIvzTkoTVWERH7v0dMfIXg="
 }

--- a/packages/oh-my-opencode/package.nix
+++ b/packages/oh-my-opencode/package.nix
@@ -4,25 +4,43 @@
   stdenv,
   bun2nix,
   bun,
+  nodejs,
   fetchFromGitHub,
+  fetchNpmDeps,
   makeWrapper,
   autoPatchelfHook,
 }:
 
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  inherit (versionData) version hash;
-in
-stdenv.mkDerivation {
-  pname = "oh-my-opencode";
-  inherit version;
+  inherit (versionData)
+    version
+    hash
+    lspToolsMcpNpmHash
+    ;
 
-  src = fetchFromGitHub {
+  upstream = fetchFromGitHub {
     owner = "code-yeongyu";
     repo = "oh-my-openagent";
     tag = "v${version}";
     inherit hash;
+    # packages/lsp-tools-mcp/ is a git submodule needed for the plugin's
+    # built-in `lsp` MCP server.
+    fetchSubmodules = true;
   };
+
+  # lsp-tools-mcp is npm-managed (own package-lock.json), so it can't
+  # share the top-level bun deps.
+  lspToolsMcpDeps = fetchNpmDeps {
+    name = "oh-my-opencode-${version}-lsp-tools-mcp-deps";
+    src = "${upstream}/packages/lsp-tools-mcp";
+    hash = lspToolsMcpNpmHash;
+  };
+in
+stdenv.mkDerivation {
+  pname = "oh-my-opencode";
+  inherit version;
+  src = upstream;
 
   # Non-empty when upstream ships a stale bun.lock; kept in sync by update.py
   patches = lib.optional (
@@ -32,6 +50,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     bun2nix.hook
     bun
+    nodejs
     makeWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
@@ -67,6 +86,21 @@ stdenv.mkDerivation {
     # Generate the config schema (non-fatal if it fails)
     bun run build:schema || true
 
+    # Build the ast_grep MCP server (bun workspace package)
+    bun run --cwd packages/ast-grep-mcp build
+
+    # Build the lsp_tools MCP server (npm-managed submodule) offline
+    # against the pre-fetched npm cache
+    pushd packages/lsp-tools-mcp >/dev/null
+      export HOME="$TMPDIR"
+      export npm_config_cache="$TMPDIR/npm-cache"
+      cp -r --no-preserve=mode ${lspToolsMcpDeps} "$npm_config_cache"
+      npm ci --offline --no-audit --no-fund --ignore-scripts
+      # /usr/bin/env shebangs in npm-installed bins (tsc, ...) fail in the sandbox
+      patchShebangs node_modules
+      npm run build
+    popd >/dev/null
+
     runHook postBuild
   '';
 
@@ -76,6 +110,17 @@ stdenv.mkDerivation {
     mkdir -p $out/lib/oh-my-opencode $out/bin
 
     cp -r dist node_modules package.json $out/lib/oh-my-opencode/
+
+    # The plugin resolves its MCP servers at
+    # <ancestor>/packages/{ast-grep-mcp,lsp-tools-mcp}/dist/cli.js
+    mkdir -p $out/lib/oh-my-opencode/packages
+    cp -r packages/{ast-grep-mcp,lsp-tools-mcp} $out/lib/oh-my-opencode/packages/
+
+    # ast-grep-mcp's dist/cli.js is a self-contained bun bundle; its
+    # node_modules only holds a workspace symlink that would dangle in
+    # $out and fail noBrokenSymlinks. lsp-tools-mcp keeps its
+    # node_modules — tsc output imports deps at runtime.
+    rm -rf $out/lib/oh-my-opencode/packages/ast-grep-mcp/node_modules
 
     # Remove broken workspace symlinks (monorepo workspace packages
     # aren't needed at runtime — the CLI bundle is self-contained)

--- a/packages/oh-my-opencode/update.py
+++ b/packages/oh-my-opencode/update.py
@@ -3,9 +3,10 @@
 
 """Update script for oh-my-opencode package.
 
-Custom updater needed because oh-my-opencode uses bun2nix: after each version
-bump the bun.nix lockfile must be regenerated from the upstream bun.lock
-using the bun2nix CLI.
+Custom updater needed because oh-my-opencode uses bun2nix (bun.nix must be
+regenerated from upstream bun.lock) and fetches submodules, so both the
+source hash and the lsp-tools-mcp npm deps hash are recovered from failed
+builds via calculate_dependency_hash instead of nix-prefetch-url.
 """
 
 import sys
@@ -14,6 +15,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
+    calculate_dependency_hash,
     clone_and_generate_bun_nix,
     fetch_github_latest_release,
     load_hashes,
@@ -21,7 +23,6 @@ from updater import (
     should_update,
     strip_workspace_entries,
 )
-from updater.nix import nix_prefetch_url
 
 PKG_DIR = Path(__file__).parent
 FLAKE_ROOT = PKG_DIR.parent.parent
@@ -46,17 +47,11 @@ def main() -> None:
 
     print(f"Updating oh-my-opencode from {current} to {latest}")
 
-    # Step 1: Calculate new source hash
-    print("Calculating source hash...")
-    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
-    src_hash = nix_prefetch_url(url, unpack=True)
-    print(f"  source hash: {src_hash}")
+    # Step 1: Bump version; hashes are filled in by the steps below
+    data["version"] = latest
+    save_hashes(HASHES_FILE, data)
 
-    # Step 2: Update hashes.json
-    save_hashes(HASHES_FILE, {"version": latest, "hash": src_hash})
-    print("Updated hashes.json")
-
-    # Step 3: Regenerate bun.nix from upstream bun.lock
+    # Step 2: Regenerate bun.nix from upstream bun.lock
     clone_and_generate_bun_nix(
         OWNER,
         REPO,
@@ -66,9 +61,33 @@ def main() -> None:
         ref_prefix="v",
         pkg_dir=PKG_DIR,
     )
-
     # Strip workspace copyPathToStore entries that don't exist in our tree
     strip_workspace_entries(BUN_NIX, "@oh-my-opencode", FLAKE_ROOT)
+
+    # Step 3: Source hash. nix-prefetch-url can't be used because the
+    # GitHub tarball excludes submodule contents.
+    print("Calculating source hash (with submodules)...")
+    src_hash = calculate_dependency_hash(
+        package_attr=".#oh-my-opencode",
+        hash_key="hash",
+        hashes_file=HASHES_FILE,
+        data=data,
+    )
+    data["hash"] = src_hash
+    save_hashes(HASHES_FILE, data)
+    print(f"  source hash: {src_hash}")
+
+    # Step 4: lsp-tools-mcp npm deps hash
+    print("Calculating lsp-tools-mcp npm cache hash...")
+    npm_hash = calculate_dependency_hash(
+        package_attr=".#oh-my-opencode",
+        hash_key="lspToolsMcpNpmHash",
+        hashes_file=HASHES_FILE,
+        data=data,
+    )
+    data["lspToolsMcpNpmHash"] = npm_hash
+    save_hashes(HASHES_FILE, data)
+    print(f"  lspToolsMcpNpmHash: {npm_hash}")
 
     print(f"Updated oh-my-opencode to {latest}")
 


### PR DESCRIPTION
## Problem

The `oh-my-opencode` plugin bundles two MCP servers that it spawns as subprocesses at runtime:

- **`ast_grep_mcp`** (workspace package at `packages/ast-grep-mcp/`) — exposes `ast_grep_search` and `ast_grep_replace` (AST-aware code search + rewrite across 25 languages).
- **`lsp_tools_mcp`** (git submodule at `packages/lsp-tools-mcp/`) — exposes `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_rename`, etc.

Both are headline features of the plugin (see upstream README: *"LSP + AST-Grep: workspace rename, pre-build diagnostics, AST-aware rewrites. IDE precision for agents."*).

Currently both fail at runtime in the Nix-built plugin with:

```
MCP error -32000: Connection closed
```

because their compiled CLIs are missing from the store output:

1. `fetchFromGitHub` omits the `lsp-tools-mcp` submodule (default `fetchSubmodules = false`), so `packages/lsp-tools-mcp/` is empty in `$src`.
2. `buildPhase` never runs upstream's `bun run build:ast-grep-mcp` or `build:lsp-tools-mcp` scripts.
3. `installPhase` only copies `dist/`, `node_modules/`, `package.json` — `packages/` is never shipped, so even the ast-grep workspace package (which IS in `$src`) wouldn't reach `$out`.

The plugin's runtime resolver (`addAncestorCommandCandidates` in `dist/index.js`) walks ancestors of its own module URL looking for `<ancestor>/packages/{ast-grep-mcp,lsp-tools-mcp}/dist/cli.js` — the same layout the published npm tarball ships (`oh-my-opencode-4.4.0.tgz` `files` field includes `packages/lsp-tools-mcp/dist` and `packages/ast-grep-mcp/dist`). Fix is to mirror that layout in `$out`.

## Changes

### `package.nix`

1. **`fetchSubmodules = true`** so `packages/lsp-tools-mcp/` is present in `$src`.
2. **New `fetchNpmDeps` FOD** scoped to `packages/lsp-tools-mcp/`. Required because upstream's `build:lsp-tools-mcp` script uses `npm ci` (not bun) — the submodule is a separate repo with its own `package-lock.json`.
3. **Extended `buildPhase`** to:
   - `bun run --cwd packages/ast-grep-mcp build` (uses top-level bun workspace symlinks already set up by `bun2nix.hook`).
   - Inside `packages/lsp-tools-mcp/`: wire the pre-fetched npm cache, `npm ci --offline`, `patchShebangs node_modules` (because npm-installed bins like `tsc` ship `#!/usr/bin/env` shebangs that fail in the Nix sandbox), then `npm run build`.
4. **Extended `installPhase`** to copy `packages/{ast-grep-mcp,lsp-tools-mcp}` into `$out/lib/oh-my-opencode/packages/`. The ast-grep-mcp `dist/cli.js` is a self-contained bun bundle so its `node_modules/` (which only carries a workspace symlink to `@oh-my-opencode/ast-grep-core`) is removed — leaving it would dangle the symlink and fail `noBrokenSymlinks`. The peer is inlined into the bundle, so dropping it is safe.
5. Added `nodejs` to `nativeBuildInputs` for the `npm ci` step.

### `hashes.json`

Added `lspToolsMcpNpmHash` alongside `version` + source `hash`.

### `update.py`

- Switched source-hash computation from `nix_prefetch_url` to `calculate_dependency_hash`. The former fetches the GitHub tarball without submodules and produces a hash that no longer matches `fetchFromGitHub { fetchSubmodules = true; }`.
- Added a second `calculate_dependency_hash` call for `lspToolsMcpNpmHash` so the npm cache hash is auto-refreshed on every version bump (the submodule pointer can move independently of the parent version).

## Verification

Local build succeeds against current `main`:

```
$ nix build .#oh-my-opencode
# ... builds clean
$ ls result/lib/oh-my-opencode/packages/{ast-grep-mcp,lsp-tools-mcp}/dist/cli.js
-r-xr-xr-x ... result/lib/oh-my-opencode/packages/ast-grep-mcp/dist/cli.js
-r--r--r-- ... result/lib/oh-my-opencode/packages/lsp-tools-mcp/dist/cli.js
```

Both MCPs respond to `tools/list` against the built artifact:

```
$ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
    | node result/lib/oh-my-opencode/packages/ast-grep-mcp/dist/cli.js mcp
{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search",...},{"name":"replace",...}]}}

$ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
    | node result/lib/oh-my-opencode/packages/lsp-tools-mcp/dist/cli.js mcp
{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"status",...},{"name":"diagnostics",...},
                                            {"name":"goto_definition",...},{"name":"find_references",...},
                                            {"name":"symbols",...},{"name":"prepare_rename",...},
                                            {"name":"rename",...}]}}
```

End-to-end validated through home-manager rebuild: the new oh-my-opencode store path is wired into `~/.config/opencode/opencode-ohmyopencode.json`, and both `cli.js` files load and answer `tools/list` against the active store path. (Compared against the pre-fix build where both failed with `Cannot find module .../packages/lsp-tools-mcp/dist/cli.js` and Connection closed.)

## Notes

- Closes the runtime gap that surfaces as red `Connection closed` entries in the OpenCode MCP status panel for `ast_grep` and `lsp` when using oh-my-openagent via this flake.
- `oh-my-claudecode` is a separate upstream project and not affected by this change (it doesn't use these submodules).
