### PR TITLE
Fix broken auto-updates: gitnexus, hermes-agent, officecli

### DIFF
--- a/packages/gitnexus/package.nix
+++ b/packages/gitnexus/package.nix
@@ -12,13 +12,13 @@ buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   forceGitDeps = true;
   pname = "gitnexus";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner = "abhigyanpatwari";
     repo = "GitNexus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bNV6yhbMbCYmkSu67dEF3Pm4amgzXNopWk+G2fmkdpI=";
+    hash = "sha256-6j6phmZwbfXMcHFbDNjOD78lBF67c3a+a5x6qo7p4as=";
   };
 
   sourceRoot = "source/gitnexus";
@@ -41,10 +41,18 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "path.join('node_modules', '.bin', 'tsc')" "'tsc'"
   '';
 
-  npmDepsHash = "sha256-BRvS1npNezOKThqQcHa1YKOSNQa5dL582/JszB6vdRI=";
+  npmDepsHash = "sha256-EG4/uRujXRVbjJkU6Q+YKOKPejIWIeSmjD/dYatuGZM=";
   makeCacheWritable = true;
 
   npmFlags = [ "--ignore-scripts" ];
+
+  # --ignore-scripts skips the upstream postinstall that copies vendored
+  # tree-sitter grammars (dart/proto/swift) into node_modules; tsc needs
+  # their type declarations. The native binding build is still skipped, as
+  # it was with the 1.6.5 file: optionalDependencies under --ignore-scripts.
+  preBuild = ''
+    node scripts/materialize-vendor-grammars.cjs
+  '';
 
   nativeBuildInputs = [
     makeWrapper
@@ -82,8 +90,7 @@ buildNpmPackage (finalAttrs: {
       fi
 
       wrapProgram $out/bin/gitnexus \
-        --set-default GITNEXUS_ORT_BINDING_PATH "${ortBinding}" \
-        --run 'export GITNEXUS_CACHE_DIR="$HOME/.cache"'
+        --set-default GITNEXUS_ORT_BINDING_PATH "${ortBinding}"
     '';
 
   passthru.category = "Memory & Code Intelligence";

--- a/packages/gitnexus/system-onnxruntime-node.patch
+++ b/packages/gitnexus/system-onnxruntime-node.patch
@@ -1,102 +1,26 @@
 diff --git gitnexus/src/core/embeddings/embedder.ts gitnexus/src/core/embeddings/embedder.ts
-index 72ddcbd7..9516db3c 100644
+index d873f3a..6e853df 100644
 --- gitnexus/src/core/embeddings/embedder.ts
 +++ gitnexus/src/core/embeddings/embedder.ts
-@@ -20,12 +20,31 @@ import {
-   type FeatureExtractionPipeline,
-   type ProgressInfo,
- } from '@huggingface/transformers';
--import { existsSync } from 'fs';
-+import { existsSync, mkdirSync } from 'fs';
- import { execFileSync } from 'child_process';
- import { join, dirname } from 'path';
- import { createRequire } from 'module';
- import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } from './types.js';
- import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
-+import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
-+
-+const configureTransformersCache = () => {
-+  const cacheRoot =
-+    process.env.GITNEXUS_CACHE_DIR ??
-+    process.env.XDG_CACHE_HOME ??
-+    (process.env.HOME ? join(process.env.HOME, '.cache') : null);
-+
-+  if (!cacheRoot) return;
-+
-+  const cacheDir = join(cacheRoot, 'gitnexus', 'transformers');
-+  try {
-+    mkdirSync(cacheDir, { recursive: true });
-+    env.cacheDir = cacheDir;
-+    env.useFSCache = true;
-+  } catch {
-+    // If cache setup fails, fall back to transformers.js defaults.
-+  }
-+};
+@@ -28,6 +28,7 @@ import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
  import { resolveEmbeddingConfig } from './config.js';
  import { applyHfEnvOverrides, isHfDownloadFailure, withHfDownloadRetry } from './hf-env.js';
+ import { getLocalEmbeddingRuntimeBlocker } from './runtime-support.js';
++import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
  import { logger } from '../logger.js';
-@@ -145,6 +164,9 @@ export const initEmbedder = async (
-   }
  
-   // If already initializing, wait for that promise
-+  applyOnnxruntimeNodeBindingOverride();
-+  configureTransformersCache();
-+
-   if (isInitializing && initPromise) {
-     return initPromise;
-   }
-diff --git gitnexus/src/mcp/core/embedder.ts gitnexus/src/mcp/core/embedder.ts
-index f529f280..00d2c737 100644
---- gitnexus/src/mcp/core/embedder.ts
-+++ gitnexus/src/mcp/core/embedder.ts
-@@ -6,6 +6,8 @@
-  */
+ /**
+@@ -179,6 +180,7 @@ export const initEmbedder = async (
+     try {
+       // Lazy-load transformers.js only after the runtime guard has passed, so
+       // unsupported platforms never reach the native ONNX import (#1515).
++      applyOnnxruntimeNodeBindingOverride();
+       const { pipeline, env } = await import('@huggingface/transformers');
  
- import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
-+import { mkdirSync } from 'fs';
-+import { join } from 'path';
- import {
-   isHttpMode,
-   getHttpDimensions,
-@@ -18,6 +20,25 @@ import {
-   withHfDownloadRetry,
- } from '../../core/embeddings/hf-env.js';
- import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
-+import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
-+
-+const configureTransformersCache = () => {
-+  const cacheRoot =
-+    process.env.GITNEXUS_CACHE_DIR ??
-+    process.env.XDG_CACHE_HOME ??
-+    (process.env.HOME ? join(process.env.HOME, '.cache') : null);
-+
-+  if (!cacheRoot) return;
-+
-+  const cacheDir = join(cacheRoot, 'gitnexus', 'transformers');
-+  try {
-+    mkdirSync(cacheDir, { recursive: true });
-+    env.cacheDir = cacheDir;
-+    env.useFSCache = true;
-+  } catch {
-+    // If cache setup fails, fall back to transformers.js defaults.
-+  }
-+};
- 
- import { logger } from '../../core/logger.js';
- // Model config
-@@ -40,6 +61,9 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
-     return embedderInstance;
-   }
- 
-+  applyOnnxruntimeNodeBindingOverride();
-+  configureTransformersCache();
-+
-   if (isInitializing && initPromise) {
-     return initPromise;
-   }
+       // Configure transformers.js environment
 diff --git gitnexus/src/core/embeddings/onnxruntime-node-loader.ts gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
 new file mode 100644
-index 00000000..252064f0
+index 0000000..252064f
 --- /dev/null
 +++ gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
 @@ -0,0 +1,53 @@
@@ -153,3 +77,23 @@ index 00000000..252064f0
 +    return originalResolve(request, parent, isMain, options);
 +  };
 +};
+diff --git gitnexus/src/mcp/core/embedder.ts gitnexus/src/mcp/core/embedder.ts
+index 451d12c..477c718 100644
+--- gitnexus/src/mcp/core/embedder.ts
++++ gitnexus/src/mcp/core/embedder.ts
+@@ -24,6 +24,7 @@ import {
+ import { getLocalEmbeddingRuntimeBlocker } from '../../core/embeddings/runtime-support.js';
+ import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
+ 
++import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
+ import { logger } from '../../core/logger.js';
+ // Model config
+ const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
+@@ -65,6 +66,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
+     try {
+       // Lazy-load transformers.js only after the runtime guard has passed, so
+       // unsupported platforms never reach the native ONNX import (#1515).
++      applyOnnxruntimeNodeBindingOverride();
+       const { pipeline, env } = await import('@huggingface/transformers');
+ 
+       env.allowLocalModels = false;

--- a/packages/hermes-agent/nix-update-args
+++ b/packages/hermes-agent/nix-update-args
@@ -1,6 +1,4 @@
 --version-regex
 ^v(\d+\.\d+\.\d+)$
 --subpackage
-hermes-tui
---subpackage
-hermes-web
+hermes-frontend

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -220,11 +220,12 @@ let
       # [web]
       fastapi
       uvicorn
+      # [markdown] — used by matrix and other formatters
+      markdown
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       # [matrix] — python-olm broken on macOS upstream.
       mautrix
-      markdown
       aiosqlite
       asyncpg
     ];

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -122,53 +122,43 @@ let
     };
   };
 
-  version = "2026.5.29";
+  version = "2026.6.5";
 
   src = fetchFromGitHub {
     owner = "NousResearch";
     repo = "hermes-agent";
     rev = "v${version}";
-    hash = "sha256-4SwFC4IjwdQi27dHXTd8QYS1eJHiQY0ja2LxyeW6KjE=";
+    hash = "sha256-ngpkopVczNrT0bfCXHm38QjgrZT96Bm/rO89NA/ls3Y=";
   };
 
-  # `hermes --tui` runs a compiled Ink/React app from ui-tui/ that the wheel
-  # does not ship. Prebuild it and expose via HERMES_TUI_DIR so the CLI takes
-  # the fast-path in hermes_cli/main.py:_make_tui_argv (#4364).
-  hermes-tui = buildNpmPackage {
-    pname = "hermes-tui";
-    inherit version;
-    src = "${src}/ui-tui";
-    npmDepsHash = "sha256-F6/MzZOWc0zhW9mIfnaY+PrllPvJcsA/OdFdEM+NpLY=";
+  # Upstream moved ui-tui/ and web/ into npm workspaces with a single root
+  # package-lock.json, so both frontends must be built from the repo root.
+  # `hermes --tui` runs the compiled Ink/React bundle via HERMES_TUI_DIR
+  # (hermes_cli/main.py:_make_tui_argv fast-path, #4364) and
+  # `hermes dashboard` serves the Vite app via HERMES_WEB_DIST.
+  hermes-frontend = buildNpmPackage {
+    pname = "hermes-frontend";
+    inherit version src;
+    npmDepsHash = "sha256-hgnqcpKRPztHhDEpwC7HJrALuJp9wsrV4+GJ6t6HI2c=";
 
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/lib/hermes-tui
-      cp -r dist node_modules package.json $out/lib/hermes-tui/
-      # @hermes/ink is a file: dep — replace dangling symlink with the source.
-      rm -f $out/lib/hermes-tui/node_modules/@hermes/ink
-      cp -r packages/hermes-ink $out/lib/hermes-tui/node_modules/@hermes/ink
-      runHook postInstall
-    '';
-  };
-
-  # `hermes dashboard` serves a Vite app from hermes_cli/web_dist. Build it
-  # ahead of time and point the wrapper at the immutable output so packaged
-  # installs never try to build frontend assets at runtime.
-  hermes-web = buildNpmPackage {
-    pname = "hermes-web";
-    inherit version;
-    src = "${src}/web";
-    npmDepsHash = "sha256-HV0aISBVjwbGqDj8qQynSxGFrrZDzuYAW3D3lB/x3zo=";
+    # The apps/desktop workspace pulls in electron; skip its binary download
+    # and all install scripts — the esbuild/vite builds below don't need them.
+    npmFlags = [ "--ignore-scripts" ];
+    env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
     buildPhase = ''
       runHook preBuild
-      npm run build -- --outDir "$TMPDIR/web-dist"
+      npm run build --workspace ui-tui
+      npm run build --workspace web -- --outDir "$TMPDIR/web-dist"
       runHook postBuild
     '';
 
+    # dist/entry.js is a self-contained esbuild bundle; package.json is kept
+    # so node resolves it as an ES module.
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/share/hermes-web
+      mkdir -p $out/lib/hermes-tui $out/share/hermes-web
+      cp -r ui-tui/dist ui-tui/package.json $out/lib/hermes-tui/
       cp -r "$TMPDIR/web-dist"/. $out/share/hermes-web/
       runHook postInstall
     '';
@@ -185,6 +175,7 @@ let
       httpx
       rich
       tenacity
+      pathspec
       pyyaml
       ruamel-yaml
       requests
@@ -273,23 +264,16 @@ python3.pkgs.buildPythonApplication {
     setuptools
   ];
 
-  postPatch = ''
-    # Upstream package discovery only lists `hermes_cli`, which drops nested
-    # modules such as dashboard_auth and proxy from isolated setuptools builds.
-    substituteInPlace pyproject.toml \
-      --replace-fail '"hermes_cli", "gateway"' '"hermes_cli", "hermes_cli.*", "gateway"'
-  '';
-
   dependencies = hermesDeps;
   optional-dependencies = optionalDeps;
 
   makeWrapperArgs = [
     "--set"
     "HERMES_TUI_DIR"
-    "${hermes-tui}/lib/hermes-tui"
+    "${hermes-frontend}/lib/hermes-tui"
     "--set"
     "HERMES_WEB_DIST"
-    "${hermes-web}/share/hermes-web"
+    "${hermes-frontend}/share/hermes-web"
     "--set"
     "HERMES_PYTHON"
     "${pythonEnv}/bin/python3"
@@ -313,6 +297,7 @@ python3.pkgs.buildPythonApplication {
     "ruamel.yaml"
     "requests"
     "pydantic"
+    "pathspec"
     "firecrawl-py"
     "pyjwt"
   ];
@@ -341,14 +326,14 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_WEB_DIST $out/bin/hermes
     grep -q HERMES_PYTHON $out/bin/hermes
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
-    test -f ${hermes-tui}/lib/hermes-tui/dist/entry.js
-    test -f ${hermes-web}/share/hermes-web/index.html
+    test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
+    test -f ${hermes-frontend}/share/hermes-web/index.html
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
   '';
 
   passthru = {
     category = "AI Assistants";
-    inherit hermes-tui hermes-web;
+    inherit hermes-frontend;
   };
 
   meta = with lib; {

--- a/packages/officecli/package.nix
+++ b/packages/officecli/package.nix
@@ -9,13 +9,13 @@
 
 buildDotnetModule rec {
   pname = "officecli";
-  version = "1.0.104";
+  version = "1.0.107";
 
   src = fetchFromGitHub {
     owner = "iOfficeAI";
     repo = "OfficeCLI";
     tag = "v${version}";
-    hash = "sha256-bqPNCOVOXwke8g3+Pm6eftm48W4mFza1gNcY49fJRwk=";
+    hash = "sha256-JnADePMkvtyqq4SXO9oASK5E6FbEvuEo+ctvXaJnAPw=";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;


### PR DESCRIPTION
Fixes three of the four failures from the last Update Dependencies run (https://github.com/numtide/llm-agents.nix/actions/runs/27224522168). The fourth (entire) was already fixed via the go-bin 1.26.4 bump.

- **gitnexus 1.6.6**: regenerate the onnxruntime-node patch for the lazy-loading rewrite and run the new vendored-grammar materialize step that `--ignore-scripts` skips.
- **hermes-agent 2026.6.5**: upstream switched to npm workspaces with a single root lockfile; merge the tui/web subbuilds into one `hermes-frontend` derivation built from the repo root.
- **officecli 1.0.107**: updated manually; the auto-update failure is a nix-update limitation (fetch-deps not flake-aware), fixed upstream in https://github.com/Mic92/nix-update/pull/615 — auto-updates work once that lands in nixpkgs.