### PR TITLE
devshell: pin nix-update 1.16.0

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -9,7 +9,17 @@ pkgs.mkShellNoCC {
     pkgs.gnugrep
     pkgs.gnused
     pkgs.jq
-    pkgs.nix-update
+    # Pin nix-update 1.16.0 for buildDotnetModule fetch-deps flake support
+    # (https://github.com/Mic92/nix-update/pull/615). Remove once nixpkgs catches up.
+    (pkgs.nix-update.overrideAttrs (old: {
+      version = "1.16.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "Mic92";
+        repo = "nix-update";
+        rev = "v1.16.0";
+        hash = "sha256-LT66e5NtAJRp0E8QXKeePdTCNpH+CMvJNF1ayzBr4rw=";
+      };
+    }))
     pkgs.nodejs
 
     # Formatter

--- a/devshell.nix
+++ b/devshell.nix
@@ -11,7 +11,7 @@ pkgs.mkShellNoCC {
     pkgs.jq
     # Pin nix-update 1.16.0 for buildDotnetModule fetch-deps flake support
     # (https://github.com/Mic92/nix-update/pull/615). Remove once nixpkgs catches up.
-    (pkgs.nix-update.overrideAttrs (old: {
+    (pkgs.nix-update.overrideAttrs (_: {
       version = "1.16.0";
       src = pkgs.fetchFromGitHub {
         owner = "Mic92";


### PR DESCRIPTION
Pin nix-update to 1.16.0 via override to fix buildDotnetModule fetch-deps in flake context. This unblocks officecli auto-updates.

Upstream fix: https://github.com/Mic92/nix-update/pull/615

Remove the override once nixpkgs catches up.