### PR TITLE
ck: fix stale source tag and update to 0.7.11

### DIFF
--- a/packages/ck/package.nix
+++ b/packages/ck/package.nix
@@ -8,18 +8,18 @@
   stdenv,
   darwinMinVersionHook,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "ck";
   version = "0.7.11";
 
   src = fetchFromGitHub {
     owner = "BeaconBay";
     repo = "ck";
-    tag = "0.7.4";
-    hash = "sha256-fUD/YeOMy8+oM1UA4clqto0i3gSZkyRuhxBnNb0KYTI=";
+    tag = version;
+    hash = "sha256-YZ5zswjTvst6Ee5arJPKzz9BDIIXf/pHuQ6QB+qZ9kc=";
   };
 
-  cargoHash = "sha256-ULuvrXV7+RsaHouuE2MuOWvR0KERkovGY8TVBeDIkjg=";
+  cargoHash = "sha256-sv7wTFN5eA7HWOE+syDGLtwcV/pvUmqyO8Cb0n5ldgE=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
## Summary

The `fetchFromGitHub` tag in `packages/ck/package.nix` was hardcoded to
`"0.7.4"` even though `version` had already been bumped to `0.7.11` across
several upstream commits. This meant the package built against stale 0.7.4
source — the `src` and `cargo` hashes also matched 0.7.4, and `nix build`
only appeared to succeed because the old NAR was cached in the store.

Changes:
- Use `tag = version` instead of a hardcoded literal, and add `rec` to
  `buildRustPackage` so `version` is in scope.
- Recompute `src` and `cargoHash` for 0.7.11 via `nix-update`.
- Verified every other `buildRustPackage` package in the repo already
  derives `tag`/`rev` from `version` — `ck` was the only stale one.

Full changelog: https://github.com/BeaconBay/ck/compare/0.7.4...0.7.11

## Test plan

- [x] `nix build --accept-flake-config .#ck` succeeds
- [x] Package updates via `nix-update` (`--flake ck`)
- [x] `nix-prefetch-url --type sha256 --unpack` against the 0.7.11 tag
      confirms the new `src` hash (`sha256-YZ5…9kc=`)

## AI Disclosure

This PR was generated with assistance from Crush (glm-5.2). The fix, hash
verification, and test plan were carried out by the AI agent under human
supervision. The human reviewed the diff and confirmed the changes are
correct.

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.


💘 Generated with Crush