### PR TITLE
memvid-cli: init at 2.0.159

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>memvid-cli</strong> - AI memory CLI - crash-safe, single-file storage with semantic search</summary>
+
+- **Source**: binary
+- **License**: Apache-2.0
+- **Homepage**: https://memvid.com
+- **Usage**: `nix run github:numtide/llm-agents.nix#memvid-cli -- --help`
+- **Nix**: [packages/memvid-cli/package.nix](packages/memvid-cli/package.nix)
+
+</details>
+<details>
 <summary><strong>nono</strong> - Kernel-enforced agent sandbox. Capability-based isolation with secure key management, atomic rollback, cryptographic immutable audit chain of provenance. Run your agents in a zero-trust environment.</summary>
 
 - **Source**: source

--- a/packages/memvid-cli/default.nix
+++ b/packages/memvid-cli/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/memvid-cli/package.nix
+++ b/packages/memvid-cli/package.nix
@@ -49,12 +49,6 @@ stdenv.mkDerivation rec {
     chmod -R u+w $out/libexec/memvid-cli
     chmod 755 $out/libexec/memvid-cli/memvid
 
-    for shared_object in $out/libexec/memvid-cli/*.so; do
-      chmod 755 "$shared_object"
-    done
-
-    autoPatchelf $out/libexec/memvid-cli
-
     makeWrapper $out/libexec/memvid-cli/memvid $out/bin/memvid \
       --prefix LD_LIBRARY_PATH : "$out/libexec/memvid-cli"
 
@@ -63,6 +57,8 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
 
+  # No versionCheckHook: --version prints the bundled memvid-core version,
+  # not the npm package version.
   installCheckPhase = ''
     runHook preInstallCheck
 
@@ -80,6 +76,7 @@ stdenv.mkDerivation rec {
     homepage = "https://memvid.com";
     changelog = "https://github.com/memvid/memvid/releases";
     license = licenses.asl20;
+    # CLI is closed-source; upstream repo only contains the memvid-core library.
     sourceProvenance = with sourceTypes; [
       binaryNativeCode
     ];

--- a/packages/memvid-cli/package.nix
+++ b/packages/memvid-cli/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  autoPatchelfHook,
+  libx11,
+  libxext,
+  libxi,
+  libxrender,
+  libxtst,
+  openssl,
+  zlib,
+  alsa-lib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "memvid-cli";
+  version = "2.0.159";
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@memvid/cli-linux-x64/-/cli-linux-x64-${version}.tgz";
+    hash = "sha256-BiqygCVYkoQq2vqmI6DE0ME9t99wb6pZZe/NKkjCXis=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libx11
+    libxext
+    libxi
+    libxrender
+    libxtst
+    openssl
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/libexec/memvid-cli
+    cp -R $src/. $out/libexec/memvid-cli/
+    chmod -R u+w $out/libexec/memvid-cli
+    chmod 755 $out/libexec/memvid-cli/memvid
+
+    for shared_object in $out/libexec/memvid-cli/*.so; do
+      chmod 755 "$shared_object"
+    done
+
+    autoPatchelf $out/libexec/memvid-cli
+
+    makeWrapper $out/libexec/memvid-cli/memvid $out/bin/memvid \
+      --prefix LD_LIBRARY_PATH : "$out/libexec/memvid-cli"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    tmp_home=$(mktemp -d)
+    tmp_cache=$(mktemp -d)
+    HOME="$tmp_home" XDG_CACHE_HOME="$tmp_cache" $out/bin/memvid --help > /dev/null
+
+    runHook postInstallCheck
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "AI memory CLI - crash-safe, single-file storage with semantic search";
+    homepage = "https://memvid.com";
+    changelog = "https://github.com/memvid/memvid/releases";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [
+      binaryNativeCode
+    ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "memvid";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary

- add memvid-cli at 2.0.159
- include generated README entry

## Testing

- ./scripts/generate-package-docs.py
- nix fmt
- git diff --check
- nix eval --accept-flake-config --raw .#packages.x86_64-linux.memvid-cli.version -> 2.0.159
- nix build --accept-flake-config --no-link .#memvid-cli
