### PR TITLE
herdr: stop forcing ReleaseSafe for libghostty-vt

### DIFF
--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -76,8 +76,6 @@ let
       export ZIG_LOCAL_CACHE_DIR="$TMPDIR/zig-local-cache"
       mkdir -p "$ZIG_GLOBAL_CACHE_DIR" "$ZIG_LOCAL_CACHE_DIR"
       ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
-      # ReleaseFast is the upstream default; ReleaseSafe keeps overflow checks.
-      export LIBGHOSTTY_VT_OPTIMIZE=ReleaseSafe
     '';
 
     # Tests spawn PTYs / interact with the terminal and don't work in the


### PR DESCRIPTION
## Summary
`ReleaseSafe` builds of Ghostty's terminal emulation code can currently trigger a crash with OSC 8 hyperlink-heavy output, as reported in https://github.com/ghostty-org/ghostty/discussions/12773.

Since `ReleaseFast` is the upstream default for this component, this removes the local override that forced `ReleaseSafe`.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
