### PR TITLE
Fix scheduled update failures for cursor-agent and openclaw

### DIFF
--- a/packages/cursor-agent/hashes.json
+++ b/packages/cursor-agent/hashes.json
@@ -1,9 +1,9 @@
 {
-  "version": "2026.06.04-5fd875e",
+  "version": "2026.06.15-18-00-12-6f5a2cf",
   "hashes": {
-    "aarch64-darwin": "sha256-GswPdGwhm/kweOTO66vWTpoptfRKN0bOmjCwFLdG0sc=",
-    "x86_64-darwin": "sha256-v0NSz3PECoPJg0C9UmmgpcuE9QEEJxdr9tZIkerKYiY=",
-    "x86_64-linux": "sha256-VCWqsp+KAdN33j3H90VXOa1Zgp4IeeoMQpa9nuxSAwA=",
-    "aarch64-linux": "sha256-840iUUKLt1duoq1LbxIFgwtRmvTna7A6Ofi4wbkEKkI="
+    "x86_64-darwin": "sha256-brifvXk3SqyBReovGXk8+j9hONdK8dRdT+KZxkRkKnQ=",
+    "aarch64-darwin": "sha256-Se2EDjq0ahKZaJB9v+8G5Fnu+y/KHE/sU461YOG1m6w=",
+    "aarch64-linux": "sha256-cD46R6R7uq5NVLSPhgp4Ctrla/2/uM/M9Xjd29VyE4I=",
+    "x86_64-linux": "sha256-M7IrDE/QOXqJ/BuQjkU2uwqPsJ2v+XrPUZ++x2VpzLM="
   }
 }

--- a/packages/cursor-agent/update.py
+++ b/packages/cursor-agent/update.py
@@ -26,7 +26,11 @@ PLATFORMS = {
 }
 
 VERSION_URL = "https://cursor.com/install"
-VERSION_PATTERN = r"downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]+)"
+# Build id suffix can contain hyphens (e.g. 2026.06.15-18-00-12-6f5a2cf);
+# match them and anchor on the trailing path separator.
+VERSION_PATTERN = (
+    r"downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f-]+)/"
+)
 
 
 def main() -> None:

--- a/packages/openclaw/nix-update-args
+++ b/packages/openclaw/nix-update-args
@@ -1,0 +1,1 @@
+--use-github-releases


### PR DESCRIPTION
The scheduled Update Dependencies run (run 27597310257) failed two jobs:

### cursor-agent
Cursor changed its lab build id format on 2026.06.15 to include extra
hyphen-separated segments (e.g. `2026.06.15-18-00-12-6f5a2cf`). The
updater's version regex only allowed a single `[a-f0-9]+` suffix, so it
truncated the version to `2026.06.15-18` and the download 403'd.

- Allow hyphens in the suffix and anchor on the trailing path separator.
- Bumps the package to the now-correctly-parsed `2026.06.15-18-00-12-6f5a2cf`.

### openclaw
Upstream tags many alpha/beta prereleases between stable releases, so
nix-update picked the latest tag, saw a prerelease and errored
(`Found an unstable version ... which is being ignored`), failing the job.
Add `--use-github-releases` so nix-update honours the prerelease flag and
tracks the latest stable release.

## Testing

- `packages/cursor-agent/update.py` now resolves `2026.06.15-18-00-12-6f5a2cf` and fetches all 4 platform hashes; `nix build .#cursor-agent` succeeds and `cursor-agent --version` reports the new version.
- `nix-update --flake openclaw --use-github-releases` -> `Not updating version, already 2026.6.6`, exit 0.
- Verified all 4 cursor download URLs return 200 for the full version (the truncated one returned 403).