### PR TITLE
toon: point nix-update at crates.io for auto-updates

### DIFF
--- a/packages/toon/nix-update-args
+++ b/packages/toon/nix-update-args
@@ -1,0 +1,5 @@
+# fetchCrate in current nixpkgs resolves to static.crates.io, which
+# nix-update's crates.io fetcher does not recognize. Point it at a
+# crates.io URL so version detection works.
+--url
+https://crates.io/api/v1/crates/toon-format/versions


### PR DESCRIPTION
## Summary

The Update Dependencies workflow fails for `toon`:

```
nix_update.errors.VersionError: Please specify the version. We can only get the
latest version from codeberg/crates.io/... projects right now
```

Root cause: since nixpkgs switched `fetchCrate` to download from `static.crates.io`,
nix-update's crates.io fetcher no longer recognizes the src URL (it requires netloc
exactly `crates.io`), so no version fetcher matches.

Fix: add `packages/toon/nix-update-args` with an explicit `--url` pointing at a
crates.io URL so the crates.io fetcher is used for version detection.

## Test plan

- [x] `nix-update --flake toon --url https://crates.io/api/v1/crates/toon-format/versions` succeeds (reports already at 0.5.0)
- [x] Package updates via `nix-update`