### PR TITLE
fix(omp): bundle compiled worker entrypoints and embed stats dashboard

### DIFF
--- a/packages/omp/expose-worker-entrypoints.patch
+++ b/packages/omp/expose-worker-entrypoints.patch
@@ -1,0 +1,19 @@
+diff --git a/scripts/ci-release-build-binaries.ts b/scripts/ci-release-build-binaries.ts
+index fad13b13a..d5ff14d57 100644
+--- a/scripts/ci-release-build-binaries.ts
++++ b/scripts/ci-release-build-binaries.ts
+@@ -23,7 +23,7 @@ const entrypoint = "./packages/coding-agent/src/cli.ts";
+ // literals at the spawn sites resolve to. Keep this in sync with the dev
+ // script at `packages/coding-agent/scripts/build-binary.ts`; the
+ // `issue-1150-repro` test pins both halves of the contract.
+-const workerEntrypoints = [
++export const workerEntrypoints = [
+ 	"./packages/stats/src/sync-worker.ts",
+ 	"./packages/coding-agent/src/tools/browser/tab-worker-entry.ts",
+ 	"./packages/coding-agent/src/eval/js/worker-entry.ts",
+@@ -209,4 +209,4 @@ async function main(): Promise<void> {
+ 	}
+ }
+ 
+-await main();
++if (import.meta.main) await main();

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -215,14 +215,22 @@ stdenv.mkDerivation {
     echo "Generating docs index..."
     bun packages/coding-agent/scripts/generate-docs-index.ts
 
+    # Generate the embedded stats dashboard client bundle
+    echo "Generating embedded stats dashboard..."
+    bun --cwd packages/stats scripts/generate-client-bundle.ts --generate
+
     # Compile the standalone binary
     echo "Compiling standalone binary..."
     bun build --compile \
-      --define PI_COMPILED=true \
       --external mupdf \
       --target="${platform.bunTarget}" \
       --root . \
       ./packages/coding-agent/src/cli.ts \
+      ./packages/stats/src/sync-worker.ts \
+      ./packages/coding-agent/src/tools/browser/tab-worker-entry.ts \
+      ./packages/coding-agent/src/eval/js/worker-entry.ts \
+      ./packages/coding-agent/src/extensibility/typebox.ts \
+      ./packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts \
       --outfile dist/omp
 
     runHook postBuild

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -135,6 +135,11 @@ stdenv.mkDerivation {
     "
   '';
 
+  # Export upstream's worker entrypoint list and guard its main() so we can
+  # import the list in buildPhase instead of duplicating it here. Fails to
+  # apply when upstream restructures the script, forcing a review on bumps.
+  patches = [ ./expose-worker-entrypoints.patch ];
+
   # We handle build and install ourselves
   dontUseBunBuild = true;
   dontUseBunInstall = true;
@@ -219,18 +224,24 @@ stdenv.mkDerivation {
     echo "Generating embedded stats dashboard..."
     bun --cwd packages/stats scripts/generate-client-bundle.ts --generate
 
-    # Compile the standalone binary
+    # Compile the standalone binary. Worker entrypoints must be listed
+    # explicitly: bun --compile only embeds modules reachable via static
+    # imports, but workers are spawned by path at runtime (upstream issue
+    # #1150). Reuse the list from upstream's release build script.
     echo "Compiling standalone binary..."
+    workerEntrypoints=$(bun -e '
+      const { workerEntrypoints } = await import("./scripts/ci-release-build-binaries.ts");
+      if (!Array.isArray(workerEntrypoints) || workerEntrypoints.length === 0) {
+        throw new Error("empty workerEntrypoints in ci-release-build-binaries.ts");
+      }
+      console.write(workerEntrypoints.join(" "));
+    ')
     bun build --compile \
       --external mupdf \
       --target="${platform.bunTarget}" \
       --root . \
       ./packages/coding-agent/src/cli.ts \
-      ./packages/stats/src/sync-worker.ts \
-      ./packages/coding-agent/src/tools/browser/tab-worker-entry.ts \
-      ./packages/coding-agent/src/eval/js/worker-entry.ts \
-      ./packages/coding-agent/src/extensibility/typebox.ts \
-      ./packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts \
+      $workerEntrypoints \
       --outfile dist/omp
 
     runHook postBuild
@@ -254,6 +265,15 @@ stdenv.mkDerivation {
     }"}
 
     runHook postInstall
+  '';
+
+  # Workers and the stats dashboard only fail at runtime when their bunfs
+  # entrypoints are missing; the smoke test catches that at build time.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    HOME=$TMPDIR $out/bin/omp --smoke-test | grep -q "smoke-test: ok"
+    runHook postInstallCheck
   '';
 
   passthru.category = "AI Coding Agents";


### PR DESCRIPTION
The OMP derivation manually runs `bun build --compile`, but it did not include the extra worker and shim entrypoints from upstream `packages/coding-agent/scripts/build-binary.ts`. Bun compiled binaries need those entrypoints explicitly listed so they are embedded into bunfs. Without them, `omp --smoke-test` and `omp stats` crash when workers are spawned.

Changes:

- Added 5 worker/shim entrypoints from upstream `build-binary.ts`: `packages/stats/src/sync-worker.ts`, `packages/coding-agent/src/tools/browser/tab-worker-entry.ts`, `packages/coding-agent/src/eval/js/worker-entry.ts`, `packages/coding-agent/src/extensibility/typebox.ts`, `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts`
- Generate embedded stats dashboard client bundle before compile, so `omp stats` serves the dashboard instead of crashing
- Removed ineffective `--define PI_COMPILED=true` — bare-identifier define doesn't match `Bun.env.PI_COMPILED` or `process.env.PI_COMPILED`; compiled-mode detection falls back to `import.meta.url` bunfs markers

Tested: `nix build .#omp` succeeds; `omp --smoke-test` prints `smoke-test: ok`; `omp stats --summary` prints stats without crashing; `omp stats --port` starts the dashboard.