### PR TITLE
ci: pass CLIENT_ID secret through reusable update workflow

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -23,8 +23,8 @@ on:
         type: boolean
         default: false
     secrets:
-      APP_ID:
-        description: 'GitHub App ID'
+      CLIENT_ID:
+        description: 'GitHub App client ID'
         required: true
       APP_PRIVATE_KEY:
         description: 'GitHub App private key'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
       pr-labels: 'dependencies,automated'
       auto-merge: true
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     permissions:
       contents: write


### PR DESCRIPTION
Commit a7ffec73 switched `create-github-app-token` from `app-id` to `client-id`, but `update-flake.yml` is a reusable workflow and only receives secrets that the caller explicitly passes. The `workflow_call` secrets block still declared `APP_ID` and `update.yml` still forwarded `APP_ID`, so `secrets.CLIENT_ID` was empty and every scheduled run failed at the 'Generate GitHub App Token' step.

Declare `CLIENT_ID` in the reusable workflow and forward it from `update.yml` instead of the now-unused `APP_ID` (the repo secret `CLIENT_ID` already exists).

Fixes #5203

Once merged, the scheduled update workflow should pick up opencode 1.15.11 and resolve #5207 as well.