### PR TITLE
rtk: ignore prerelease GitHub releases in auto-update

### DIFF
--- a/packages/rtk/nix-update-args
+++ b/packages/rtk/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$


### PR DESCRIPTION
## Problem

The Update Dependencies workflow fails for `rtk`:

```
nix_update.errors.VersionError: Found an unstable version dev-0.43.0-rc.249,
which is being ignored. To update to unstable version, please use '--version=unstable'
```

Upstream (rtk-ai/rtk) floods GitHub releases with `dev-X.Y.Z-rc.N` prereleases, so the releases.atom feed nix-update consults only contains unstable versions.

## Fix

Add `packages/rtk/nix-update-args` using the GitHub releases API (which excludes prereleases) and restricting versions to stable `vX.Y.Z` tags — same approach as qwen-code and gitnexus.

## Verification

```
nix develop -c nix-update --flake rtk --use-github-releases --version-regex '^v([0-9]+\.[0-9]+\.[0-9]+)$'
```

picks latest stable 0.42.0 (already current on main), no error.