### PR TITLE
hermes-desktop: init at 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>hermes-desktop</strong> - Desktop companion for Hermes Agent</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://github.com/fathah/hermes-desktop
+- **Usage**: `nix run github:numtide/llm-agents.nix#hermes-desktop -- --help`
+- **Nix**: [packages/hermes-desktop/package.nix](packages/hermes-desktop/package.nix)
+
+</details>
+<details>
 <summary><strong>hermes-hud</strong> - TUI consciousness monitor for Hermes Agent</summary>
 
 - **Source**: source

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 <details>
 <summary><strong>hermes-desktop</strong> - Desktop companion for Hermes Agent</summary>
 
-- **Source**: binary
+- **Source**: source
 - **License**: MIT
 - **Homepage**: https://github.com/fathah/hermes-desktop
 - **Usage**: `nix run github:numtide/llm-agents.nix#hermes-desktop -- --help`

--- a/packages/hermes-desktop/default.nix
+++ b/packages/hermes-desktop/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, flake }: pkgs.callPackage ./package.nix { inherit flake; }

--- a/packages/hermes-desktop/nix-update-args
+++ b/packages/hermes-desktop/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/hermes-desktop/package.nix
+++ b/packages/hermes-desktop/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  autoPatchelfHook,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  dbus-glib,
+  expat,
+  glib,
+  gsettings-desktop-schemas,
+  hicolor-icon-theme,
+  gtk2,
+  gtk3,
+  libgbm,
+  libglvnd,
+  libdbusmenu,
+  libdbusmenu-gtk2,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libxkbcommon,
+  libXrandr,
+  nspr,
+  nss,
+  pango,
+  udev,
+}:
+
+let
+  pname = "hermes-desktop";
+  version = "0.5.1";
+
+  src = fetchurl {
+    url = "https://github.com/fathah/hermes-desktop/releases/download/v${version}/hermes-desktop-${version}.AppImage";
+    hash = "sha256-UQsmsBkE7zeBeacnR0EfJRK+HAxZS8d+yILjQQvPK9c=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    dbus-glib
+    expat
+    glib
+    gsettings-desktop-schemas
+    hicolor-icon-theme
+    gtk2
+    gtk3
+    libgbm
+    libglvnd
+    libdbusmenu
+    libdbusmenu-gtk2
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libxkbcommon
+    libXrandr
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    udev
+  ];
+
+  runtimeDependencies = [
+    libgbm
+    libglvnd
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/hermes-desktop $out/bin $out/share/applications $out/share/icons/hicolor/512x512/apps
+    cp -R ${appimageContents}/. $out/lib/hermes-desktop/
+    chmod -R u+w $out/lib/hermes-desktop
+
+    makeWrapper $out/lib/hermes-desktop/hermes-desktop $out/bin/hermes-desktop \
+      --chdir $out/lib/hermes-desktop \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libgbm
+          libglvnd
+        ]
+      } \
+      --set GSETTINGS_SCHEMA_DIR ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}/glib-2.0/schemas \
+      --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:${hicolor-icon-theme}/share:$out/share \
+      --add-flags --no-sandbox \
+      --add-flags --disable-gpu-sandbox
+
+    install -Dm644 $out/lib/hermes-desktop/hermes-desktop.png \
+      $out/share/icons/hicolor/512x512/apps/hermes-desktop.png
+    install -Dm644 $out/lib/hermes-desktop/hermes-desktop.desktop \
+      $out/share/applications/hermes-desktop.desktop
+    substituteInPlace $out/share/applications/hermes-desktop.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=hermes-desktop' \
+      --replace-fail 'Icon=hermes-desktop' 'Icon=hermes-desktop'
+
+    runHook postInstall
+  '';
+
+  passthru.category = "AI Assistants";
+
+  meta = with lib; {
+    description = "Desktop companion for Hermes Agent";
+    homepage = "https://github.com/fathah/hermes-desktop";
+    changelog = "https://github.com/fathah/hermes-desktop/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "hermes-desktop";
+  };
+}

--- a/packages/hermes-desktop/package.nix
+++ b/packages/hermes-desktop/package.nix
@@ -2,134 +2,111 @@
   lib,
   flake,
   stdenv,
-  fetchurl,
-  appimageTools,
-  autoPatchelfHook,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron_40,
   makeWrapper,
-  alsa-lib,
-  at-spi2-atk,
-  at-spi2-core,
-  atk,
-  cairo,
-  cups,
-  dbus,
-  dbus-glib,
-  expat,
-  glib,
-  gsettings-desktop-schemas,
-  hicolor-icon-theme,
-  gtk2,
-  gtk3,
-  libgbm,
-  libglvnd,
-  libdbusmenu,
-  libdbusmenu-gtk2,
-  libX11,
-  libxcb,
-  libXcomposite,
-  libXdamage,
-  libXext,
-  libXfixes,
-  libxkbcommon,
-  libXrandr,
-  nspr,
-  nss,
-  pango,
-  udev,
+  copyDesktopItems,
+  makeDesktopItem,
+  python3,
 }:
 
 let
+  # Upstream pins electron ^39, but electron_39 is EOL/insecure in nixpkgs.
+  # Electron majors are backwards compatible enough for this app; the build
+  # guard below catches the day upstream jumps ahead of what we ship.
+  electron = electron_40;
+in
+buildNpmPackage rec {
   pname = "hermes-desktop";
   version = "0.5.1";
 
-  src = fetchurl {
-    url = "https://github.com/fathah/hermes-desktop/releases/download/v${version}/hermes-desktop-${version}.AppImage";
-    hash = "sha256-UQsmsBkE7zeBeacnR0EfJRK+HAxZS8d+yILjQQvPK9c=";
+  src = fetchFromGitHub {
+    owner = "fathah";
+    repo = "hermes-desktop";
+    tag = "v${version}";
+    hash = "sha256-XOo2C0tyQsBnz/p5yCs/JY6uXUXYUZfAWRiR2Mqo+lI=";
   };
 
-  appimageContents = appimageTools.extractType2 {
-    inherit pname version src;
-  };
-in
-stdenv.mkDerivation {
-  inherit pname version src;
+  npmDepsHash = "sha256-Bffhu/l+ybkdSwj9kl2Iu3XtHteJ2a4JFY2Q+I6+PLg=";
+  npmDepsFetcherVersion = 2;
+
+  # Upstream postinstall runs electron-builder install-app-deps and husky;
+  # neither works in the sandbox. Native modules are rebuilt explicitly below.
+  npmFlags = [ "--ignore-scripts" ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
-    autoPatchelfHook
     makeWrapper
-  ];
+    python3 # node-gyp needs it to rebuild better-sqlite3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ];
 
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    dbus-glib
-    expat
-    glib
-    gsettings-desktop-schemas
-    hicolor-icon-theme
-    gtk2
-    gtk3
-    libgbm
-    libglvnd
-    libdbusmenu
-    libdbusmenu-gtk2
-    libX11
-    libxcb
-    libXcomposite
-    libXdamage
-    libXext
-    libXfixes
-    libxkbcommon
-    libXrandr
-    nspr
-    nss
-    pango
-    stdenv.cc.cc.lib
-    udev
-  ];
+  buildPhase = ''
+    runHook preBuild
 
-  runtimeDependencies = [
-    libgbm
-    libglvnd
-  ];
+    # Fail loudly if upstream moves to an Electron major newer than ours.
+    upstream_electron=$(node -p "require('./package.json').devDependencies.electron")
+    upstream_major=''${upstream_electron#^}
+    upstream_major=''${upstream_major%%.*}
+    nix_major=${lib.versions.major electron.version}
+    if (( upstream_major > nix_major )); then
+      echo "error: upstream expects electron $upstream_electron but we provide ${electron.version}"
+      echo "Update the electron input in package.nix to match."
+      exit 1
+    fi
 
-  dontUnpack = true;
+    # better-sqlite3 ships no prebuilds for Electron's ABI; compile it
+    # against the Electron headers so the main process can load it.
+    export npm_config_nodedir=${electron.headers}
+    npm rebuild better-sqlite3 --build-from-source
+
+    npx electron-vite build
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/hermes-desktop $out/bin $out/share/applications $out/share/icons/hicolor/512x512/apps
-    cp -R ${appimageContents}/. $out/lib/hermes-desktop/
-    chmod -R u+w $out/lib/hermes-desktop
+    mkdir -p $out/share/hermes-desktop $out/bin
 
-    makeWrapper $out/lib/hermes-desktop/hermes-desktop $out/bin/hermes-desktop \
-      --chdir $out/lib/hermes-desktop \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          libgbm
-          libglvnd
-        ]
-      } \
-      --set GSETTINGS_SCHEMA_DIR ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}/glib-2.0/schemas \
-      --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:${hicolor-icon-theme}/share:$out/share \
-      --add-flags --no-sandbox \
-      --add-flags --disable-gpu-sandbox
+    cp -r out package.json $out/share/hermes-desktop/
 
-    install -Dm644 $out/lib/hermes-desktop/hermes-desktop.png \
-      $out/share/icons/hicolor/512x512/apps/hermes-desktop.png
-    install -Dm644 $out/lib/hermes-desktop/hermes-desktop.desktop \
-      $out/share/applications/hermes-desktop.desktop
-    substituteInPlace $out/share/applications/hermes-desktop.desktop \
-      --replace-fail 'Exec=AppRun' 'Exec=hermes-desktop' \
-      --replace-fail 'Icon=hermes-desktop' 'Icon=hermes-desktop'
+    # Runtime dependencies for the main process: electron-vite externalizes
+    # everything in package.json "dependencies" (better-sqlite3, i18next,
+    # electron-updater, ...), so they must exist in node_modules.
+    npm prune --omit=dev
+    # Drop node-gyp intermediates; only the compiled addon is needed.
+    find node_modules/better-sqlite3/build -mindepth 1 -maxdepth 1 ! -name Release -exec rm -rf {} +
+    find node_modules/better-sqlite3/build/Release -mindepth 1 ! -name better_sqlite3.node -exec rm -rf {} +
+    cp -r node_modules $out/share/hermes-desktop/
+
+    install -Dm644 build/icon.png $out/share/icons/hicolor/512x512/apps/hermes-desktop.png
+
+    # app.isPackaged stays false on purpose: upstream skips its
+    # electron-updater code path in that case, which is what we want for a
+    # store-managed install.
+    makeWrapper ${lib.getExe electron} $out/bin/hermes-desktop \
+      --add-flags $out/share/hermes-desktop \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "hermes-desktop";
+      desktopName = "Hermes Agent";
+      comment = "Self-improving AI assistant desktop app";
+      exec = "hermes-desktop %U";
+      icon = "hermes-desktop";
+      categories = [ "Utility" ];
+      startupWMClass = "hermes-desktop";
+    })
+  ];
 
   passthru.category = "AI Assistants";
 
@@ -138,9 +115,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/fathah/hermes-desktop";
     changelog = "https://github.com/fathah/hermes-desktop/releases/tag/v${version}";
     license = licenses.mit;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ smdex ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "hermes-desktop";
   };
 }


### PR DESCRIPTION
## Summary

- add hermes-desktop at 0.5.1
- include generated README entry

## Testing

- ./scripts/generate-package-docs.py
- nix fmt
- git diff --check
- nix eval --accept-flake-config --raw .#packages.x86_64-linux.hermes-desktop.version -> 0.5.1
- nix build --accept-flake-config --no-link .#hermes-desktop
