### PR TITLE
hermes-agent: fix hermes dashboard issues

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -272,6 +272,13 @@ python3.pkgs.buildPythonApplication {
     setuptools
   ];
 
+  postPatch = ''
+    # Upstream package discovery only lists `hermes_cli`, which drops nested
+    # modules such as dashboard_auth and proxy from isolated setuptools builds.
+    substituteInPlace pyproject.toml \
+      --replace-fail '"hermes_cli", "gateway"' '"hermes_cli", "hermes_cli.*", "gateway"'
+  '';
+
   dependencies = hermesDeps;
   optional-dependencies = optionalDeps;
 
@@ -308,6 +315,8 @@ python3.pkgs.buildPythonApplication {
 
   pythonImportsCheck = [
     "hermes_cli"
+    "hermes_cli.dashboard_auth"
+    "hermes_cli.proxy"
     # #4175: adapters swallow ImportError, so assert these import.
     "slack_bolt"
     "discord"

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -259,8 +259,9 @@ let
   };
 
   # The TUI spawns `$HERMES_PYTHON -m tui_gateway.entry`; sys.executable is the
-  # bare interpreter, so give it an env with the runtime deps. tui_gateway
-  # itself is found via PYTHONPATH=$out/site-packages (HERMES_PYTHON_SRC_ROOT).
+  # bare interpreter, so give it an env with the runtime deps. The dashboard
+  # PTY path copies wrapper env into a nested Node subprocess, which then
+  # resolves the gateway import root from HERMES_PYTHON_SRC_ROOT.
   pythonEnv = python3.withPackages (_: hermesDeps);
 in
 python3.pkgs.buildPythonApplication {
@@ -292,6 +293,9 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_PYTHON"
     "${pythonEnv}/bin/python3"
+    "--set"
+    "HERMES_PYTHON_SRC_ROOT"
+    "${placeholder "out"}/${python3.sitePackages}"
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
@@ -336,6 +340,7 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_TUI_DIR $out/bin/hermes
     grep -q HERMES_WEB_DIST $out/bin/hermes
     grep -q HERMES_PYTHON $out/bin/hermes
+    grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     test -f ${hermes-tui}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-web}/share/hermes-web/index.html
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'


### PR DESCRIPTION
## Summary
Running hermes-agent with `dashboard` fails due to an import issue.

```
✦ ❯ nix run github:numtide/llm-agents.nix#hermes-agent -- dashboard
Traceback (most recent call last):
  File "/nix/store/hcg5j9nxcrj6lpf8z8pjl9q61f4dvn14-hermes-agent-2026.5.29/bin/.hermes-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/hcg5j9nxcrj6lpf8z8pjl9q61f4dvn14-hermes-agent-2026.5.29/lib/python3.13/site-packages/hermes_cli/main.py", line 14303, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/nix/store/hcg5j9nxcrj6lpf8z8pjl9q61f4dvn14-hermes-agent-2026.5.29/lib/python3.13/site-packages/hermes_cli/main.py", line 10937, in cmd_dashboard
    from hermes_cli.web_server import start_server
  File "/nix/store/hcg5j9nxcrj6lpf8z8pjl9q61f4dvn14-hermes-agent-2026.5.29/lib/python3.13/site-packages/hermes_cli/web_server.py", line 4822, in <module>
    from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'hermes_cli.dashboard_auth'
```

Additionally, the chat feature exposed when running `dashboard --tui` (using a web pty lib) was also failing due to another python env issue.

## Test plan
- `nix run .#hermes-agent -- dashboard --tui`
- Start a chat in the web interface

- [x] `nix build .#<package>` succeeds