### PR TITLE
gascity: init at 1.2.1

### DIFF
--- a/.github/ci/discovery.py
+++ b/.github/ci/discovery.py
@@ -22,14 +22,16 @@ let
   flake = builtins.getFlake (toString ./.);
   pkgs = flake.packages.${config.system};
   isHidden = pkg: pkg.passthru.hideFromDocs or false;
+  updateEvenIfHidden = pkg: pkg.passthru.updateEvenIfHidden or false;
+  shouldDiscover = pkg: !(isHidden pkg) || updateEvenIfHidden pkg;
   getVersion = name:
-    if pkgs ? ${name} && pkgs.${name} ? version && !(isHidden pkgs.${name})
+    if pkgs ? ${name} && pkgs.${name} ? version && shouldDiscover pkgs.${name}
     then { inherit name; value = pkgs.${name}.version; }
     else null;
 in
   if config.filter == null then
     builtins.mapAttrs (name: pkg:
-      if pkg ? version && !(isHidden pkg) then pkg.version else null
+      if pkg ? version && shouldDiscover pkg then pkg.version else null
     ) pkgs
   else
     builtins.listToAttrs

--- a/README.md
+++ b/README.md
@@ -637,6 +637,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>gascity</strong> - Orchestration-builder SDK for multi-agent coding workflows</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/gastownhall/gascity
+- **Usage**: `nix run github:numtide/llm-agents.nix#gascity -- --help`
+- **Nix**: [packages/gascity/package.nix](packages/gascity/package.nix)
+
+</details>
+<details>
 <summary><strong>gastown</strong> - Gas Town - multi-agent workspace manager</summary>
 
 - **Source**: source

--- a/packages/dolt/default.nix
+++ b/packages/dolt/default.nix
@@ -1,0 +1,23 @@
+# nixpkgs ships dolt 1.x, but gascity's managed bd/Dolt runtime requires
+# Dolt >= 2.1.0. Bump the nixpkgs package; dolt 2.1.2 requires go >= 1.26.2,
+# newer than nixpkgs' default Go, so build with go-bin.
+{ pkgs, perSystem, ... }:
+let
+  base = pkgs.dolt.override {
+    buildGoModule = pkgs.buildGoModule.override { go = perSystem.self.go-bin; };
+  };
+in
+(base.overrideAttrs (old: rec {
+  version = "2.1.2";
+  src = pkgs.fetchFromGitHub {
+    owner = "dolthub";
+    repo = "dolt";
+    rev = "v${version}";
+    hash = "sha256-npmvNbBcsjGrGE2juiInHLcQdznnKmBfISadRK+rSig=";
+  };
+  vendorHash = "sha256-JFvO4B+iOuaCGFDzESB9UXeeFzbvcLXcoN6kPiN5r9Y=";
+  passthru = (old.passthru or { }) // {
+    hideFromDocs = true;
+    updateEvenIfHidden = true;
+  };
+}))

--- a/packages/gascity/default.nix
+++ b/packages/gascity/default.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+let
+  dolt = perSystem.self.dolt;
+  beads = pkgs.callPackage ../beads/package.nix {
+    inherit dolt;
+    inherit (perSystem.self) go-bin;
+  };
+in
+pkgs.callPackage ./package.nix {
+  inherit beads dolt;
+  inherit (perSystem.self) go-bin;
+}

--- a/packages/gascity/nix-update-args
+++ b/packages/gascity/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/gascity/package.nix
+++ b/packages/gascity/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  go-bin,
+  beads,
+  dolt,
+  flock,
+  gitMinimal,
+  jq,
+  lsof,
+  procps,
+  tmux,
+  versionCheckHook,
+}:
+
+assert lib.versionAtLeast dolt.version "2.1.0";
+
+(buildGoModule.override { go = go-bin; }) rec {
+  pname = "gascity";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "gastownhall";
+    repo = "gascity";
+    rev = "v${version}";
+    hash = "sha256-q9ehkxbkq4bnGn8vB0OM/8MJRk6zgVCBLnlrmHx7/RI=";
+  };
+
+  vendorHash = "sha256-jKuPfAilxCndnkOCJf475wLh0DyxZxXQ33c+7nwFYzM=";
+
+  env.CGO_ENABLED = "0";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  subPackages = [ "cmd/gc" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=nixpkgs"
+    "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/gc \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          beads
+          dolt
+          flock
+          gitMinimal
+          jq
+          lsof
+          procps
+          tmux
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "version" ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Orchestration-builder SDK for multi-agent coding workflows";
+    homepage = "https://github.com/gastownhall/gascity";
+    changelog = "https://github.com/gastownhall/gascity/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ zaninime ];
+    mainProgram = "gc";
+    platforms = dolt.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Summary

Adds `gascity`, the Gas City multi-agent orchestration CLI, packaged from source at `1.2.1`.

Also adds a hidden `dolt-bin` helper package so Gas City gets a Dolt version new enough for its managed bd/Dolt runtime requirements.

## Details

- Add `packages/gascity`
  - Builds from `gastownhall/gascity` source
  - Uses `go-bin` for Go 1.26.3
  - Installs the `gc` CLI
  - Wraps runtime dependencies: `bd`, Dolt, `tmux`, `jq`, `git`, `flock`, `lsof`, `procps`
  - Asserts Dolt is at least `2.1.0`

- Add hidden `packages/dolt-bin`
  - Packages upstream Dolt release tarballs
  - Current version: `2.1.2`
  - Hidden from README docs
  - Opts into automated update discovery despite being hidden
  - Includes an `update.py` that updates all platform hashes

- Rebuild Gas City's wrapped `beads` package with `dolt-bin`, so `bd` does not accidentally use nixpkgs' older Dolt.

- Update package discovery so hidden helper packages can opt into automated updates with `passthru.updateEvenIfHidden = true`.

- Regenerate README package docs.

## Testing

- `nix build --accept-flake-config .#dolt-bin .#gascity`
- `nix run --accept-flake-config .#gascity -- version`
- `nix run --accept-flake-config .#dolt-bin -- version`
- `packages/dolt-bin/update.py`
- `nix run --accept-flake-config nixpkgs#nix-update -- --flake gascity`
- `nix build --accept-flake-config .#checks.$system.meta-maintainers`
- `nix fmt`
- `mypy packages/dolt-bin/update.py`
- `mypy .github/ci/discovery.py`
- `coderabbit review --agent -t committed --base upstream/main` (0 findings)
