### PR TITLE
annot: init at 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 ### Code Review
 
 <details>
+<summary><strong>annot</strong> - Human-in-the-loop annotation tool for AI workflows</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-only
+- **Homepage**: https://github.com/denolehov/annot
+- **Usage**: `nix run github:numtide/llm-agents.nix#annot -- --help`
+- **Nix**: [packages/annot/package.nix](packages/annot/package.nix)
+
+</details>
+<details>
 <summary><strong>code-review-graph</strong> - Local knowledge graph for AI coding agents — builds persistent map of your codebase for token-efficient code reviews</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -132,6 +132,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 55891793;
         name = "arch-fan";
       };
+      fraggerfox = {
+        github = "fraggerfox";
+        githubId = 189939;
+        name = "Santhosh Raju";
+      };
     };
   }
 )

--- a/packages/annot/default.nix
+++ b/packages/annot/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+}

--- a/packages/annot/package.nix
+++ b/packages/annot/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  flake,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  jq,
+  moreutils,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs,
+  cargo-tauri,
+  pkg-config,
+  wrapGAppsHook3,
+  makeBinaryWrapper,
+
+  libsoup_3,
+  openssl,
+  webkitgtk_4_1,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "annot";
+  version = "0.11.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "denolehov";
+    repo = "annot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kCqMavuqDDfVe8CPMqzKjEHAvwUBMQpdfaWIXMAvm9o=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-5905ZoTV8e7dSM1KE8VybDt5z2VpqzkNMmKygW2wTzY=";
+  };
+
+  postPatch = ''
+    jq '.bundle.createUpdaterArtifacts = false' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  '';
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-GOXNrdK8QSj4y+DKhgFnoBnsyaV7iQCrC3AbOcJNc5s=";
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+    pnpmConfigHook
+    pnpm_10
+    nodejs
+    cargo-tauri.hook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      libsoup_3
+      openssl
+      webkitgtk_4_1
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      openssl
+    ];
+
+  # pnpmConfigHook runs with --ignore-scripts, so the postinstall that copies
+  # Excalidraw fonts from node_modules into static/ must be run manually.
+  preBuild = ''
+    node scripts/copy-excalidraw-fonts.js
+  '';
+
+  # Disable automatic wrapper to handle it manually per platform
+  dontWrapGApps = stdenv.hostPlatform.isLinux;
+
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapGApp "$out/bin/annot"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      makeWrapper "$out/Applications/annot.app/Contents/MacOS/annot" "$out/bin/annot"
+    '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    category = "Code Review";
+  };
+
+  meta = {
+    description = "Human-in-the-loop annotation tool for AI workflows";
+    changelog = "https://github.com/denolehov/annot/releases/tag/v${finalAttrs.version}";
+    longDescription = ''
+      annot is an annotation tool for human-in-the-loop AI workflows. AI
+      agents work fast, but vague feedback is a lossy channel. When an agent
+      drafts a plan, proposes a refactor, or generates code, annot provides a
+      moment of structured review: it opens a native window, you annotate
+      specific lines with located, typed comments, then it closes and returns
+      structured output to the agent.
+
+      annot can be used as a standalone CLI (open a file, annotate, get
+      output) or as an MCP server, allowing AI agents to block on human
+      review mid-workflow. It supports reviewing files, diffs, and
+      agent-generated content, with optional exit modes so the human can
+      signal approval, rejection, or custom next steps.
+    '';
+    homepage = "https://github.com/denolehov/annot";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "annot";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ fraggerfox ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

Add annot. Human-in-the-loop annotation tool for AI workflows
## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

### Testing

  Built and validated on `x86_64-linux`:

  | Check | Result |
  |---|---|
  | `nix fmt` | 0 files changed |
  | `nix build .#annot` | `result/bin/annot` (0.11.0) |
  | `nix build .#checks.x86_64-linux.pkgs-annot` | passed |
  | `nix flake check` | passed for `pkgs-annot` |
  | `nix-update --flake annot` round-trip from 0.10.0 |  bumped version + src/cargo/pnpm hashes |
  | Rust unit tests during build | all pass (`test result: ok` for state/snapshot/output suites) |

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
