### PR TITLE
fix(omp): generate embedded HTML-export tool-views bundle

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -219,6 +219,12 @@ stdenv.mkDerivation {
     echo "Generating embedded stats dashboard..."
     bun --cwd packages/stats scripts/generate-client-bundle.ts --generate
 
+    # Generate the embedded HTML-export tool-views bundle (coding-agent prepack
+    # step): export/html/index.ts text-imports ./tool-views.generated.js, which
+    # bun compile cannot resolve unless it is generated first.
+    echo "Generating embedded HTML-export tool-views..."
+    bun --cwd packages/collab-web scripts/build-tool-views.ts
+
     # Compile the standalone binary. Since v15.11.0 workers re-enter via
     # Bun.main, so no separate worker entrypoints are needed.
     echo "Compiling standalone binary..."


### PR DESCRIPTION
#5807 (omp: 15.11.6 -> 15.13.1) is blocked: Buildbot's `pkgs-omp` build fails on all platforms (x86_64-linux, aarch64-linux, aarch64-darwin).

Since 15.12.x, coding-agent's `src/export/html/index.ts` statically imports the generated `./tool-views.generated.js` (`with { type: "text" }`), produced upstream in coding-agent's `prepack` via `bun --cwd=packages/collab-web run build:tool-views`. The OMP derivation generates the docs index and the stats dashboard bundle but never ran that step, so `bun build --compile` fails:

    error: Could not resolve: "./tool-views.generated.js"
        at packages/coding-agent/src/export/html/index.ts:14:25

This PR targets `update/omp` so the fix lands in #5807; once merged, Buildbot rebuilds `pkgs-omp` green and the bump auto-merges to `main`.

Change:

- Generate the embedded HTML-export tool-views bundle before compile (`bun --cwd packages/collab-web scripts/build-tool-views.ts`), mirroring the existing docs-index and stats-dashboard generation steps

Tested: `nix build .#omp` succeeds; `omp --version` -> `omp/15.13.1`; `omp --smoke-test` prints `smoke-test: ok`; the `<omp-tool-view>` renderer bundle is embedded in the compiled binary.
