### PR TITLE
antigravity-cli: remove antigravity symlink

### DIFF
--- a/packages/antigravity-cli/package.nix
+++ b/packages/antigravity-cli/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm755 antigravity $out/bin/agy
-    ln -s agy $out/bin/antigravity
 
     runHook postInstall
   '';


### PR DESCRIPTION
Remove the `antigravity` symlink that conflicts with the antigravity GUI IDE from nixpkgs. The canonical binary name is `agy`.

Fixes #5754