### PR TITLE
mistral-vibe: bump textual override to 8.2.7

### DIFF
--- a/packages/mistral-vibe/package.nix
+++ b/packages/mistral-vibe/package.nix
@@ -99,14 +99,15 @@ let
     packageOverrides = _pyfinal: pyprev: {
       inherit textual-speedups tree-sitter-bash;
 
-      # mistral-vibe pins textual==8.2.4. Textual 8.2.5 removed the built-in
-      # "textual-ansi" theme that vibe sets at startup, causing
-      # `Theme 'textual-ansi' has not been registered` (issue #4914).
+      # mistral-vibe 2.12.1 pins textual==8.2.7 and sets DEFAULT_THEME="ansi-dark"
+      # (vibe/core/config/_settings.py), a built-in theme that only exists in
+      # textual >=8.2.5. Pinning textual to 8.2.4 crashed vibe at startup with
+      # `InvalidThemeError: Theme 'ansi-dark' has not been registered`.
       textual = pyprev.textual.overridePythonAttrs (old: rec {
-        version = "8.2.4";
+        version = "8.2.7";
         src = old.src.override {
           tag = "v${version}";
-          hash = "sha256-827cm9pcj1o1FYeaoWKCJ6dEyXeDop4kYd205cySTfg=";
+          hash = "sha256-jRTdxVpeRk8gAur5+VpLVVghBdYenXysoEFRBfczkR4=";
         };
       });
 


### PR DESCRIPTION
## Problem

`vibe` (mistral-vibe 2.12.1) crashes instantly on startup when installed from this flake:

```
InvalidThemeError: Theme 'ansi-dark' has not been registered. Call 'App.register_theme' before setting the 'App.theme' attribute.
```

Traceback shows the build links against **textual 8.2.4**, while `vibe` sets `DEFAULT_THEME = "ansi-dark"` (`vibe/core/config/_settings.py`) and applies it in `app.py` (`self.theme = ...`). The `ansi-dark` / `ansi-light` built-in themes only exist in **textual >= 8.2.5** — 8.2.4 only ships `textual-ansi`, so the theme lookup fails and the app dies before the UI mounts.

## Root cause

`packages/mistral-vibe/package.nix` force-downgrades textual to 8.2.4:

```nix
# mistral-vibe pins textual==8.2.4. Textual 8.2.5 removed the built-in
# "textual-ansi" theme that vibe sets at startup ...
textual = pyprev.textual.overridePythonAttrs (old: rec {
  version = "8.2.4";
  ...
});
```

But vibe 2.12.1's `pyproject.toml` actually pins **`textual==8.2.7`** and no longer uses `textual-ansi` — it uses `ansi-dark`. `pythonRelaxDeps = true` strips the `==8.2.7` constraint, so the stale override silently wins and the mismatch only surfaces at runtime. The comment about 8.2.5 removing `textual-ansi` no longer matches what vibe does.

## Fix

Bump the textual override (and its src hash) to **8.2.7** to match vibe's pin, and update the now-stale comment.

## Verification

```
$ nix build .#mistral-vibe -L
# build EXIT=0, versionCheck + pythonImportsCheck pass (vibe 2.12.1)

$ nix path-info -r ./result | grep textual-8
/nix/store/...-python3.13-textual-8.2.7   # was 8.2.4

$ ./result/bin/vibe --help   # runs OK, no InvalidThemeError
```