### PR TITLE
voxterm: init at 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,16 +737,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>paseo-desktop</strong> - Voice-controlled desktop development environment for AI coding agents</summary>
-
-- **Source**: source
-- **License**: AGPL-3.0-or-later
-- **Homepage**: https://paseo.sh
-- **Usage**: `nix run github:numtide/llm-agents.nix#paseo-desktop -- --help`
-- **Nix**: [packages/paseo-desktop/package.nix](packages/paseo-desktop/package.nix)
-
-</details>
-<details>
 <summary><strong>ralph-tui</strong> - AI Agent Loop Orchestrator TUI</summary>
 
 - **Source**: source
@@ -867,6 +857,39 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/agavra/tuicr
 - **Usage**: `nix run github:numtide/llm-agents.nix#tuicr -- --help`
 - **Nix**: [packages/tuicr/package.nix](packages/tuicr/package.nix)
+
+</details>
+
+### Voice & Transcription
+
+<details>
+<summary><strong>handy</strong> - Fast and accurate local transcription app using AI models</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://handy.computer/
+- **Usage**: `nix run github:numtide/llm-agents.nix#handy -- --help`
+- **Nix**: [packages/handy/package.nix](packages/handy/package.nix)
+
+</details>
+<details>
+<summary><strong>paseo-desktop</strong> - Voice-controlled desktop development environment for AI coding agents</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-or-later
+- **Homepage**: https://paseo.sh
+- **Usage**: `nix run github:numtide/llm-agents.nix#paseo-desktop -- --help`
+- **Nix**: [packages/paseo-desktop/package.nix](packages/paseo-desktop/package.nix)
+
+</details>
+<details>
+<summary><strong>voxterm</strong> - Local real-time voice transcription TUI with speaker diarization</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/dmarzzz/VoxTerm
+- **Usage**: `nix run github:numtide/llm-agents.nix#voxterm -- --help`
+- **Nix**: [packages/voxterm/package.nix](packages/voxterm/package.nix)
 
 </details>
 
@@ -1130,16 +1153,6 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/raine/git-surgeon
 - **Usage**: `nix run github:numtide/llm-agents.nix#git-surgeon -- --help`
 - **Nix**: [packages/git-surgeon/package.nix](packages/git-surgeon/package.nix)
-
-</details>
-<details>
-<summary><strong>handy</strong> - Fast and accurate local transcription app using AI models</summary>
-
-- **Source**: binary
-- **License**: MIT
-- **Homepage**: https://handy.computer/
-- **Usage**: `nix run github:numtide/llm-agents.nix#handy -- --help`
-- **Nix**: [packages/handy/package.nix](packages/handy/package.nix)
 
 </details>
 <details>

--- a/packages/handy/package.nix
+++ b/packages/handy/package.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation {
   # GUI-only Tauri app - no CLI version support, would block trying to start GUI
   doInstallCheck = false;
 
-  passthru.category = "Utilities";
+  passthru.category = "Voice & Transcription";
 
   meta = with lib; {
     description = "Fast and accurate local transcription app using AI models";

--- a/packages/paseo-desktop/package.nix
+++ b/packages/paseo-desktop/package.nix
@@ -180,7 +180,7 @@ buildNpmPackage (finalAttrs: {
     })
   ];
 
-  passthru.category = "Workflow & Project Management";
+  passthru.category = "Voice & Transcription";
 
   meta = {
     description = "Voice-controlled desktop development environment for AI coding agents";

--- a/packages/voxterm/default.nix
+++ b/packages/voxterm/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/voxterm/package.nix
+++ b/packages/voxterm/package.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchPypi,
+  makeWrapper,
+  ffmpeg,
+  xdotool,
+  wtype,
+  ydotool,
+}:
+
+let
+  # Not yet in nixpkgs. Packaged inline; all transitive deps are available.
+  faster-whisper = python3.pkgs.buildPythonPackage rec {
+    pname = "faster-whisper";
+    version = "1.2.1";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "SYSTRAN";
+      repo = "faster-whisper";
+      tag = "v${version}";
+      hash = "sha256-pWVYxC1h0kIhhBxAt9oT2USuvoarlcwwYmaLUJlZZwY=";
+    };
+
+    build-system = with python3.pkgs; [ setuptools ];
+
+    dependencies = with python3.pkgs; [
+      av
+      ctranslate2
+      huggingface-hub
+      onnxruntime
+      tokenizers
+      tqdm
+    ];
+
+    pythonImportsCheck = [ "faster_whisper" ];
+    # Test suite downloads models from the Hugging Face Hub.
+    doCheck = false;
+
+    meta = {
+      description = "Faster Whisper transcription with CTranslate2";
+      homepage = "https://github.com/SYSTRAN/faster-whisper";
+      license = lib.licenses.mit;
+      sourceProvenance = with lib.sourceTypes; [ fromSource ];
+      platforms = lib.platforms.all;
+    };
+  };
+
+  # Not yet in nixpkgs. VoxTerm only reads the bundled ONNX model via
+  # onnxruntime (see audio/vad.py), but we keep torch in the deps to match
+  # upstream metadata.
+  silero-vad = python3.pkgs.buildPythonPackage rec {
+    pname = "silero-vad";
+    version = "6.2.1";
+    pyproject = true;
+
+    src = fetchPypi {
+      pname = "silero_vad";
+      inherit version;
+      hash = "sha256-sjBisOOfrRexJm/CPB57QpAhnb6CzghRCInjL2gfSzs=";
+    };
+
+    build-system = with python3.pkgs; [ hatchling ];
+
+    dependencies = with python3.pkgs; [
+      onnxruntime
+      packaging
+      torch
+      torchaudio
+    ];
+
+    pythonImportsCheck = [ "silero_vad" ];
+
+    meta = {
+      description = "Pre-trained enterprise-grade Voice Activity Detector";
+      homepage = "https://github.com/snakers4/silero-vad";
+      license = lib.licenses.mit;
+      sourceProvenance = with lib.sourceTypes; [ fromSource ];
+      platforms = lib.platforms.all;
+    };
+  };
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "voxterm";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dmarzzz";
+    repo = "VoxTerm";
+    tag = "v${version}";
+    hash = "sha256-yOmqc0EnK4UkIWfYZlae5yGnDH/xlj6nwPOR0oC/SCU=";
+  };
+
+  build-system = with python3.pkgs; [ hatchling ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dependencies = with python3.pkgs; [
+    cryptography
+    numpy
+    onnxruntime
+    scipy
+    silero-vad
+    sounddevice
+    textual
+    zeroconf
+    faster-whisper
+    pillow
+    pystray
+    xlib
+  ];
+
+  # qwen-asr is an optional transcription backend (probed at runtime via
+  # importlib.util.find_spec; VoxTerm falls back to faster-whisper when it is
+  # absent). It pulls exact-pinned, unpackaged deps (nagisa, soynlp,
+  # qwen-omni-utils), so we drop it from the dependency closure.
+  pythonRemoveDeps = [ "qwen-asr" ];
+
+  # onnxruntime is capped <1.24 upstream to avoid a heap leak; nixpkgs ships a
+  # newer release. torch is pulled in transitively via silero-vad.
+  pythonRelaxDeps = [
+    "onnxruntime"
+    "torch"
+  ];
+
+  # tui.app sets up a faulthandler crash dir under $HOME on import, so the
+  # import check needs a writable HOME.
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "tui.app" ];
+
+  # Dictation mode shells out to ffmpeg and keyboard-injection tools.
+  postFixup = ''
+    wrapProgram $out/bin/voxterm \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          xdotool
+          wtype
+          ydotool
+        ]
+      }
+  '';
+
+  passthru.category = "Voice & Transcription";
+
+  meta = {
+    description = "Local real-time voice transcription TUI with speaker diarization";
+    homepage = "https://github.com/dmarzzz/VoxTerm";
+    changelog = "https://github.com/dmarzzz/VoxTerm/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    # macOS support requires unpackaged MLX backends; Linux-only for now.
+    platforms = lib.platforms.linux;
+    mainProgram = "voxterm";
+  };
+}

--- a/packages/voxterm/package.nix
+++ b/packages/voxterm/package.nix
@@ -155,6 +155,7 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/dmarzzz/VoxTerm/releases/tag/v${version}";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ zimbatm ];
     # macOS support requires unpackaged MLX backends; Linux-only for now.
     platforms = lib.platforms.linux;
     mainProgram = "voxterm";

--- a/scripts/generate-package-docs.py
+++ b/scripts/generate-package-docs.py
@@ -82,6 +82,7 @@ CATEGORY_ORDER = [
     "Usage Analytics",
     "Workflow & Project Management",
     "Code Review",
+    "Voice & Transcription",
     "Memory & Code Intelligence",
     "Sandboxing & Isolation",
     "Skills & Plugins",


### PR DESCRIPTION
## Summary

Adds **voxterm** — a local real-time voice transcription TUI with speaker diarization ([dmarzzz/VoxTerm](https://github.com/dmarzzz/VoxTerm)).

Introduces a new **Voice & Transcription** category and moves the existing `handy` and `paseo-desktop` packages into it.

## Details

- Packages two PyPI dependencies inline (not yet in nixpkgs): `faster-whisper` 1.2.1 (from GitHub, setuptools) and `silero-vad` 6.2.1 (from PyPI sdist, hatchling). All their transitive deps are already in nixpkgs.
- **Drops the optional `qwen-asr` backend.** VoxTerm probes it at runtime via `importlib.util.find_spec` and falls back to faster-whisper (`fw-small`) when absent. Packaging it would require exact-pinned, unpackaged deps (`nagisa`, `soynlp`, `qwen-omni-utils`), so it is excluded via `pythonRemoveDeps`.
- `onnxruntime`/`torch` version pins are relaxed (`pythonRelaxDeps`) to match nixpkgs.
- The launcher is wrapped with `ffmpeg`, `xdotool`, `wtype`, and `ydotool` on PATH for dictation mode.
- **Linux-only** for now — macOS support needs the unpackaged MLX backends (`mlx-whisper`, `parakeet-mlx`, etc.).

## Testing

- `nix build .#voxterm` succeeds.
- `voxterm --help` and `voxterm --list-models` run correctly (default backend `fw-small` / faster-whisper):

```
Available models:
  fw-tiny              → tiny [faster-whisper]
  fw-base              → base [faster-whisper]
  fw-small             → small [faster-whisper] (default)
  fw-medium            → medium [faster-whisper]
  fw-large-v3          → large-v3 [faster-whisper]
  fw-distil-large-v3   → distil-large-v3 [faster-whisper]
```

- `nix fmt` clean; README package docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)