### PR TITLE
vix: init at 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/reasonix/package.nix](packages/reasonix/package.nix)
 
 </details>
+<details>
+<summary><strong>vix</strong> - Sleek, Fast and Token Efficient AI Coding Agent</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-only
+- **Homepage**: https://github.com/get-vix/vix
+- **Usage**: `nix run github:numtide/llm-agents.nix#vix -- --help`
+- **Nix**: [packages/vix/package.nix](packages/vix/package.nix)
+
+</details>
 
 ### AI Assistants
 

--- a/packages/vix/default.nix
+++ b/packages/vix/default.nix
@@ -1,0 +1,6 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+}

--- a/packages/vix/default.nix
+++ b/packages/vix/default.nix
@@ -1,6 +1,2 @@
-{
-  pkgs,
-  ...
-}:
-pkgs.callPackage ./package.nix {
-}
+{ pkgs, ... }:
+pkgs.callPackage ./package.nix { }

--- a/packages/vix/package.nix
+++ b/packages/vix/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  versionCheckHook,
+  pkg-config,
+}:
+
+buildGoModule rec {
+  pname = "vix";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "get-vix";
+    repo = "vix";
+    rev = "v${version}";
+    hash = "sha256-dlW07swW66Qkc7K0Ugt+dyqJnHE4cKiPOXIlEkAqiO8=";
+  };
+
+  # source already has vendor folder
+  vendorHash = null;
+
+  subPackages = [
+    "cmd/vix"
+    "cmd/vixd"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+    "-X github.com/get-vix/vix/internal/ui.Version=${version}"
+  ];
+
+  doCheck = true;
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Sleek, Fast and Token Efficient AI Coding Agent";
+    homepage = "https://github.com/get-vix/vix";
+    changelog = "https://github.com/get-vix/vix/releases/tag/v${version}";
+    license = licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ daspk04 ];
+    mainProgram = "vix";
+    platforms = platforms.unix;
+  };
+}

--- a/packages/vix/package.nix
+++ b/packages/vix/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   buildGoModule,
   versionCheckHook,
-  pkg-config,
 }:
 
 buildGoModule rec {
@@ -25,16 +24,12 @@ buildGoModule rec {
     "cmd/vixd"
   ];
 
-  nativeBuildInputs = [ pkg-config ];
-
   ldflags = [
     "-s"
     "-w"
     "-X main.Version=${version}"
-    "-X github.com/get-vix/vix/internal/ui.Version=${version}"
   ];
 
-  doCheck = true;
   doInstallCheck = true;
 
   nativeInstallCheckInputs = [
@@ -48,8 +43,8 @@ buildGoModule rec {
     homepage = "https://github.com/get-vix/vix";
     changelog = "https://github.com/get-vix/vix/releases/tag/v${version}";
     license = licenses.agpl3Only;
-    sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with lib.maintainers; [ daspk04 ];
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ daspk04 ];
     mainProgram = "vix";
     platforms = platforms.unix;
   };


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

Package Vix: https://getvix.dev/
Project repo: https://github.com/get-vix/vix


## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#vix` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
- [x]  python ./scripts/generate-package-docs.py
- [x] nix fmt 

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
