### PR TITLE
mimo-code: init at 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>mimo-code</strong> - Open-source AI coding agent with cross-session memory</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://github.com/XiaomiMiMo/MiMo-Code
+- **Usage**: `nix run github:numtide/llm-agents.nix#mimo-code -- --help`
+- **Nix**: [packages/mimo-code/package.nix](packages/mimo-code/package.nix)
+
+</details>
+<details>
 <summary><strong>mistral-vibe</strong> - Minimal CLI coding agent by Mistral AI - open-source command-line coding assistant powered by Devstral</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -142,6 +142,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 8346803;
         name = "Cirios Santhiago";
       };
+      scotttrinh = {
+        github = "scotttrinh";
+        githubId = 1682194;
+        name = "Scott Trinh";
+      };
     };
   }
 )

--- a/packages/mimo-code/default.nix
+++ b/packages/mimo-code/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  perSystem,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) wrapBuddy versionCheckHomeHook;
+}

--- a/packages/mimo-code/hashes.json
+++ b/packages/mimo-code/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1.1",
+  "hashes": {
+    "x86_64-linux": "sha256-U6d3xNgo1WShOaUFaevvBxzShrF5oTpfzcI4V84lb3o=",
+    "aarch64-linux": "sha256-VMH8B+ESSGyJXu4shoXzseHXNtt17Q7mY0NyiCpO0tk=",
+    "x86_64-darwin": "sha256-wPRW7qjVLZHsbG5pN8DS1/2siJCWYmb4unTq4WXoZCA=",
+    "aarch64-darwin": "sha256-o2Jaejwlh567L2jpkg5Kb1qeQ641o36oAqYrLjeLJos="
+  }
+}

--- a/packages/mimo-code/package.nix
+++ b/packages/mimo-code/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  unzip,
+  wrapBuddy,
+  fzf,
+  ripgrep,
+  versionCheckHook,
+  versionCheckHomeHook,
+  writeShellScriptBin,
+  flake,
+}:
+
+let
+  pname = "mimo-code";
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = {
+      asset = "mimocode-linux-x64.tar.gz";
+      isZip = false;
+    };
+    aarch64-linux = {
+      asset = "mimocode-linux-arm64.tar.gz";
+      isZip = false;
+    };
+    x86_64-darwin = {
+      asset = "mimocode-darwin-x64.zip";
+      isZip = true;
+    };
+    aarch64-darwin = {
+      asset = "mimocode-darwin-arm64.zip";
+      isZip = true;
+    };
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformInfo = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+
+  src = fetchurl {
+    url = "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v${version}/${platformInfo.asset}";
+    hash = hashes.${platform};
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals platformInfo.isZip [
+    unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapBuddy
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (writeShellScriptBin "sysctl" "echo 0")
+  ];
+  versionCheckKeepEnvironment = "PATH";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  wrapBuddyExtraNeeded = lib.optionals stdenv.hostPlatform.isLinux [
+    "libstdc++.so.6"
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+  ''
+  + lib.optionalString platformInfo.isZip ''
+    unzip $src
+  ''
+  + lib.optionalString (!platformInfo.isZip) ''
+    tar -xzf $src
+  ''
+  + ''
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 mimo $out/bin/mimo
+
+    wrapProgram $out/bin/mimo \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fzf
+          ripgrep
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Open-source AI coding agent with cross-session memory";
+    longDescription = ''
+      MiMoCode is a terminal-native AI coding assistant based on OpenCode.
+      It adds persistent memory, context management, subagent orchestration,
+      goal-driven autonomous loops, and compose workflows.
+    '';
+    homepage = "https://github.com/XiaomiMiMo/MiMo-Code";
+    changelog = "https://github.com/XiaomiMiMo/MiMo-Code/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ scotttrinh ];
+    platforms = builtins.attrNames platformMap;
+    mainProgram = "mimo";
+  };
+}

--- a/packages/mimo-code/update.py
+++ b/packages/mimo-code/update.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for mimo-code package binary releases."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+PLATFORMS = {
+    "x86_64-linux": "mimocode-linux-x64.tar.gz",
+    "aarch64-linux": "mimocode-linux-arm64.tar.gz",
+    "x86_64-darwin": "mimocode-darwin-x64.zip",
+    "aarch64-darwin": "mimocode-darwin-arm64.zip",
+}
+
+
+def main() -> None:
+    """Update the mimo-code package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("XiaomiMiMo", "MiMo-Code")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = (
+        f"https://github.com/XiaomiMiMo/MiMo-Code/releases/download/"
+        f"v{latest}/{{platform}}"
+    )
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the newly released MiMo-Code project as a package. Since this is a fork of OpenCode and seemingly has a similar distribution pattern, I've mostly copied the code from the existing opencode package. Built with the help of codex.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

