### PR TITLE
reasonix: fix Go package

### DIFF
--- a/packages/reasonix/nix-update-args
+++ b/packages/reasonix/nix-update-args
@@ -1,3 +1,2 @@
---use-github-releases
 --version-regex
 ^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/reasonix/nix-update-args
+++ b/packages/reasonix/nix-update-args
@@ -1,2 +1,3 @@
+--use-github-releases
 --version-regex
 ^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/reasonix/package.nix
+++ b/packages/reasonix/package.nix
@@ -1,20 +1,25 @@
 {
-  pkgs,
   lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
   flake,
+  makeWrapper,
+  ripgrep,
+  bubblewrap,
   versionCheckHook,
   versionCheckHomeHook,
-  ...
 }:
+
 # Upstream rewrote reasonix from TypeScript to Go in 1.0.0.
-pkgs.buildGoModule (finalAttrs: {
+buildGoModule rec {
   pname = "reasonix";
   version = "1.3.0";
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "esengine";
     repo = "DeepSeek-Reasonix";
-    rev = "v${finalAttrs.version}";
+    rev = "v${version}";
     hash = "sha256-NcKZLH2TQTxujGHmVhoYZUW+P/Z63UiDwQ8phViqZEc=";
   };
 
@@ -22,13 +27,17 @@ pkgs.buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/reasonix" ];
 
-  env.CGO_ENABLED = 0;
+  nativeBuildInputs = [ makeWrapper ];
+
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"
     "-w"
-    "-X main.version=v${finalAttrs.version}"
+    "-X main.version=v${version}"
   ];
+
+  doCheck = true;
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [
@@ -36,18 +45,22 @@ pkgs.buildGoModule (finalAttrs: {
     versionCheckHomeHook
   ];
 
+  postFixup = ''
+    wrapProgram $out/bin/reasonix \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--suffix PATH : ${lib.makeBinPath [ bubblewrap ]}"}
+  '';
+
   meta = {
     description = "DeepSeek-native AI coding agent for your terminal";
     homepage = "https://github.com/esengine/DeepSeek-Reasonix";
     license = lib.licenses.mit;
-    changelog = "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ arch-fan ];
     mainProgram = "reasonix";
     platforms = lib.platforms.unix;
   };
 
-  passthru = {
-    category = "AI Coding Agents";
-  };
-})
+  passthru.category = "AI Coding Agents";
+}


### PR DESCRIPTION
## Summary

Fix `reasonix` packaging:

- enable Go checks
- wrap the CLI with `ripgrep` and Linux `bubblewrap` for runtime search/sandbox support
- keep `nix-update` on plain `v*` tags
- idiomatic cleanup: use direct package inputs, string env values, and `passthru.category`

## Test plan

- [x] `nix build .#reasonix` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

Also checked:

- `nix build --accept-flake-config .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).pkgs-reasonix`
- `./result/bin/reasonix --version`
- `PATH= HOME=$(mktemp -d) ./result/bin/reasonix doctor --json`
- `nix run --accept-flake-config nixpkgs#nix-update -- --flake --version-regex '^v([0-9]+\.[0-9]+\.[0-9]+)$' reasonix`

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
