### PR TITLE
forgecode: disable self-update via env wrapper

### DIFF
--- a/packages/forgecode/package.nix
+++ b/packages/forgecode/package.nix
@@ -55,6 +55,17 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  # Forge phones home on every start and, if a newer release exists, runs
+  # `curl -fsSL https://forgecode.dev/cli | sh` which drops a mutable copy
+  # into ~/.local/bin and shadows the Nix-managed binary. Force the update
+  # frequency to "never" so the store path stays authoritative.
+  # https://github.com/numtide/llm-agents.nix/issues/5976
+  postFixup = ''
+    wrapProgram $out/bin/forge \
+      --set-default FORGE_UPDATES__FREQUENCY never \
+      --set-default FORGE_UPDATES__AUTO_UPDATE false
+  '';
+
   passthru.category = "AI Coding Agents";
 
   meta = with lib; {


### PR DESCRIPTION
Forge checks GitHub for newer releases on every startup and, when one is
found, executes "curl -fsSL https://forgecode.dev/cli | sh". This drops a
mutable copy into ~/.local/bin which then shadows the Nix store path,
defeating the point of packaging it.

Forge reads FORGE_-prefixed env vars as the highest-priority config
source, so wrap the binary with FORGE_UPDATES__FREQUENCY=never (and
AUTO_UPDATE=false for good measure). --set-default is used so users can
still opt back in if they really want to.

Fixes #5976