### PR TITLE
codex: expose source override arguments

### DIFF
--- a/lib/rusty-v8.nix
+++ b/lib/rusty-v8.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+lib.makeOverridable (
+  {
+    version,
+    hashes,
+  }:
+
+  fetchurl {
+    name = "librusty_v8-${version}";
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    hash = hashes.${stdenv.hostPlatform.system};
+    meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  }
+)

--- a/packages/codex-acp/default.nix
+++ b/packages/codex-acp/default.nix
@@ -1,1 +1,10 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{
+  pkgs,
+  ...
+}@args:
+pkgs.callPackage ./package.nix (
+  {
+    mkRustyV8Archive = pkgs.callPackage ../../lib/rusty-v8.nix { };
+  }
+  // builtins.removeAttrs args [ "pkgs" ]
+)

--- a/packages/codex-acp/package.nix
+++ b/packages/codex-acp/package.nix
@@ -2,92 +2,81 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
   rustPlatform,
   pkg-config,
   openssl,
   libcap,
-}:
-let
-  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  inherit (versionData)
-    version
-    hash
-    cargoHash
-    codexOwner
-    codexRev
-    codexSrcHash
-    librusty_v8
-    ;
-
-  # codex-linux-sandbox's build.rs compiles a vendored copy of bubblewrap (with
-  # patches) that lives in codex-rs/vendor/bubblewrap in the main codex repo.
-  # Cargo vendoring flattens the workspace so this directory is missing; we
-  # fetch the codex source at the pinned rev to provide it via
-  # CODEX_BWRAP_SOURCE_DIR.
-  codexSrc = fetchFromGitHub {
-    owner = codexOwner;
-    repo = "codex";
-    rev = codexRev;
-    hash = codexSrcHash;
-  };
-
-  # The v8 crate downloads a prebuilt static library at build time. Fetch it
-  # as a fixed-output derivation so the build stays sandboxed.
-  librustyV8 = fetchurl {
-    name = "librusty_v8-${librusty_v8.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${librusty_v8.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-    hash = librusty_v8.hashes.${stdenv.hostPlatform.system};
-    meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-  };
-in
-rustPlatform.buildRustPackage {
-  pname = "codex-acp";
-  inherit version;
-
-  src = fetchFromGitHub {
+  mkRustyV8Archive,
+  versionData ? builtins.fromJSON (builtins.readFile ./hashes.json),
+  version ? versionData.version,
+  hash ? versionData.hash,
+  src ? fetchFromGitHub {
     owner = "zed-industries";
     repo = "codex-acp";
     rev = "v${version}";
     inherit hash;
-  };
+  },
+  sourceRoot ? "source",
+  cargoVendor ? {
+    cargoHash = versionData.cargoHash;
+  },
+  codexOwner ? versionData.codexOwner,
+  codexRev ? versionData.codexRev,
+  codexSrcHash ? versionData.codexSrcHash,
+  codexSrc ? fetchFromGitHub {
+    owner = codexOwner;
+    repo = "codex";
+    rev = codexRev;
+    hash = codexSrcHash;
+  },
+  codexBwrapSourceDir ? "${codexSrc}/codex-rs/vendor/bubblewrap",
+  librusty_v8 ? mkRustyV8Archive versionData.librusty_v8,
+}:
+rustPlatform.buildRustPackage (
+  {
+    pname = "codex-acp";
+    inherit version src sourceRoot;
 
-  inherit cargoHash;
+    env = {
+      RUSTY_V8_ARCHIVE = librusty_v8;
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      # Point the codex-linux-sandbox build.rs at the vendored bubblewrap source
+      CODEX_BWRAP_SOURCE_DIR = codexBwrapSourceDir;
+    };
 
-  env = {
-    RUSTY_V8_ARCHIVE = librustyV8;
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-    # Point the codex-linux-sandbox build.rs at the vendored bubblewrap source
-    CODEX_BWRAP_SOURCE_DIR = "${codexSrc}/codex-rs/vendor/bubblewrap";
-  };
-
-  nativeBuildInputs = [
-    pkg-config
-  ];
-
-  buildInputs = [
-    openssl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libcap
-  ];
-
-  doCheck = false;
-
-  passthru.category = "ACP Ecosystem";
-
-  meta = with lib; {
-    description = "An ACP-compatible coding agent powered by Codex";
-    homepage = "https://github.com/zed-industries/codex-acp";
-    changelog = "https://github.com/zed-industries/codex-acp/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
-    sourceProvenance = with sourceTypes; [
-      fromSource
-      binaryNativeCode
+    nativeBuildInputs = [
+      pkg-config
     ];
-    mainProgram = "codex-acp";
-  };
-}
+
+    buildInputs = [
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libcap
+    ];
+
+    doCheck = false;
+
+    passthru = {
+      category = "ACP Ecosystem";
+      inherit mkRustyV8Archive;
+      inherit librusty_v8;
+    };
+
+    meta = with lib; {
+      description = "An ACP-compatible coding agent powered by Codex";
+      homepage = "https://github.com/zed-industries/codex-acp";
+      changelog = "https://github.com/zed-industries/codex-acp/releases/tag/v${version}";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ ];
+      platforms = platforms.unix;
+      sourceProvenance = with sourceTypes; [
+        fromSource
+        binaryNativeCode
+      ];
+      mainProgram = "codex-acp";
+    };
+  }
+  // cargoVendor
+)

--- a/packages/codex/default.nix
+++ b/packages/codex/default.nix
@@ -1,5 +1,10 @@
 {
   pkgs,
   ...
-}:
-pkgs.callPackage ./package.nix { }
+}@args:
+pkgs.callPackage ./package.nix (
+  {
+    mkRustyV8Archive = pkgs.callPackage ../../lib/rusty-v8.nix { };
+  }
+  // builtins.removeAttrs args [ "pkgs" ]
+)

--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
   fetchzip,
   installShellFiles,
   makeWrapper,
@@ -12,22 +11,34 @@
   bubblewrap,
   libcap,
   versionCheckHook,
+  mkRustyV8Archive,
+  versionData ? builtins.fromJSON (builtins.readFile ./hashes.json),
+  version ? versionData.version,
+  hash ? versionData.hash,
+  src ? fetchFromGitHub {
+    owner = "openai";
+    repo = "codex";
+    tag = "rust-v${version}";
+    inherit hash;
+  },
+  sourceRoot ? "source/codex-rs",
+  cargoVendor ? {
+    cargoHash = versionData.cargoHash;
+  },
+  preBuild ? ''
+    # Upstream's low codegen-units (4 since 0.140.0) makes late-stage rustc
+    # hold large IR modules, peaking at ~12 GiB and OOMing our 16 GiB aarch64
+    # builder. Raise to 16 to bound memory; __TEXT still stays below the
+    # 128 MiB ARM64 branch range the Mach-O linker hit on aarch64-darwin (#4417).
+    substituteInPlace Cargo.toml \
+      --replace-fail 'codegen-units = 4' 'codegen-units = 16'
+  '',
+  doInstallCheck ? true,
+  librusty_v8 ? mkRustyV8Archive versionData.librusty_v8,
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 let
-  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  inherit (versionData) version hash cargoHash;
-
-  # The v8 crate downloads a prebuilt static library at build time. Fetch it
-  # as a fixed-output derivation so the build stays sandboxed.
-  librusty_v8 = fetchurl {
-    name = "librusty_v8-${versionData.librusty_v8.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${versionData.librusty_v8.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-    hash = versionData.librusty_v8.hashes.${stdenv.hostPlatform.system};
-    meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-  };
-
   # codex-realtime-webrtc pulls in livekit's webrtc-sys on macOS, whose
   # build.rs would download a ~300MB prebuilt libwebrtc archive at build
   # time. Prefetch it as a fixed-output derivation and point the crate at
@@ -48,95 +59,84 @@ let
         hash = versionData.livekit_webrtc.hashes.${stdenv.hostPlatform.system};
         meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
       };
-
-  src = fetchFromGitHub {
-    owner = "openai";
-    repo = "codex";
-    tag = "rust-v${version}";
-    inherit hash;
-  };
 in
-rustPlatform.buildRustPackage {
-  pname = "codex";
-  inherit version src;
+rustPlatform.buildRustPackage (
+  {
+    pname = "codex";
+    inherit version src sourceRoot;
 
-  inherit cargoHash;
-
-  sourceRoot = "source/codex-rs";
-
-  cargoBuildFlags = [
-    "--package"
-    "codex-cli"
-  ];
-
-  nativeBuildInputs = [
-    installShellFiles
-    makeWrapper
-    pkg-config
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.dylib']
-    rustPlatform.bindgenHook
-  ];
-
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap ];
-
-  env = {
-    RUSTY_V8_ARCHIVE = librusty_v8;
-    # Cap concurrent rustc jobs to keep peak RSS bounded with ThinLTO on the
-    # 16 GiB aarch64 builder.
-    CARGO_BUILD_JOBS = "2";
-    # Drop debuginfo from the shipped binary; combined with ThinLTO this
-    # keeps the codex __TEXT segment well below the 128 MiB ARM64 branch
-    # limit on aarch64-darwin.
-    CARGO_PROFILE_RELEASE_DEBUG = "false";
-    CARGO_PROFILE_RELEASE_STRIP = "symbols";
-  }
-  // lib.optionalAttrs (livekitWebrtc != null) {
-    LK_CUSTOM_WEBRTC = livekitWebrtc;
-  };
-
-  preBuild = ''
-    # Upstream's low codegen-units (4 since 0.140.0) makes late-stage rustc
-    # hold large IR modules, peaking at ~12 GiB and OOMing our 16 GiB aarch64
-    # builder. Raise to 16 to bound memory; __TEXT still stays below the
-    # 128 MiB ARM64 branch range the Mach-O linker hit on aarch64-darwin (#4417).
-    substituteInPlace Cargo.toml \
-      --replace-fail 'codegen-units = 4' 'codegen-units = 16'
-  '';
-
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    mkdir -p $out/codex-resources
-    ln -s ${lib.getExe bubblewrap} $out/codex-resources/bwrap
-
-    wrapProgram $out/bin/codex \
-      --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
-  '';
-
-  doCheck = false;
-
-  postInstall = lib.optionalString installShellCompletions ''
-    installShellCompletion --cmd codex \
-      --bash <($out/bin/codex completion bash) \
-      --fish <($out/bin/codex completion fish) \
-      --zsh <($out/bin/codex completion zsh)
-  '';
-
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [ versionCheckHook ];
-
-  passthru.category = "AI Coding Agents";
-
-  meta = {
-    description = "OpenAI Codex CLI - a coding agent that runs locally on your computer";
-    homepage = "https://github.com/openai/codex";
-    changelog = "https://github.com/openai/codex/releases/tag/rust-v${version}";
-    sourceProvenance = with lib.sourceTypes; [
-      fromSource
-      binaryNativeCode # librusty_v8
+    cargoBuildFlags = [
+      "--package"
+      "codex-cli"
     ];
-    license = lib.licenses.asl20;
-    mainProgram = "codex";
-    platforms = lib.platforms.unix;
-  };
-}
+
+    nativeBuildInputs = [
+      installShellFiles
+      makeWrapper
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.dylib']
+      rustPlatform.bindgenHook
+    ];
+
+    buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap ];
+
+    env = {
+      RUSTY_V8_ARCHIVE = librusty_v8;
+      # Cap concurrent rustc jobs to keep peak RSS bounded with ThinLTO on the
+      # 16 GiB aarch64 builder.
+      CARGO_BUILD_JOBS = "2";
+      # Drop debuginfo from the shipped binary; combined with ThinLTO this
+      # keeps the codex __TEXT segment well below the 128 MiB ARM64 branch
+      # limit on aarch64-darwin.
+      CARGO_PROFILE_RELEASE_DEBUG = "false";
+      CARGO_PROFILE_RELEASE_STRIP = "symbols";
+    }
+    // lib.optionalAttrs (livekitWebrtc != null) {
+      LK_CUSTOM_WEBRTC = livekitWebrtc;
+    };
+
+    inherit preBuild;
+
+    postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/codex-resources
+      ln -s ${lib.getExe bubblewrap} $out/codex-resources/bwrap
+
+      wrapProgram $out/bin/codex \
+        --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
+    '';
+
+    doCheck = false;
+
+    postInstall = lib.optionalString installShellCompletions ''
+      installShellCompletion --cmd codex \
+        --bash <($out/bin/codex completion bash) \
+        --fish <($out/bin/codex completion fish) \
+        --zsh <($out/bin/codex completion zsh)
+    '';
+
+    inherit doInstallCheck;
+    nativeInstallCheckInputs = [ versionCheckHook ];
+
+    passthru = {
+      category = "AI Coding Agents";
+      inherit mkRustyV8Archive;
+      inherit librusty_v8;
+    };
+
+    meta = {
+      description = "OpenAI Codex CLI - a coding agent that runs locally on your computer";
+      homepage = "https://github.com/openai/codex";
+      changelog = "https://github.com/openai/codex/releases/tag/rust-v${version}";
+      sourceProvenance = with lib.sourceTypes; [
+        fromSource
+        binaryNativeCode # librusty_v8
+      ];
+      license = lib.licenses.asl20;
+      mainProgram = "codex";
+      platforms = lib.platforms.unix;
+    };
+  }
+  // cargoVendor
+)


### PR DESCRIPTION
Changes:
- Add an overridable rusty_v8 archive helper shared by Codex packages.
- Allow codex package callers to override version, source, sourceRoot, cargo vendor output, preBuild, install check behavior, and librusty_v8 without overrideAttrs.
- Allow codex-acp package callers to override version, source, sourceRoot, cargo vendor output, Codex bubblewrap source, and librusty_v8 without overrideAttrs.
- Forward package override arguments through the codex and codex-acp default wrappers.