### PR TITLE
README: split out new categories and fix miscategorized packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>bernstein</strong> - Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://github.com/chernistry/bernstein
-- **Usage**: `nix run github:numtide/llm-agents.nix#bernstein -- --help`
-- **Nix**: [packages/bernstein/package.nix](packages/bernstein/package.nix)
-
-</details>
-<details>
 <summary><strong>claude-code</strong> - Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster</summary>
 
 - **Source**: binary
@@ -57,16 +47,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/ultraworkers/claw-code
 - **Usage**: `nix run github:numtide/llm-agents.nix#claw-code -- --help`
 - **Nix**: [packages/claw-code/package.nix](packages/claw-code/package.nix)
-
-</details>
-<details>
-<summary><strong>cli-proxy-api</strong> - Unified proxy providing OpenAI/Gemini/Claude/Codex compatible APIs for AI coding CLI tools</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/router-for-me/CLIProxyAPI
-- **Usage**: `nix run github:numtide/llm-agents.nix#cli-proxy-api -- --help`
-- **Nix**: [packages/cli-proxy-api/package.nix](packages/cli-proxy-api/package.nix)
 
 </details>
 <details>
@@ -151,16 +131,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>gastown</strong> - Gas Town - multi-agent workspace manager</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/gastownhall/gastown
-- **Usage**: `nix run github:numtide/llm-agents.nix#gastown -- --help`
-- **Nix**: [packages/gastown/package.nix](packages/gastown/package.nix)
-
-</details>
-<details>
 <summary><strong>gemini-cli</strong> - AI agent that brings the power of Gemini directly into your terminal</summary>
 
 - **Source**: source
@@ -171,23 +141,13 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>gitnexus</strong> - Graph-powered code intelligence for AI agents</summary>
-
-- **Source**: source
-- **License**: unfree
-- **Homepage**: https://github.com/abhigyanpatwari/GitNexus
-- **Usage**: `nix run github:numtide/llm-agents.nix#gitnexus -- --help`
-- **Nix**: [packages/gitnexus/package.nix](packages/gitnexus/package.nix)
-
-</details>
-<details>
-<summary><strong>gnhf</strong> - Ralph/autoresearch-style orchestrator that keeps coding agents running while you sleep</summary>
+<summary><strong>gitclaw</strong> - Universal git-native multimodal AI agent (formerly gitagent)</summary>
 
 - **Source**: source
 - **License**: MIT
-- **Homepage**: https://github.com/kunchenguid/gnhf
-- **Usage**: `nix run github:numtide/llm-agents.nix#gnhf -- --help`
-- **Nix**: [packages/gnhf/package.nix](packages/gnhf/package.nix)
+- **Homepage**: https://github.com/open-gitagent/gitagent
+- **Usage**: `nix run github:numtide/llm-agents.nix#gitclaw -- --help`
+- **Nix**: [packages/gitclaw/package.nix](packages/gitclaw/package.nix)
 
 </details>
 <details>
@@ -517,26 +477,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>claude-plugins</strong> - CLI tool for managing Claude Code plugins</summary>
-
-- **Source**: bytecode
-- **License**: MIT
-- **Homepage**: https://github.com/Kamalnrf/claude-plugins
-- **Usage**: `nix run github:numtide/llm-agents.nix#claude-plugins -- --help`
-- **Nix**: [packages/claude-plugins/package.nix](packages/claude-plugins/package.nix)
-
-</details>
-<details>
-<summary><strong>claudebox</strong> - Sandboxed environment for Claude Code</summary>
-
-- **Source**: source
-- **License**: Check package
-- **Homepage**: https://github.com/numtide/claudebox
-- **Usage**: `nix run github:numtide/llm-agents.nix#claudebox -- --help`
-- **Nix**: [packages/claudebox/package.nix](packages/claudebox/package.nix)
-
-</details>
-<details>
 <summary><strong>oh-my-claudecode</strong> - Multi-agent orchestration system for Claude Code</summary>
 
 - **Source**: source
@@ -544,36 +484,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/yeachan-heo/oh-my-claudecode
 - **Usage**: `nix run github:numtide/llm-agents.nix#oh-my-claudecode -- --help`
 - **Nix**: [packages/oh-my-claudecode/package.nix](packages/oh-my-claudecode/package.nix)
-
-</details>
-<details>
-<summary><strong>sandbox-runtime</strong> - Lightweight sandboxing tool for enforcing filesystem and network restrictions</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://github.com/anthropic-experimental/sandbox-runtime
-- **Usage**: `nix run github:numtide/llm-agents.nix#sandbox-runtime -- --help`
-- **Nix**: [packages/sandbox-runtime/package.nix](packages/sandbox-runtime/package.nix)
-
-</details>
-<details>
-<summary><strong>skills</strong> - The open agent skills tool for installing and managing skills across AI coding agents</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/vercel-labs/skills
-- **Usage**: `nix run github:numtide/llm-agents.nix#skills -- --help`
-- **Nix**: [packages/skills/package.nix](packages/skills/package.nix)
-
-</details>
-<details>
-<summary><strong>skills-installer</strong> - Install agent skills across multiple AI coding clients</summary>
-
-- **Source**: bytecode
-- **License**: MIT
-- **Homepage**: https://github.com/Kamalnrf/claude-plugins
-- **Usage**: `nix run github:numtide/llm-agents.nix#skills-installer -- --help`
-- **Nix**: [packages/skills-installer/package.nix](packages/skills-installer/package.nix)
 
 </details>
 
@@ -621,6 +531,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/ryoppippi/ccusage
 - **Usage**: `nix run github:numtide/llm-agents.nix#ccusage -- --help`
 - **Nix**: [packages/ccusage/package.nix](packages/ccusage/package.nix)
+
+</details>
+<details>
+<summary><strong>entire</strong> - CLI tool that captures AI agent sessions and links them to code changes</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/entireio/cli
+- **Usage**: `nix run github:numtide/llm-agents.nix#entire -- --help`
+- **Nix**: [packages/entire/package.nix](packages/entire/package.nix)
 
 </details>
 
@@ -677,6 +597,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>bernstein</strong> - Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/chernistry/bernstein
+- **Usage**: `nix run github:numtide/llm-agents.nix#bernstein -- --help`
+- **Nix**: [packages/bernstein/package.nix](packages/bernstein/package.nix)
+
+</details>
+<details>
 <summary><strong>but</strong> - GitButler CLI - virtual branches and AI-assisted Git workflow from the terminal</summary>
 
 - **Source**: source
@@ -707,6 +637,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>gastown</strong> - Gas Town - multi-agent workspace manager</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/gastownhall/gastown
+- **Usage**: `nix run github:numtide/llm-agents.nix#gastown -- --help`
+- **Nix**: [packages/gastown/package.nix](packages/gastown/package.nix)
+
+</details>
+<details>
 <summary><strong>gitbutler</strong> - Git client for simultaneous branches on top of your existing workflow</summary>
 
 - **Source**: source
@@ -714,6 +654,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://gitbutler.com
 - **Usage**: `nix run github:numtide/llm-agents.nix#gitbutler -- --help`
 - **Nix**: [packages/gitbutler/package.nix](packages/gitbutler/package.nix)
+
+</details>
+<details>
+<summary><strong>gnhf</strong> - Ralph/autoresearch-style orchestrator that keeps coding agents running while you sleep</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/kunchenguid/gnhf
+- **Usage**: `nix run github:numtide/llm-agents.nix#gnhf -- --help`
+- **Nix**: [packages/gnhf/package.nix](packages/gnhf/package.nix)
 
 </details>
 <details>
@@ -880,6 +830,186 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 
+### Memory & Code Intelligence
+
+<details>
+<summary><strong>ck</strong> - Local first semantic and hybrid BM25 grep / search tool for use by AI and humans!</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/BeaconBay/ck
+- **Usage**: `nix run github:numtide/llm-agents.nix#ck -- --help`
+- **Nix**: [packages/ck/package.nix](packages/ck/package.nix)
+
+</details>
+<details>
+<summary><strong>codegraph</strong> - Semantic code intelligence for AI coding agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/colbymchenry/codegraph
+- **Usage**: `nix run github:numtide/llm-agents.nix#codegraph -- --help`
+- **Nix**: [packages/codegraph/package.nix](packages/codegraph/package.nix)
+
+</details>
+<details>
+<summary><strong>context-hub</strong> - CLI for Context Hub - search and retrieve LLM-optimized docs and skills</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/andrewyng/context-hub
+- **Usage**: `nix run github:numtide/llm-agents.nix#context-hub -- --help`
+- **Nix**: [packages/context-hub/package.nix](packages/context-hub/package.nix)
+
+</details>
+<details>
+<summary><strong>gitnexus</strong> - Graph-powered code intelligence for AI agents</summary>
+
+- **Source**: source
+- **License**: unfree
+- **Homepage**: https://github.com/abhigyanpatwari/GitNexus
+- **Usage**: `nix run github:numtide/llm-agents.nix#gitnexus -- --help`
+- **Nix**: [packages/gitnexus/package.nix](packages/gitnexus/package.nix)
+
+</details>
+<details>
+<summary><strong>gno</strong> - Local-first knowledge engine with hybrid search, RAG Q&A, and MCP server integration</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/gmickel/gno
+- **Usage**: `nix run github:numtide/llm-agents.nix#gno -- --help`
+- **Nix**: [packages/gno/package.nix](packages/gno/package.nix)
+
+</details>
+<details>
+<summary><strong>memvid-cli</strong> - AI memory CLI - crash-safe, single-file storage with semantic search</summary>
+
+- **Source**: binary
+- **License**: Apache-2.0
+- **Homepage**: https://memvid.com
+- **Usage**: `nix run github:numtide/llm-agents.nix#memvid-cli -- --help`
+- **Nix**: [packages/memvid-cli/package.nix](packages/memvid-cli/package.nix)
+
+</details>
+<details>
+<summary><strong>qmd</strong> - mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/tobi/qmd
+- **Usage**: `nix run github:numtide/llm-agents.nix#qmd -- --help`
+- **Nix**: [packages/qmd/package.nix](packages/qmd/package.nix)
+- **Documentation**: See [packages/qmd/README.md](packages/qmd/README.md) for detailed usage
+
+</details>
+<details>
+<summary><strong>semble</strong> - Fast and accurate local code search for AI agents — CLI and MCP server</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/MinishLab/semble
+- **Usage**: `nix run github:numtide/llm-agents.nix#semble -- --help`
+- **Nix**: [packages/semble/package.nix](packages/semble/package.nix)
+
+</details>
+<details>
+<summary><strong>zat</strong> - Code outline viewer for LLM coding agents — shows exported symbols with line numbers</summary>
+
+- **Source**: source
+- **License**: GPL-3.0-only
+- **Homepage**: https://github.com/bglgwyng/zat
+- **Usage**: `nix run github:numtide/llm-agents.nix#zat -- --help`
+- **Nix**: [packages/zat/package.nix](packages/zat/package.nix)
+
+</details>
+
+### Sandboxing & Isolation
+
+<details>
+<summary><strong>claudebox</strong> - Sandboxed environment for Claude Code</summary>
+
+- **Source**: source
+- **License**: Check package
+- **Homepage**: https://github.com/numtide/claudebox
+- **Usage**: `nix run github:numtide/llm-agents.nix#claudebox -- --help`
+- **Nix**: [packages/claudebox/package.nix](packages/claudebox/package.nix)
+
+</details>
+<details>
+<summary><strong>fence</strong> - Lightweight, container-free sandbox for running commands with network and filesystem restrictions</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://fencesandbox.com/
+- **Usage**: `nix run github:numtide/llm-agents.nix#fence -- --help`
+- **Nix**: [packages/fence/package.nix](packages/fence/package.nix)
+
+</details>
+<details>
+<summary><strong>nono</strong> - Kernel-enforced agent sandbox. Capability-based isolation with secure key management, atomic rollback, cryptographic immutable audit chain of provenance. Run your agents in a zero-trust environment.</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://nono.sh/
+- **Usage**: `nix run github:numtide/llm-agents.nix#nono -- --help`
+- **Nix**: [packages/nono/package.nix](packages/nono/package.nix)
+
+</details>
+<details>
+<summary><strong>sandbox-runtime</strong> - Lightweight sandboxing tool for enforcing filesystem and network restrictions</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/anthropic-experimental/sandbox-runtime
+- **Usage**: `nix run github:numtide/llm-agents.nix#sandbox-runtime -- --help`
+- **Nix**: [packages/sandbox-runtime/package.nix](packages/sandbox-runtime/package.nix)
+
+</details>
+
+### Skills & Plugins
+
+<details>
+<summary><strong>claude-plugins</strong> - CLI tool for managing Claude Code plugins</summary>
+
+- **Source**: bytecode
+- **License**: MIT
+- **Homepage**: https://github.com/Kamalnrf/claude-plugins
+- **Usage**: `nix run github:numtide/llm-agents.nix#claude-plugins -- --help`
+- **Nix**: [packages/claude-plugins/package.nix](packages/claude-plugins/package.nix)
+
+</details>
+<details>
+<summary><strong>openskills</strong> - Universal skills loader for AI coding agents - install and load Anthropic SKILL.md format skills in any agent</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/numman-ali/openskills
+- **Usage**: `nix run github:numtide/llm-agents.nix#openskills -- --help`
+- **Nix**: [packages/openskills/package.nix](packages/openskills/package.nix)
+
+</details>
+<details>
+<summary><strong>skills</strong> - The open agent skills tool for installing and managing skills across AI coding agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/vercel-labs/skills
+- **Usage**: `nix run github:numtide/llm-agents.nix#skills -- --help`
+- **Nix**: [packages/skills/package.nix](packages/skills/package.nix)
+
+</details>
+<details>
+<summary><strong>skills-installer</strong> - Install agent skills across multiple AI coding clients</summary>
+
+- **Source**: bytecode
+- **License**: MIT
+- **Homepage**: https://github.com/Kamalnrf/claude-plugins
+- **Usage**: `nix run github:numtide/llm-agents.nix#skills-installer -- --help`
+- **Nix**: [packages/skills-installer/package.nix](packages/skills-installer/package.nix)
+
+</details>
+
 ### Utilities
 
 <details>
@@ -903,23 +1033,13 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>ck</strong> - Local first semantic and hybrid BM25 grep / search tool for use by AI and humans!</summary>
+<summary><strong>cli-proxy-api</strong> - Unified proxy providing OpenAI/Gemini/Claude/Codex compatible APIs for AI coding CLI tools</summary>
 
 - **Source**: source
 - **License**: MIT
-- **Homepage**: https://github.com/BeaconBay/ck
-- **Usage**: `nix run github:numtide/llm-agents.nix#ck -- --help`
-- **Nix**: [packages/ck/package.nix](packages/ck/package.nix)
-
-</details>
-<details>
-<summary><strong>codegraph</strong> - Semantic code intelligence for AI coding agents</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/colbymchenry/codegraph
-- **Usage**: `nix run github:numtide/llm-agents.nix#codegraph -- --help`
-- **Nix**: [packages/codegraph/package.nix](packages/codegraph/package.nix)
+- **Homepage**: https://github.com/router-for-me/CLIProxyAPI
+- **Usage**: `nix run github:numtide/llm-agents.nix#cli-proxy-api -- --help`
+- **Nix**: [packages/cli-proxy-api/package.nix](packages/cli-proxy-api/package.nix)
 
 </details>
 <details>
@@ -933,16 +1053,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>context-hub</strong> - CLI for Context Hub - search and retrieve LLM-optimized docs and skills</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/andrewyng/context-hub
-- **Usage**: `nix run github:numtide/llm-agents.nix#context-hub -- --help`
-- **Nix**: [packages/context-hub/package.nix](packages/context-hub/package.nix)
-
-</details>
-<details>
 <summary><strong>copilot-language-server</strong> - GitHub Copilot Language Server - AI pair programmer LSP</summary>
 
 - **Source**: bytecode
@@ -953,26 +1063,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>entire</strong> - CLI tool that captures AI agent sessions and links them to code changes</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/entireio/cli
-- **Usage**: `nix run github:numtide/llm-agents.nix#entire -- --help`
-- **Nix**: [packages/entire/package.nix](packages/entire/package.nix)
-
-</details>
-<details>
-<summary><strong>fence</strong> - Lightweight, container-free sandbox for running commands with network and filesystem restrictions</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://fencesandbox.com/
-- **Usage**: `nix run github:numtide/llm-agents.nix#fence -- --help`
-- **Nix**: [packages/fence/package.nix](packages/fence/package.nix)
-
-</details>
-<details>
 <summary><strong>git-surgeon</strong> - Git primitives for autonomous coding agents</summary>
 
 - **Source**: source
@@ -980,26 +1070,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/raine/git-surgeon
 - **Usage**: `nix run github:numtide/llm-agents.nix#git-surgeon -- --help`
 - **Nix**: [packages/git-surgeon/package.nix](packages/git-surgeon/package.nix)
-
-</details>
-<details>
-<summary><strong>gitclaw</strong> - Universal git-native multimodal AI agent (formerly gitagent)</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/open-gitagent/gitagent
-- **Usage**: `nix run github:numtide/llm-agents.nix#gitclaw -- --help`
-- **Nix**: [packages/gitclaw/package.nix](packages/gitclaw/package.nix)
-
-</details>
-<details>
-<summary><strong>gno</strong> - Local-first knowledge engine with hybrid search, RAG Q&A, and MCP server integration</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/gmickel/gno
-- **Usage**: `nix run github:numtide/llm-agents.nix#gno -- --help`
-- **Nix**: [packages/gno/package.nix](packages/gno/package.nix)
 
 </details>
 <details>
@@ -1033,26 +1103,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>memvid-cli</strong> - AI memory CLI - crash-safe, single-file storage with semantic search</summary>
-
-- **Source**: binary
-- **License**: Apache-2.0
-- **Homepage**: https://memvid.com
-- **Usage**: `nix run github:numtide/llm-agents.nix#memvid-cli -- --help`
-- **Nix**: [packages/memvid-cli/package.nix](packages/memvid-cli/package.nix)
-
-</details>
-<details>
-<summary><strong>nono</strong> - Kernel-enforced agent sandbox. Capability-based isolation with secure key management, atomic rollback, cryptographic immutable audit chain of provenance. Run your agents in a zero-trust environment.</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://nono.sh/
-- **Usage**: `nix run github:numtide/llm-agents.nix#nono -- --help`
-- **Nix**: [packages/nono/package.nix](packages/nono/package.nix)
-
-</details>
-<details>
 <summary><strong>officecli</strong> - CLI for creating and editing Office Open XML documents</summary>
 
 - **Source**: source
@@ -1060,16 +1110,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/iOfficeAI/OfficeCLI
 - **Usage**: `nix run github:numtide/llm-agents.nix#officecli -- --help`
 - **Nix**: [packages/officecli/package.nix](packages/officecli/package.nix)
-
-</details>
-<details>
-<summary><strong>openskills</strong> - Universal skills loader for AI coding agents - install and load Anthropic SKILL.md format skills in any agent</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://github.com/numman-ali/openskills
-- **Usage**: `nix run github:numtide/llm-agents.nix#openskills -- --help`
-- **Nix**: [packages/openskills/package.nix](packages/openskills/package.nix)
 
 </details>
 <details>
@@ -1083,17 +1123,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>qmd</strong> - mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/tobi/qmd
-- **Usage**: `nix run github:numtide/llm-agents.nix#qmd -- --help`
-- **Nix**: [packages/qmd/package.nix](packages/qmd/package.nix)
-- **Documentation**: See [packages/qmd/README.md](packages/qmd/README.md) for detailed usage
-
-</details>
-<details>
 <summary><strong>rtk</strong> - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands</summary>
 
 - **Source**: source
@@ -1101,16 +1130,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/rtk-ai/rtk
 - **Usage**: `nix run github:numtide/llm-agents.nix#rtk -- --help`
 - **Nix**: [packages/rtk/package.nix](packages/rtk/package.nix)
-
-</details>
-<details>
-<summary><strong>semble</strong> - Fast and accurate local code search for AI agents — CLI and MCP server</summary>
-
-- **Source**: source
-- **License**: MIT
-- **Homepage**: https://github.com/MinishLab/semble
-- **Usage**: `nix run github:numtide/llm-agents.nix#semble -- --help`
-- **Nix**: [packages/semble/package.nix](packages/semble/package.nix)
 
 </details>
 <details>
@@ -1131,16 +1150,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/toon-format/toon-rust
 - **Usage**: `nix run github:numtide/llm-agents.nix#toon -- --help`
 - **Nix**: [packages/toon/package.nix](packages/toon/package.nix)
-
-</details>
-<details>
-<summary><strong>zat</strong> - Code outline viewer for LLM coding agents — shows exported symbols with line numbers</summary>
-
-- **Source**: source
-- **License**: GPL-3.0-only
-- **Homepage**: https://github.com/bglgwyng/zat
-- **Usage**: `nix run github:numtide/llm-agents.nix#zat -- --help`
-- **Nix**: [packages/zat/package.nix](packages/zat/package.nix)
 
 </details>
 <!-- END GENERATED PACKAGE DOCS -->

--- a/packages/bernstein/package.nix
+++ b/packages/bernstein/package.nix
@@ -128,7 +128,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
   versionCheckProgramArg = [ "--version" ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "Workflow & Project Management";
 
   meta = with lib; {
     description = "Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents";

--- a/packages/ck/package.nix
+++ b/packages/ck/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage {
     install_name_tool -add_rpath "${lib.getLib onnxruntime}/lib" $out/bin/ck
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = with lib; {
     description = "Local first semantic and hybrid BM25 grep / search tool for use by AI and humans!";

--- a/packages/claude-plugins/package.nix
+++ b/packages/claude-plugins/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.category = "Claude Code Ecosystem";
+  passthru.category = "Skills & Plugins";
 
   meta = with lib; {
     description = "CLI tool for managing Claude Code plugins";

--- a/packages/claudebox/package.nix
+++ b/packages/claudebox/package.nix
@@ -44,7 +44,7 @@ in
 pkgs.runCommand "claudebox"
   {
     buildInputs = [ pkgs.makeWrapper ];
-    passthru.category = "Claude Code Ecosystem";
+    passthru.category = "Sandboxing & Isolation";
     meta = with pkgs.lib; {
       mainProgram = "claudebox";
       description = "Sandboxed environment for Claude Code";

--- a/packages/cli-proxy-api/package.nix
+++ b/packages/cli-proxy-api/package.nix
@@ -42,7 +42,7 @@ buildGoModule.override { go = go_1_26; } {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "Utilities";
 
   meta = with lib; {
     description = "Unified proxy providing OpenAI/Gemini/Claude/Codex compatible APIs for AI coding CLI tools";

--- a/packages/codegraph/package.nix
+++ b/packages/codegraph/package.nix
@@ -24,7 +24,7 @@ buildNpmPackage rec {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = {
     description = "Semantic code intelligence for AI coding agents";

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -44,7 +44,7 @@ buildNpmPackage rec {
   versionCheckProgramArg = "--cli-version";
   doInstallCheck = true;
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = {
     description = "CLI for Context Hub - search and retrieve LLM-optimized docs and skills";

--- a/packages/entire/package.nix
+++ b/packages/entire/package.nix
@@ -41,7 +41,7 @@
   ];
   versionCheckProgramArg = [ "version" ];
 
-  passthru.category = "Utilities";
+  passthru.category = "Usage Analytics";
 
   meta = with lib; {
     description = "CLI tool that captures AI agent sessions and links them to code changes";

--- a/packages/fence/package.nix
+++ b/packages/fence/package.nix
@@ -69,7 +69,7 @@ buildGoModule rec {
       }
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Sandboxing & Isolation";
 
   meta = with lib; {
     description = "Lightweight, container-free sandbox for running commands with network and filesystem restrictions";

--- a/packages/gastown/package.nix
+++ b/packages/gastown/package.nix
@@ -58,7 +58,7 @@ buildGoModule rec {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "Workflow & Project Management";
 
   meta = with lib; {
     description = "Gas Town - multi-agent workspace manager";

--- a/packages/gitclaw/package.nix
+++ b/packages/gitclaw/package.nix
@@ -31,7 +31,7 @@ buildNpmPackage (finalAttrs: {
     rm -rf $out/lib/node_modules/gitclaw/node_modules/@googleworkspace
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "AI Coding Agents";
 
   meta = {
     description = "Universal git-native multimodal AI agent (formerly gitagent)";

--- a/packages/gitnexus/package.nix
+++ b/packages/gitnexus/package.nix
@@ -86,7 +86,7 @@ buildNpmPackage (finalAttrs: {
         --run 'export GITNEXUS_CACHE_DIR="$HOME/.cache"'
     '';
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = with lib; {
     description = "Graph-powered code intelligence for AI agents";

--- a/packages/gnhf/package.nix
+++ b/packages/gnhf/package.nix
@@ -41,7 +41,7 @@ buildNpmPackage rec {
     versionCheckHomeHook
   ];
 
-  passthru.category = "AI Coding Agents";
+  passthru.category = "Workflow & Project Management";
 
   meta = with lib; {
     description = "Ralph/autoresearch-style orchestrator that keeps coding agents running while you sleep";

--- a/packages/gno/package.nix
+++ b/packages/gno/package.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = with lib; {
     description = "Local-first knowledge engine with hybrid search, RAG Q&A, and MCP server integration";

--- a/packages/memvid-cli/package.nix
+++ b/packages/memvid-cli/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = with lib; {
     description = "AI memory CLI - crash-safe, single-file storage with semantic search";

--- a/packages/nono/package.nix
+++ b/packages/nono/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     versionCheckHook
   ];
 
-  passthru.category = "Utilities";
+  passthru.category = "Sandboxing & Isolation";
 
   meta = with lib; {
     description = "Kernel-enforced agent sandbox. Capability-based isolation with secure key management, atomic rollback, cryptographic immutable audit chain of provenance. Run your agents in a zero-trust environment.";

--- a/packages/openskills/package.nix
+++ b/packages/openskills/package.nix
@@ -20,7 +20,7 @@ buildNpmPackage (finalAttrs: {
   npmDepsHash = "sha256-ZYiY66PKF7hAnFkw3RQ5xBw7L9WZx0giUhgE8ySE0Xw=";
   makeCacheWritable = true;
 
-  passthru.category = "Utilities";
+  passthru.category = "Skills & Plugins";
 
   meta = {
     description = "Universal skills loader for AI coding agents - install and load Anthropic SKILL.md format skills in any agent";

--- a/packages/qmd/package.nix
+++ b/packages/qmd/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = with lib; {
     description = "mini cli search engine for your docs, knowledge bases, meeting notes, whatever. Tracking current sota approaches while being all local";

--- a/packages/sandbox-runtime/package.nix
+++ b/packages/sandbox-runtime/package.nix
@@ -57,7 +57,7 @@ buildNpmPackage {
   # (1.0.0 from commander instead of 0.0.26 from package.json)
   doInstallCheck = false;
 
-  passthru.category = "Claude Code Ecosystem";
+  passthru.category = "Sandboxing & Isolation";
 
   meta = {
     description = "Lightweight sandboxing tool for enforcing filesystem and network restrictions";

--- a/packages/semble/package.nix
+++ b/packages/semble/package.nix
@@ -202,7 +202,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   passthru = {
-    category = "Utilities";
+    category = "Memory & Code Intelligence";
     inherit model2vec vicinity bm25s;
   };
 

--- a/packages/skills-installer/package.nix
+++ b/packages/skills-installer/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Claude Code Ecosystem";
+  passthru.category = "Skills & Plugins";
 
   meta = with lib; {
     description = "Install agent skills across multiple AI coding clients";

--- a/packages/skills/package.nix
+++ b/packages/skills/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.category = "Claude Code Ecosystem";
+  passthru.category = "Skills & Plugins";
 
   meta = with lib; {
     description = "The open agent skills tool for installing and managing skills across AI coding agents";

--- a/packages/zat/package.nix
+++ b/packages/zat/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Utilities";
+  passthru.category = "Memory & Code Intelligence";
 
   meta = {
     description = "Code outline viewer for LLM coding agents — shows exported symbols with line numbers";

--- a/scripts/generate-package-docs.py
+++ b/scripts/generate-package-docs.py
@@ -79,10 +79,12 @@ CATEGORY_ORDER = [
     "AI Assistants",
     "Claude Code Ecosystem",
     "ACP Ecosystem",
-    "MCP",
     "Usage Analytics",
     "Workflow & Project Management",
     "Code Review",
+    "Memory & Code Intelligence",
+    "Sandboxing & Isolation",
+    "Skills & Plugins",
     "Utilities",
     "Uncategorized",
 ]


### PR DESCRIPTION
The Utilities section had grown into a dumping ground (26 packages) and
several packages sat in categories that did not match what they do:
code-intelligence tools were split between "AI Coding Agents" and
"Utilities", sandboxes between "Claude Code Ecosystem" and "Utilities",
and skills managers across both as well.

Introduce three new categories and move packages accordingly:

- Memory & Code Intelligence: ck, semble, qmd, gno, memvid-cli,
  context-hub, codegraph, gitnexus, zat
- Sandboxing & Isolation: fence, nono, sandbox-runtime, claudebox
- Skills & Plugins: skills, skills-installer, openskills, claude-plugins

Fix packages that were not agents but listed as such, and other
mismatches:

- cli-proxy-api: AI Coding Agents -> Utilities (API proxy, not an agent)
- gastown, bernstein, gnhf: AI Coding Agents -> Workflow & Project
  Management (orchestrators/workspace managers, like herdr/ralph-tui)
- entire: Utilities -> Usage Analytics (session capture/analytics)
- gitclaw: Utilities -> AI Coding Agents (it is an agent)

Also drop the unused "MCP" entry from CATEGORY_ORDER.