### PR TITLE
mardi-gras: init at 0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>mardi-gras</strong> - Terminal UI for Beads issue tracking with a parade-inspired workflow view</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/quietpublish/mardi-gras
+- **Usage**: `nix run github:numtide/llm-agents.nix#mardi-gras -- --help`
+- **Nix**: [packages/mardi-gras/package.nix](packages/mardi-gras/package.nix)
+
+</details>
+<details>
 <summary><strong>openspec</strong> - Spec-driven development for AI coding assistants</summary>
 
 - **Source**: bytecode

--- a/packages/mardi-gras/default.nix
+++ b/packages/mardi-gras/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) go-bin versionCheckHomeHook;
+}

--- a/packages/mardi-gras/default.nix
+++ b/packages/mardi-gras/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
   perSystem,
+  flake,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit flake;
   inherit (perSystem.self) go-bin versionCheckHomeHook;
 }

--- a/packages/mardi-gras/package.nix
+++ b/packages/mardi-gras/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake,
   buildGoModule,
   fetchFromGitHub,
   go-bin,
@@ -9,16 +10,16 @@
 
 buildGoModule.override { go = go-bin; } rec {
   pname = "mardi-gras";
-  version = "0.17.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "quietpublish";
     repo = "mardi-gras";
     rev = "v${version}";
-    hash = "sha256-zBrUOVcuAOeVQsm3TdBREkJwJgd2BR/5pKXUROtDab0=";
+    hash = "sha256-JBiig+kI2X6SZhEb5mAiacLiMI5nIU0klWlBCBFshMo=";
   };
 
-  vendorHash = "sha256-CbftluOGy00UtbStnH544kLAI63lC5rL3BZUp+Gf5Bc=";
+  vendorHash = "sha256-FuXR6Cq+BLJ7h5UqFEDJ/BVlWIUpye7GOpiqbhjv6aM=";
 
   subPackages = [ "cmd/mg" ];
 
@@ -43,7 +44,7 @@ buildGoModule.override { go = go-bin; } rec {
     changelog = "https://github.com/quietpublish/mardi-gras/releases/tag/v${version}";
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    maintainers = with maintainers; [ zimbatm ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
     mainProgram = "mg";
     platforms = platforms.unix;
   };

--- a/packages/mardi-gras/package.nix
+++ b/packages/mardi-gras/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go-bin,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+buildGoModule.override { go = go-bin; } rec {
+  pname = "mardi-gras";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "quietpublish";
+    repo = "mardi-gras";
+    rev = "v${version}";
+    hash = "sha256-zBrUOVcuAOeVQsm3TdBREkJwJgd2BR/5pKXUROtDab0=";
+  };
+
+  vendorHash = "sha256-CbftluOGy00UtbStnH544kLAI63lC5rL3BZUp+Gf5Bc=";
+
+  subPackages = [ "cmd/mg" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Terminal UI for Beads issue tracking with a parade-inspired workflow view";
+    homepage = "https://github.com/quietpublish/mardi-gras";
+    changelog = "https://github.com/quietpublish/mardi-gras/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ zimbatm ];
+    mainProgram = "mg";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary

- add mardi-gras at 0.17.0
- include generated README entry

## Testing

- ./scripts/generate-package-docs.py
- nix fmt
- git diff --check
- nix eval --accept-flake-config --raw .#packages.x86_64-linux.mardi-gras.version -> 0.17.0
- nix build --accept-flake-config --no-link .#mardi-gras
