### PR TITLE
reasonix: wrap runtime dependencies

### DIFF
--- a/packages/reasonix/default.nix
+++ b/packages/reasonix/default.nix
@@ -6,5 +6,5 @@
 }:
 pkgs.callPackage ./package.nix {
   inherit flake;
-  inherit (perSystem.self) versionCheckHomeHook;
+  inherit (perSystem.self) codegraph versionCheckHomeHook;
 }

--- a/packages/reasonix/package.nix
+++ b/packages/reasonix/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
   stdenv,
+  bash,
   buildGoModule,
+  codegraph,
   fetchFromGitHub,
   flake,
   makeWrapper,
@@ -47,8 +49,18 @@ buildGoModule rec {
 
   postFixup = ''
     wrapProgram $out/bin/reasonix \
-      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
-      ${lib.optionalString stdenv.hostPlatform.isLinux "--suffix PATH : ${lib.makeBinPath [ bubblewrap ]}"}
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            bash
+            codegraph
+            ripgrep
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            bubblewrap
+          ]
+        )
+      }
   '';
 
   meta = {


### PR DESCRIPTION
## Summary

Reasonix discovers several runtime helpers dynamically through `PATH`. This change wraps the relevant Nix packages so `nix run` behaves reproducibly and does not depend on binaries installed outside the Nix closure.

- **Bash**
  - [`ResolveShell`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/shell.go#L42-L55) passes `exec.LookPath` to the internal resolver, which searches for `bash` with `lookPath("bash")`.
  - Reasonix falls back to the literal executable name `"bash"` when it cannot resolve an absolute path: [`shell.go#L54-L70`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/shell.go#L54-L70).
  - Commands are executed through Bash using `bash -c`: [`shell.go#L136-L144`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/shell.go#L136-L144).
  - Wrapping Bash makes the shell tool independent of the user's interactive shell and host environment.

- **CodeGraph**
  - The complete resolution order is documented in [`internal/codegraph/codegraph.go#L49-L72`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/codegraph/codegraph.go#L49-L72):
    1. Explicitly configured `[codegraph].path`
    2. Previously downloaded cache
    3. `exec.LookPath("codegraph")`
    4. A bundled executable beside Reasonix
  - The actual `PATH` lookup occurs at [`codegraph.go#L66`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/codegraph/codegraph.go#L66).
  - If no executable is resolved, Reasonix can download CodeGraph into the user cache. The installation and download logic is implemented in [`internal/codegraph/install.go#L81-L118`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/codegraph/install.go#L81-L118).
  - Providing CodeGraph through the wrapper prevents this unmanaged first-run download on clean installations.

- **Bubblewrap**
  - Reasonix searches for `bwrap` with `exec.LookPath("bwrap")` before launching a sandboxed command: [`internal/sandbox/seatbelt_other.go#L16-L26`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/seatbelt_other.go#L16-L26).
  - Its sandbox availability check performs the same lookup: [`seatbelt_other.go#L29-L33`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/seatbelt_other.go#L29-L33).
  - When Bubblewrap is unavailable, Reasonix falls back to running the command without OS-level sandboxing.
  - Bubblewrap is therefore wrapped on Linux to preserve the intended sandbox enforcement.

- **Ripgrep**
  - Reasonix first checks for an explicitly configured `rg_path`, then searches `PATH` using `exec.LookPath("rg")`: [`internal/tool/builtin/grep.go#L252-L267`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/tool/builtin/grep.go#L252-L267).
  - When Ripgrep is unavailable, Reasonix falls back to its native Go search implementation: [`grep.go#L269-L278`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/tool/builtin/grep.go#L269-L278).
  - Ripgrep is included as the preferred fast search backend rather than as a strict functional requirement.

Bubblewrap remains Linux-only. On macOS, Reasonix uses the system-provided `sandbox-exec`:

- The command is wrapped with `sandbox-exec` in [`internal/sandbox/seatbelt_darwin.go#L16-L20`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/seatbelt_darwin.go#L16-L20).
- Its availability is checked with `exec.LookPath("sandbox-exec")` in [`seatbelt_darwin.go#L23-L26`](https://github.com/esengine/DeepSeek-Reasonix/blob/v1.3.0/internal/sandbox/seatbelt_darwin.go#L23-L26).

All of these programs are discovered by Reasonix at runtime rather than being linked directly. Adding the packaged executables to the wrapper's `PATH` makes their availability explicit and reproducible.

## Test plan

- [X] `nix build .#reasonix` succeeds
- [X] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work