### PR TITLE
bugfix: symlinking bwrap to non-wrapped codex

### DIFF
--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -111,6 +111,9 @@ rustPlatform.buildRustPackage {
   '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/codex-resources
+    ln -s ${lib.getExe bubblewrap} $out/codex-resources/bwrap
+
     wrapProgram $out/bin/codex \
       --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
   '';


### PR DESCRIPTION
## Summary

The Codex package currently wraps only `$out/bin/codex` to add `bubblewrap` to `PATH`.
Codex creates arg0 helper symlinks using `std::env::current_exe()`, after wrapping it resolves to the unwrapped binary: `$out/bin/.codex-wrapped`
Helpers such as codex-linux-sandbox can point directly at .codex-wrapped and bypass the wrapper-provided PATH. When that happens sandboxed commands fail because bwrap is not visible to the sandbox launcher.
PR symlinks bubblewrap into Codex’s expected resource directory: `$out/codex-resources/bwrap`, Codex already checks this location as a bundled-resource fallback, so the sandbox helper can find bwrap even when invoked through the unwrapped binary.

## Test plan
- [x] `nix build .#codex` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
- [x] Verified sandboxed commands work after rebuilding:
  - echo sandbox-test succeeds
  - writing to /tmp succeeds
  - writing outside the writable sandbox roots fails with Read-only file system


Closes #5831 