### PR TITLE
officecli: 1.0.36 -> 1.0.104

### DIFF
--- a/packages/officecli/package.nix
+++ b/packages/officecli/package.nix
@@ -9,13 +9,13 @@
 
 buildDotnetModule rec {
   pname = "officecli";
-  version = "1.0.36";
+  version = "1.0.104";
 
   src = fetchFromGitHub {
     owner = "iOfficeAI";
     repo = "OfficeCLI";
     tag = "v${version}";
-    hash = "sha256-sx1w3cSBiU7AUeW6k2nqAGOEZk+PrTZoyQnem9DK9j8=";
+    hash = "sha256-bqPNCOVOXwke8g3+Pm6eftm48W4mFza1gNcY49fJRwk=";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;


### PR DESCRIPTION
Manual update; the bot fails because nix-update's nuget fetch-deps step calls `nix-build -A officecli.fetch-deps` on the repo root, which has no default.nix. deps.json regenerated via `nix build .#officecli.fetch-deps`.