### PR TITLE
agentsview: disable telemetry

### DIFF
--- a/packages/agentsview/package.nix
+++ b/packages/agentsview/package.nix
@@ -5,6 +5,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   versionCheckHook,
+  makeBinaryWrapper,
   unpinGoModVersionHook,
 }:
 
@@ -41,7 +42,10 @@ buildGoModule {
   pname = "agentsview";
   inherit version src vendorHash;
 
-  nativeBuildInputs = [ unpinGoModVersionHook ];
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    unpinGoModVersionHook
+  ];
 
   subPackages = [ "cmd/agentsview" ];
   tags = [ "fts5" ];
@@ -64,6 +68,11 @@ buildGoModule {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = ''
+    wrapProgram $out/bin/agentsview \
+      --set AGENTSVIEW_TELEMETRY_ENABLED 0
+  '';
 
   passthru.category = "Usage Analytics";
 


### PR DESCRIPTION
## Summary

Starting with 0.33 the package sends telemetry. Wrap the binary to disable it.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work


Also ran with `strace -f -e trace=connect,sendto,write -s 2000 -o /tmp/NET` to confirm telemetry sent before and not sent after.