### PR TITLE
code-review-graph: scode-v0.2.1 -> 2.3.5, restrict updater to backend tags

### DIFF
--- a/packages/code-review-graph/nix-update-args
+++ b/packages/code-review-graph/nix-update-args
@@ -1,0 +1,5 @@
+# Upstream also tags VS Code extension releases (vscode-vX.Y.Z); only
+# accept plain Python backend tags like v2.3.5 (or v2.2.3.1).
+--use-github-releases
+--version-regex
+^v([0-9]+(?:\.[0-9]+)+)$

--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -18,14 +18,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "code-review-graph";
-  version = "scode-v0.2.1";
+  version = "2.3.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tirth8205";
     repo = "code-review-graph";
     rev = "v${version}";
-    hash = "sha256-XbiMzON15tSga/exf4rNG8cAzbrAYKRYOdO6ojda2nU=";
+    hash = "sha256-dbtvtxSi4S42sBkCBLtYPH3ck6f1gKsmvGmcrcBqcdU=";
   };
 
   build-system = with python.pkgs; [
@@ -46,7 +46,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   # Relax version constraints — nixpkgs versions are newer but compatible.
-  # fastmcp: upstream vscode-v0.2.1 pins `<3` but main already moved to `>=3.2.4`
+  # fastmcp: upstream v2.3.5 pins `<3` but main already moved to `>=3.2.4`
   # (no API breaks for the tool/prompt decorators used here), so accept the
   # nixpkgs 3.x build until the next tagged release.
   pythonRelaxDeps = [


### PR DESCRIPTION
The automated nix-update run picked up the VS Code extension release tag `vscode-v0.2.1` as the latest GitHub release, downgrading the package from the Python backend `v2.3.2` and producing the bogus version `scode-v0.2.1` (after stripping the leading `v`).

- Add a `nix-update-args` file with `--version-regex` so only plain backend tags (`vX.Y.Z`, including four-component ones like `v2.2.3.1`) are considered.
- Bump to the current backend release v2.3.5.

Tested: `nix build .#code-review-graph` succeeds, `code-review-graph --help` works.

Fixes #5204