### PR TITLE
Maintainer and category updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>icm</strong> - Persistent memory for AI agents with hybrid search, temporal decay, and multilingual embeddings</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/rtk-ai/icm
+- **Usage**: `nix run github:numtide/llm-agents.nix#icm -- --help`
+- **Nix**: [packages/icm/package.nix](packages/icm/package.nix)
+
+</details>
+<details>
 <summary><strong>lean-ctx</strong> - Context OS for AI development — compression, memory, and routing for LLM context</summary>
 
 - **Source**: source
@@ -1130,16 +1140,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/slopus/happy
 - **Usage**: `nix run github:numtide/llm-agents.nix#happy-coder -- --help`
 - **Nix**: [packages/happy-coder/package.nix](packages/happy-coder/package.nix)
-
-</details>
-<details>
-<summary><strong>icm</strong> - Persistent memory for AI agents with hybrid search, temporal decay, and multilingual embeddings</summary>
-
-- **Source**: source
-- **License**: Apache-2.0
-- **Homepage**: https://github.com/rtk-ai/icm
-- **Usage**: `nix run github:numtide/llm-agents.nix#icm -- --help`
-- **Nix**: [packages/icm/package.nix](packages/icm/package.nix)
 
 </details>
 <details>

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -137,8 +137,8 @@ inputs.nixpkgs.lib.extend (
         githubId = 189939;
         name = "Santhosh Raju";
       };
-      cirios-santhiago = {
-        github = "cirios-santhiago";
+      csanthiago = {
+        github = "csanthiago";
         githubId = 8346803;
         name = "Cirios Santhiago";
       };

--- a/packages/icm/package.nix
+++ b/packages/icm/package.nix
@@ -120,7 +120,7 @@ rustPlatform.buildRustPackage {
     changelog = "https://github.com/rtk-ai/icm/releases/tag/icm-v${hashes.version}";
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    maintainers = with flake.lib.maintainers; [ cirios-santhiago ];
+    maintainers = with flake.lib.maintainers; [ csanthiago ];
     mainProgram = "icm";
     platforms = platforms.unix;
   };

--- a/packages/icm/package.nix
+++ b/packages/icm/package.nix
@@ -111,7 +111,7 @@ rustPlatform.buildRustPackage {
 
   passthru = {
     inherit icm-web;
-    category = "Utilities";
+    category = "Memory & Code Intelligence";
   };
 
   meta = with lib; {

--- a/packages/lean-ctx/package.nix
+++ b/packages/lean-ctx/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/yvgude/lean-ctx/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with flake.lib.maintainers; [ cirios-santhiago ];
+    maintainers = with flake.lib.maintainers; [ csanthiago ];
     mainProgram = "lean-ctx";
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
## Summary

- Rename maintainer `cirios-santhiago` → `csanthiago` (same account, githubId 8346803) across `lib/default.nix`, `packages/icm`, and `packages/lean-ctx`
- Move `icm` to `Memory & Code Intelligence` category per feedback in #5617

## AI Disclosure

Developed with Crush 💘 (qwen3.7-max). Reviewed and approved by a human.