### PR TITLE
Fix failed auto-updates: gemini-cli 0.44.0, cache bun2nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,16 +74,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "lastModified": 1779955849,
+        "narHash": "sha256-31mhzm2HpzRr/rupWAFfWBmt9SUjzwr5+giv5Nmb/rA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "rev": "a2c6938835fca96e4a10c8561d461efd2f91d04f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     systems.url = "github:nix-systems/default";
     blueprint = {
       url = "github:numtide/blueprint";

--- a/packages/bun2nix/default.nix
+++ b/packages/bun2nix/default.nix
@@ -1,0 +1,17 @@
+{
+  flake,
+  pkgs,
+  ...
+}:
+# bun2nix CLI from the flake input, exposed so CI pushes it to the binary
+# cache and update jobs don't have to build it from source (crates.io
+# rejects nix's crate downloads with 403).
+let
+  bun2nix = flake.inputs.bun2nix.packages.${pkgs.stdenv.hostPlatform.system}.bun2nix;
+in
+bun2nix
+// {
+  passthru = (bun2nix.passthru or { }) // {
+    hideFromDocs = true;
+  };
+}

--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -19,16 +19,16 @@
 buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   pname = "gemini-cli";
-  version = "0.43.0";
+  version = "0.44.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UFz+CQLGbzFlpa5Mhf/frnQJWttF35URvua1QTfoaZ0=";
+    hash = "sha256-+DoYL1+bmA3iRL/wa98gaN/CckYsx83TPCuTGoxrKeM=";
   };
 
-  npmDepsHash = "sha256-kz3S+EYAKYJtRAaHYsYHgsfAMxf4PZzDi4A6256FDLc=";
+  npmDepsHash = "sha256-/AQ0FapaqZp5F7d42bYQ44X6rZtp4ARrZDmYvRm/L9k=";
   makeCacheWritable = true;
 
   nativeBuildInputs = [
@@ -52,10 +52,15 @@ buildNpmPackage (finalAttrs: {
   '';
 
   postPatch = ''
-    # Hardcode ripgrep path so ensureRgPath() returns our Nix-provided binary
-    # instead of downloading or finding a dynamically-linked one
+    # Point resolveRipgrepPath() at our ripgrep: no bundled rg binaries exist
+    # and the trusted-path check rejects /nix/store, so allow the store dir.
     substituteInPlace packages/core/src/tools/ripGrep.ts \
-      --replace-fail "await ensureRgPath();" "'${lib.getExe ripgrep}';"
+      --replace-fail \
+        "const systemRg = resolveExecutable('rg');" \
+        "const systemRg = resolveExecutable('${lib.getExe ripgrep}');" \
+      --replace-fail \
+        "if (isTrustedSystemPath(realPath)) {" \
+        "if (isTrustedSystemPath(realPath) || realPath.startsWith('${builtins.storeDir}/')) {"
 
     # Disable auto-update and update nag: Nix manages updates, not the tool itself.
     # v0.27.0 reads these defaults cleanly from the schema (unlike v0.25.2 / nixpkgs#13569).

--- a/packages/gitbutler/package.nix
+++ b/packages/gitbutler/package.nix
@@ -64,8 +64,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 2;
-    hash = "sha256-ODWwS8zszq890nRCxEjE9/i9nmNZfIkKZ/Ag9Fka/PA=";
+    fetcherVersion = 3;
+    hash = "sha256-a8vpHJXIEDXrovGezNnBrSbmybyFRemQLzn0oyY0s9M=";
   };
 
   nativeBuildInputs = [

--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    hash = "sha256-6v+ZYBLqh30MbddSSMUnZrDzxriIMP8znGpxhuLcN4Q=";
-    fetcherVersion = 2;
+    hash = "sha256-GiqtQ0HtdfpVmCK1sDZPt/KeGPcHUe6I4piAbzIxOBQ=";
+    fetcherVersion = 3;
     prePnpmInstall = stripPatchedDeps;
   };
 

--- a/scripts/updater/bun.py
+++ b/scripts/updater/bun.py
@@ -21,14 +21,13 @@ def regenerate_bun_nix(
 ) -> None:
     """Regenerate a bun.nix file from a bun.lock using bun2nix.
 
-    Runs bun2nix directly from the flake's bun2nix input via
-    ``nix run --inputs-from``, which handles building and caching
-    the binary automatically.
+    Runs the flake's own ``bun2nix`` package, which is available from the
+    binary cache.
 
     Args:
         bun_lock_path: Path to the bun.lock file
         bun_nix_output: Path where bun.nix should be written
-        flake_root: Root directory of the flake (to resolve bun2nix input)
+        flake_root: Root directory of the flake (provides the bun2nix package)
 
     Raises:
         RuntimeError: If bun2nix fails
@@ -39,9 +38,7 @@ def regenerate_bun_nix(
             [
                 "nix",
                 "run",
-                "--inputs-from",
-                str(flake_root),
-                "bun2nix#bun2nix",
+                f"{flake_root}#bun2nix",
                 "--",
                 "--lock-file",
                 str(bun_lock_path),


### PR DESCRIPTION
Fixes the failed update jobs from https://github.com/numtide/llm-agents.nix/actions/runs/26562840727

- gemini-cli: bump to 0.44.0; upstream replaced `ensureRgPath()` with `resolveRipgrepPath()`, breaking our ripgrep patch. New patch resolves the Nix ripgrep and allows the store dir in the trusted-path check.
- bun2nix: update jobs built bun2nix from source and failed because crates.io now returns 403 to nix's crate downloads (askama). Expose bun2nix as a hidden package so CI caches it on cache.numtide.com and run the updater against that package.