### PR TITLE
oh-my-opencode: install required shared-skills package

### DIFF
--- a/packages/oh-my-opencode/package.nix
+++ b/packages/oh-my-opencode/package.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
     # The plugin resolves its MCP servers at
     # <ancestor>/packages/{ast-grep-mcp,lsp-tools-mcp}/dist/cli.js
     mkdir -p $out/lib/oh-my-opencode/packages
-    cp -r packages/{ast-grep-mcp,lsp-tools-mcp} $out/lib/oh-my-opencode/packages/
+    cp -r packages/{ast-grep-mcp,lsp-tools-mcp,shared-skills} $out/lib/oh-my-opencode/packages/
 
     # ast-grep-mcp's dist/cli.js is a self-contained bun bundle; its
     # node_modules only holds a workspace symlink that would dangle in


### PR DESCRIPTION
Without it, the plugin fails to load with: `ENOENT: no such file or directory, open '/nix/store/x47gkdmndc20w0vz24xkdmg7gj9zin5h-oh-my-opencode-4.5.12/lib/oh-my-opencode/packages/shared-skills/skills/frontend-ui-ux/SKILL.md' failed to load plugin`