### PR TITLE
codegraph: init at 0.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>codegraph</strong> - Semantic code intelligence for AI coding agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/colbymchenry/codegraph
+- **Usage**: `nix run github:numtide/llm-agents.nix#codegraph -- --help`
+- **Nix**: [packages/codegraph/package.nix](packages/codegraph/package.nix)
+
+</details>
+<details>
 <summary><strong>codex-auth</strong> - CLI tool for switching Codex accounts</summary>
 
 - **Source**: source

--- a/packages/codegraph/default.nix
+++ b/packages/codegraph/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) buildNpmPackage;
+}

--- a/packages/codegraph/nix-update-args
+++ b/packages/codegraph/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/codegraph/package.nix
+++ b/packages/codegraph/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flake,
+  versionCheckHook,
+}:
+
+buildNpmPackage rec {
+  npmDepsFetcherVersion = 2;
+  pname = "codegraph";
+  version = "0.9.7";
+
+  src = fetchFromGitHub {
+    owner = "colbymchenry";
+    repo = "codegraph";
+    rev = "v${version}";
+    hash = "sha256-s1fV+x6NAPjcrr0MG4KqTNelo8gXwE6WvLUdQGwyEIA=";
+  };
+
+  npmDepsHash = "sha256-ujfsy5SrbWLlUL7H4W13n3wFoww1uC+SKSaiNRTCs8I=";
+  makeCacheWritable = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Semantic code intelligence for AI coding agents";
+    homepage = "https://github.com/colbymchenry/codegraph";
+    changelog = "https://github.com/colbymchenry/codegraph/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ Bad3r ];
+    mainProgram = "codegraph";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary

Package CodeGraph 0.9.7 from the upstream GitHub tag using buildNpmPackage.

Add nix-update release filtering for plain `vX.Y.Z` tags and regenerate the README package list.

https://github.com/colbymchenry/codegraph

## Test plan

- [x] `nix build --accept-flake-config .#codegraph --print-build-logs`
- [x] `nix run --accept-flake-config .#codegraph -- --version`
- [x] `nix develop --accept-flake-config -c .github/ci/update.py package codegraph`
- [x] `nix fmt -- README.md packages/codegraph/default.nix packages/codegraph/package.nix packages/codegraph/nix-update-args`
- [x] `./scripts/generate-package-docs.py`
- [x] `git diff --check --cached`
- [x] `nix flake check --accept-flake-config --no-build` fails on current main before reaching this package: `packages.x86_64-linux.bun2nix` reports `path 'g55xfyracb1zwi9j7w514h7s3nx6rgjq-bun2nix' is not valid`.

- [x] `nix build .#codegraph` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update does not work