### PR TITLE
semble: init at 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>semble</strong> - Fast and accurate local code search for AI agents — CLI and MCP server</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/MinishLab/semble
+- **Usage**: `nix run github:numtide/llm-agents.nix#semble -- --help`
+- **Nix**: [packages/semble/package.nix](packages/semble/package.nix)
+
+</details>
+<details>
 <summary><strong>showboat</strong> - Create executable demo documents showing and proving an agent's work</summary>
 
 - **Source**: source

--- a/packages/semble/default.nix
+++ b/packages/semble/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  perSystem,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/semble/package.nix
+++ b/packages/semble/package.nix
@@ -1,0 +1,232 @@
+{
+  lib,
+  flake,
+  python3,
+  fetchFromGitHub,
+  fetchPypi,
+  makeWrapper,
+  versionCheckHomeHook,
+}:
+
+let
+  # Three of semble's direct runtime dependencies are not in nixpkgs.
+  # Vendor them inline (same pattern as hermes-agent / parallel-cli), since
+  # they have no consumer in this flake other than semble itself.
+
+  model2vec = python3.pkgs.buildPythonPackage rec {
+    pname = "model2vec";
+    version = "0.8.1";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-mjXTX2pETkzsGfICfuEGxUllzSa3/UpPACtfPitnd/Q=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+      setuptools-scm
+    ];
+
+    env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+    dependencies = with python3.pkgs; [
+      jinja2
+      joblib
+      numpy
+      rich
+      safetensors
+      setuptools
+      tokenizers
+      tqdm
+    ];
+
+    # Tests require torch + the [distill] / [train] extras, which we do not ship.
+    doCheck = false;
+
+    pythonImportsCheck = [ "model2vec" ];
+
+    meta = with lib; {
+      description = "Distill a small fast model from any sentence transformer";
+      homepage = "https://github.com/MinishLab/model2vec";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  vicinity = python3.pkgs.buildPythonPackage rec {
+    pname = "vicinity";
+    version = "0.4.4";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-Tg/+G7B4zkYE2nYn0vMgw52W0lKUhdDqpeLEyyuzKys=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+      setuptools-scm
+    ];
+
+    env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+    dependencies = with python3.pkgs; [
+      numpy
+      orjson
+      tqdm
+    ];
+
+    # Tests require optional backends (hnswlib, faiss, etc.) that we don't ship.
+    doCheck = false;
+
+    pythonImportsCheck = [ "vicinity" ];
+
+    meta = with lib; {
+      description = "Lightweight nearest neighbors library with flexible backends";
+      homepage = "https://github.com/MinishLab/vicinity";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  bm25s = python3.pkgs.buildPythonPackage rec {
+    pname = "bm25s";
+    version = "0.3.9";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-iVxnnZUrfeg1XttfPhpiCh4vKU0dQrkZvwghzOLi9Zc=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+    ];
+
+    dependencies = with python3.pkgs; [
+      numpy
+      # bm25s declares orjson/tqdm/PyStemmer/numba only under the [core] extra,
+      # but semble exercises code paths that need them at runtime (tokenization,
+      # progress bars, JSON serialization, JIT-compiled scoring).
+      orjson
+      tqdm
+      pystemmer
+      numba
+    ];
+
+    # Tests need optional extras (jax, scipy, pytrec_eval, etc.).
+    doCheck = false;
+
+    pythonImportsCheck = [ "bm25s" ];
+
+    meta = with lib; {
+      description = "Fast lexical search using Best Matching 25 (BM25)";
+      homepage = "https://github.com/xhluca/bm25s";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "semble";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MinishLab";
+    repo = "semble";
+    rev = "v${version}";
+    hash = "sha256-daFdBd9yM8AjnSi56n5AS++hhe3VMTg1bOP9rXyZHDo=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+    setuptools-scm
+  ];
+
+  # setuptools_scm normally derives the version from git metadata, but the
+  # fetched source tarball has none. Inject the version explicitly so the
+  # build doesn't fall back to 0.0.0+unknown (which would also break the
+  # static `attr = semble.version.__version__` resolver in pyproject.toml).
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  # Ship the [mcp] extra unconditionally — Nix users get one closure either
+  # way, and exposing both binaries (`semble` and `semble-mcp`) is cleaner
+  # than gating MCP behind a separate derivation.
+  dependencies = with python3.pkgs; [
+    model2vec
+    vicinity
+    numpy
+    bm25s
+    pathspec
+    tree-sitter
+    tree-sitter-language-pack
+    orjson
+    # [mcp] extra:
+    mcp
+    watchfiles
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Upstream's `semble` entry point auto-dispatches to either the CLI or the
+  # MCP server based on argv[1]. Expose a second binary that always launches
+  # the MCP server so users can wire it into agent configs without relying on
+  # the implicit "no-subcommand-means-MCP" behaviour.
+  postInstall = ''
+    makeWrapper $out/bin/semble $out/bin/semble-mcp
+  '';
+
+  pythonImportsCheck = [
+    "semble"
+    "semble.cli"
+    "semble.mcp"
+  ];
+
+  # semble does not implement `--version`, so skip versionCheckHook and run
+  # an equivalent smoke check ourselves. versionCheckHomeHook is still useful
+  # because semble touches ~/.semble for the `savings` ledger.
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHomeHook
+  ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/semble --help >/dev/null
+    test -x $out/bin/semble-mcp
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    category = "Utilities";
+    inherit model2vec vicinity bm25s;
+  };
+
+  meta = with lib; {
+    description = "Fast and accurate local code search for AI agents — CLI and MCP server";
+    longDescription = ''
+      Semble indexes a codebase using tree-sitter-aware chunking, static
+      Model2Vec embeddings, and BM25, then serves results either through the
+      `semble` CLI (search, index, find-related, init, savings) or through the
+      `semble-mcp` MCP server for agents like Claude Code, Cursor, Codex, and
+      OpenCode.
+    '';
+    homepage = "https://github.com/MinishLab/semble";
+    changelog = "https://github.com/MinishLab/semble/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ murlakatam ];
+    mainProgram = "semble";
+    # x86_64-darwin excluded: arrow-cpp (transitive via tree-sitter-language-pack)
+    # is marked broken on that platform in nixpkgs.
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
Adds [Semble](https://github.com/MinishLab/semble) — a fast tree-sitter + Model2Vec + BM25 hybrid code search engine for AI agents.

## What

Ships **two binaries from one derivation**:

- `semble` — the CLI (`search`, `index`, `find-related`, `init`, `savings`)
- `semble-mcp` — a thin `makeWrapper` wrapper that launches Semble's MCP server, so users can wire it into Claude Code / Cursor / Codex / OpenCode configs without relying on the implicit "`semble` with no args means MCP" dispatch behaviour upstream uses.

Both binaries share the same closure (the [mcp] extra is shipped unconditionally). Splitting into two derivations was considered, but the closure-size win for a CLI-only build is negligible (`mcp` + `watchfiles` are tiny next to `tokenizers`, `safetensors`, `numpy`, and `tree-sitter-language-pack`), and the maintenance cost of two near-identical derivations is real.

## Vendored dependencies

Three direct runtime deps are not in nixpkgs and are vendored inline in the same let-binding (same pattern as `hermes-agent` and `parallel-cli`):

- **model2vec** 0.8.1 — static embedding distillation
- **vicinity** 0.4.4 — lightweight nearest-neighbours library
- **bm25s** 0.3.9 — BM25 lexical retriever

They are also exposed via `passthru` in case other packages want to depend on them later.

## Platforms

- `x86_64-linux` ✅
- `aarch64-linux` ✅ (eval-checked)
- `aarch64-darwin` ✅ (eval-checked)
- `x86_64-darwin` ❌ — excluded because `arrow-cpp` (transitive via `tree-sitter-language-pack`) is marked broken on that platform in nixpkgs

## Testing

```console
$ nix build .#semble
$ ./result/bin/semble --help
usage: semble [-h] {search,find-related,init,savings} ...

$ ./result/bin/semble search 'user authentication logic' /tmp/semble-test/
Search results for: 'user authentication logic'
## 1. app.py:1-8  [score=0.020]
```def authenticate_user(username, password): ...```

$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' | ./result/bin/semble-mcp
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{...},"serverInfo":{"name":"semble","version":"1.26.0"},...}}
```

Also verified:
- `nix fmt` clean
- `nix build .#checks.x86_64-linux.pkgs-semble` passes
- `nix build .#checks.x86_64-linux.meta-maintainers` passes
- README package docs regenerated via `./scripts/generate-package-docs.py`