### PR TITLE
goose-cli: 1.24.0 -> 1.36.0, fix automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 - **Source**: source
 - **License**: Apache-2.0
-- **Homepage**: https://github.com/block/goose
+- **Homepage**: https://github.com/aaif-goose/goose
 - **Usage**: `nix run github:numtide/llm-agents.nix#goose-cli -- --help`
 - **Nix**: [packages/goose-cli/package.nix](packages/goose-cli/package.nix)
 

--- a/packages/goose-cli/hashes.json
+++ b/packages/goose-cli/hashes.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.36.0",
+  "hash": "sha256-L/B4JpjvNcU+N0lkzVBcWviCXHzP+r3WXlWlnUtzPjg=",
+  "cargoHash": "sha256-eP2NeThOJDykE87GYMGEP0xby7x7Qyp6qqCLEBcKbWo=",
+  "librustyV8": {
+    "version": "145.0.0",
+    "hashes": {
+      "x86_64-linux": "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=",
+      "aarch64-linux": "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=",
+      "x86_64-darwin": "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=",
+      "aarch64-darwin": "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k="
+    }
+  }
+}

--- a/packages/goose-cli/librusty_v8.nix
+++ b/packages/goose-cli/librusty_v8.nix
@@ -1,13 +1,12 @@
-# Pre-built librusty_v8 library for goose-cli
-# This file specifies the rusty_v8 version and hashes for all supported platforms
+# Pre-built librusty_v8 library for goose-cli.
+# Version and per-platform hashes live in hashes.json (librustyV8 key) and are
+# kept in sync with goose's Cargo.lock by update.py.
 { fetchLibrustyV8 }:
 
+let
+  data = (builtins.fromJSON (builtins.readFile ./hashes.json)).librustyV8;
+in
 fetchLibrustyV8 {
-  version = "145.0.0";
-  shas = {
-    x86_64-linux = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
-    aarch64-linux = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
-    x86_64-darwin = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
-    aarch64-darwin = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
-  };
+  inherit (data) version;
+  shas = data.hashes;
 }

--- a/packages/goose-cli/package.nix
+++ b/packages/goose-cli/package.nix
@@ -3,33 +3,50 @@
   fetchFromGitHub,
   rustPlatform,
   pkg-config,
+  cmake,
   openssl,
   libxcb,
   dbus,
   versionCheckHook,
+  cacert,
   librusty_v8,
 }:
 
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+in
 rustPlatform.buildRustPackage rec {
   pname = "goose-cli";
-  version = "1.24.0";
+  inherit (versionData) version cargoHash;
 
   src = fetchFromGitHub {
-    owner = "block";
+    # Upstream moved from block/goose to aaif-goose/goose.
+    owner = "aaif-goose";
     repo = "goose";
     rev = "v${version}";
-    hash = "sha256-98psnT7hmnLav7pYFN55fj04R+avjzoc2lVpXsFN6M8=";
+    inherit (versionData) hash;
   };
 
-  cargoHash = "sha256-jZpk9x0d4JXfFGSmgi51uO774boOlUEyNhkSQMZZmSM=";
+  nativeBuildInputs = [
+    pkg-config
+    # llama-cpp-sys-2 builds llama.cpp via cmake and generates bindings with
+    # bindgen, which needs libclang at build time.
+    cmake
+    rustPlatform.bindgenHook
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
+  # The cmake setup hook would otherwise try to configure the cargo project
+  # itself; llama-cpp-sys-2 invokes cmake on its own.
+  dontUseCmakeConfigure = true;
 
   buildInputs = [
     openssl
     libxcb
     dbus
   ];
+
+  # reqwest-based tests need a CA bundle to construct HTTP clients.
+  nativeCheckInputs = [ cacert ];
 
   # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
@@ -51,8 +68,10 @@ rustPlatform.buildRustPackage rec {
     export XDG_CACHE_HOME=$HOME/.cache
     mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME $XDG_STATE_HOME $XDG_CACHE_HOME
 
-    # Run tests for goose-cli package only
-    cargo test --package goose-cli --release
+    # Run tests for goose-cli package only.
+    # test_verify_provenance_warns_on_missing_attestation needs network access.
+    cargo test --package goose-cli --release -- \
+      --skip commands::update::tests::test_verify_provenance_warns_on_missing_attestation
   '';
 
   doInstallCheck = true;
@@ -62,8 +81,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "CLI for Goose - a local, extensible, open source AI agent that automates engineering tasks";
-    homepage = "https://github.com/block/goose";
-    changelog = "https://github.com/block/goose/releases/tag/v${version}";
+    homepage = "https://github.com/aaif-goose/goose";
+    changelog = "https://github.com/aaif-goose/goose/releases/tag/v${version}";
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
     mainProgram = "goose";

--- a/packages/goose-cli/update.py
+++ b/packages/goose-cli/update.py
@@ -3,23 +3,35 @@
 
 """Update script for goose-cli package.
 
-This script updates both the goose-cli version and the librusty_v8 hashes.
-The v8 version is extracted from the Cargo.lock file of the goose repository.
+Bumps the goose version, source hash and cargoHash in hashes.json and keeps
+the librusty_v8 release hashes in sync with the v8 version pinned in goose's
+Cargo.lock. Everything is driven through hashes.json because nix-update
+cannot handle the extra librusty_v8 fixed-output derivation.
 """
 
 import sys
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
+    calculate_dependency_hash,
     calculate_platform_hashes,
+    calculate_url_hash,
+    fetch_github_latest_release,
     fetch_text,
     load_hashes,
     save_hashes,
+    should_update,
 )
+from updater.hash import DUMMY_SHA256_HASH
+from updater.nix import NixCommandError
 
-HASHES_FILE = Path(__file__).parent / "librusty_v8_hashes.json"
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+# Upstream moved from block/goose to aaif-goose/goose.
+OWNER = "aaif-goose"
+REPO = "goose"
 
 PLATFORMS = {
     "x86_64-linux": "x86_64-unknown-linux-gnu",
@@ -31,14 +43,14 @@ PLATFORMS = {
 
 def fetch_v8_version_from_cargo_lock(goose_version: str) -> str:
     """Extract the v8 version from goose's Cargo.lock file."""
-    url = f"https://raw.githubusercontent.com/block/goose/v{goose_version}/Cargo.lock"
+    url = (
+        f"https://raw.githubusercontent.com/{OWNER}/{REPO}/v{goose_version}/Cargo.lock"
+    )
     cargo_lock = fetch_text(url)
 
-    # Parse the Cargo.lock to find v8 version
     lines = cargo_lock.split("\n")
     for i, line in enumerate(lines):
         if line.strip() == 'name = "v8"':
-            # Look for version in the next few lines
             for j in range(i + 1, min(i + 10, len(lines))):
                 if "version = " in lines[j]:
                     return lines[j].split('"')[1]
@@ -47,60 +59,53 @@ def fetch_v8_version_from_cargo_lock(goose_version: str) -> str:
     raise ValueError(msg)
 
 
-def main() -> None:
-    """Update the librusty_v8 hashes for goose-cli."""
-    # Read the current goose-cli version from package.nix
-    package_nix = (Path(__file__).parent / "package.nix").read_text()
-    for line in package_nix.split("\n"):
-        if "version = " in line and '"' in line:
-            goose_version = line.split('"')[1]
-            break
-    else:
-        msg = "Could not find version in package.nix"
-        raise ValueError(msg)
-
-    print(f"Goose version: {goose_version}")
-
-    # Get the v8 version from Cargo.lock
+def update_librusty_v8(data: dict[str, Any], goose_version: str) -> None:
+    """Sync librustyV8 entry in hashes.json with goose's Cargo.lock."""
     v8_version = fetch_v8_version_from_cargo_lock(goose_version)
-    print(f"V8 version: {v8_version}")
+    current = data.get("librustyV8", {})
+    if current.get("version") == v8_version:
+        print(f"librusty_v8 already up to date ({v8_version})")
+        return
 
-    # Check if we need to update
+    print(f"Updating librusty_v8 to {v8_version}")
+    url_template = (
+        f"https://github.com/denoland/rusty_v8/releases/download/"
+        f"v{v8_version}/librusty_v8_release_{{platform}}.a.gz"
+    )
+    data["librustyV8"] = {
+        "version": v8_version,
+        "hashes": calculate_platform_hashes(url_template, PLATFORMS),
+    }
+
+
+def main() -> None:
+    """Update the goose-cli package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release(OWNER, REPO)
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    src_url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
+    data["version"] = latest
+    data["hash"] = calculate_url_hash(src_url, unpack=True)
+    data["cargoHash"] = DUMMY_SHA256_HASH
+    update_librusty_v8(data, latest)
+    save_hashes(HASHES_FILE, data)
+
     try:
-        data = load_hashes(HASHES_FILE)
-        current_v8 = data.get("version", "")
-        if current_v8 == v8_version:
-            print(f"V8 hashes already up to date ({v8_version})")
-            return
-    except FileNotFoundError:
-        print("No existing hashes file, creating new one")
+        data["cargoHash"] = calculate_dependency_hash(
+            ".#goose-cli", "cargoHash", HASHES_FILE, data
+        )
+    except (ValueError, NixCommandError) as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    save_hashes(HASHES_FILE, data)
 
-    # Calculate hashes for all platforms
-    url_template = f"https://github.com/denoland/rusty_v8/releases/download/v{v8_version}/librusty_v8_release_{{platform}}.a.gz"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    # Save the hashes
-    save_hashes(HASHES_FILE, {"version": v8_version, "hashes": hashes})
-
-    # Update librusty_v8.nix
-    librusty_v8_nix = Path(__file__).parent / "librusty_v8.nix"
-    content = f"""# Pre-built librusty_v8 library for goose-cli
-# This file specifies the rusty_v8 version and hashes for all supported platforms
-{{ fetchLibrustyV8 }}:
-
-fetchLibrustyV8 {{
-  version = "{v8_version}";
-  shas = {{
-    x86_64-linux = "{hashes["x86_64-linux"]}";
-    aarch64-linux = "{hashes["aarch64-linux"]}";
-    x86_64-darwin = "{hashes["x86_64-darwin"]}";
-    aarch64-darwin = "{hashes["aarch64-darwin"]}";
-  }};
-}}
-"""
-    librusty_v8_nix.write_text(content)
-
-    print(f"Updated librusty_v8 to {v8_version}")
+    print(f"Updated to {latest}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
goose-cli has been stuck at 1.24.0 since February because its update script only refreshed the librusty_v8 hashes and never bumped the goose version it read from `package.nix`, so the scheduled update job succeeded every run without doing anything. On top of that, upstream moved from `block/goose` to `aaif-goose/goose`, so API lookups against the old owner now return redirects.

Changes:
- Move version, source hash, cargoHash and the librusty_v8 pins into `hashes.json`.
- Rewrite `update.py` to bump the goose release from `aaif-goose/goose`, prefetch the source, recalculate cargoHash via the dummy-hash build and keep librusty_v8 in sync with Cargo.lock.
- Build fixes for 1.36.0:
  - llama-cpp-sys-2 builds llama.cpp with cmake and bindgen → add `cmake` and `rustPlatform.bindgenHook` (with `dontUseCmakeConfigure`).
  - reqwest-based unit tests need a CA bundle → add `cacert` to `nativeCheckInputs`, skip the one test that needs network access.

Tested: `nix build .#packages.x86_64-linux.goose-cli` (full cargo test for goose-cli + version check) passes; update script verified end-to-end (it produced this bump).

Fixes #5206