### PR TITLE
Preserve OpenClaw src layout at install time

### DIFF
--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Remove development/build files not needed at runtime
     pushd $out/lib/openclaw
     rm -rf \
-      src \
       test \
       apps \
       Swabble \


### PR DESCRIPTION
This PR makes the smallest possible packaging fix for `openclaw` in `llm-agents.nix` by stopping the install step from pruning `src/` entirely.

### Why

OpenClaw’s published package still expects runtime assets under `src/`, including template files used at runtime. The current Nix packaging removes `src/` during `installPhase`, which breaks that contract.

That is the same issue tracked in #5588.

### What changed

- Stop deleting `src/` from the installed `openclaw` output.
- Keep the rest of the existing cleanup intact.

### Result

This preserves OpenClaw’s runtime layout without changing the rest of the package behavior.