### PR TITLE
officecli: init at 1.0.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>officecli</strong> - CLI for creating and editing Office Open XML documents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/iOfficeAI/OfficeCLI
+- **Usage**: `nix run github:numtide/llm-agents.nix#officecli -- --help`
+- **Nix**: [packages/officecli/package.nix](packages/officecli/package.nix)
+
+</details>
+<details>
 <summary><strong>openskills</strong> - Universal skills loader for AI coding agents - install and load Anthropic SKILL.md format skills in any agent</summary>
 
 - **Source**: source

--- a/packages/officecli/default.nix
+++ b/packages/officecli/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, flake }: pkgs.callPackage ./package.nix { inherit flake; }

--- a/packages/officecli/deps.json
+++ b/packages/officecli/deps.json
@@ -1,0 +1,22 @@
+[
+  {
+    "pname": "DocumentFormat.OpenXml",
+    "version": "3.4.1",
+    "hash": "sha256-kCsDhby6ZgVZKV43UHVZbiR1d/g6rD50C2IR4lnJPDk="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml.Framework",
+    "version": "3.4.1",
+    "hash": "sha256-Qi4wz7WocNUpGqZIE6RIA0wgfbc981r6fHyz19Pn+5g="
+  },
+  {
+    "pname": "System.CommandLine",
+    "version": "3.0.0-preview.2.26159.112",
+    "hash": "sha256-Al+rUmQ8/OAY1VszXMEqRpAKiTgspQjDwfaPmSI1ss4="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "8.0.1",
+    "hash": "sha256-xf0BAfqQvITompBsvfpxiLts/6sRQEzdjNA3f/q/vY4="
+  }
+]

--- a/packages/officecli/package.nix
+++ b/packages/officecli/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  flake,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildDotnetModule rec {
+  pname = "officecli";
+  version = "1.0.36";
+
+  src = fetchFromGitHub {
+    owner = "iOfficeAI";
+    repo = "OfficeCLI";
+    tag = "v${version}";
+    hash = "sha256-sx1w3cSBiU7AUeW6k2nqAGOEZk+PrTZoyQnem9DK9j8=";
+  };
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  selfContainedBuild = true;
+  projectFile = "src/officecli/officecli.csproj";
+  executables = [ "officecli" ];
+  nugetDeps = ./deps.json;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "CLI for creating and editing Office Open XML documents";
+    homepage = "https://github.com/iOfficeAI/OfficeCLI";
+    changelog = "https://github.com/iOfficeAI/OfficeCLI/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "officecli";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary

- add officecli at 1.0.36
- include generated README entry

## Testing

- ./scripts/generate-package-docs.py
- nix fmt
- git diff --check
- nix eval --accept-flake-config --raw .#packages.x86_64-linux.officecli.version -> 1.0.36
- nix build --accept-flake-config --no-link .#officecli
