### PR TITLE
flake: switch nixpkgs back to nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,16 +74,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780164493,
-        "narHash": "sha256-kAWygfPvwSp7fFkYABWDL002pb0HNzy6xIKtiwWWTsM=",
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01c8df74197a537d728921214ac2fd70e4ce1666",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
     blueprint = {
       url = "github:numtide/blueprint";


### PR DESCRIPTION
The nixpkgs input was pinned to nixos-unstable-small as a stopgap
(#5254) because crates.io started rejecting curl/python-requests
user-agents, breaking rustPlatform.importCargoLock for all bun-based
packages.

The upstream fix (NixOS/nixpkgs#524985, importCargoLock downloads from
static.crates.io) has now reached the nixpkgs-unstable channel:

  $ gh api repos/NixOS/nixpkgs/compare/e9a7635a...c0a89c379b -q .status
  behind

Switch back to the regular channel as planned.

Closes #5256