### PR TITLE
trellis: init at 0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>trellis</strong> - An out-of-the-box engineering framework for AI coding.</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-only
+- **Homepage**: https://github.com/mindfold-ai/trellis
+- **Usage**: `nix run github:numtide/llm-agents.nix#trellis -- --help`
+- **Nix**: [packages/trellis/package.nix](packages/trellis/package.nix)
+
+</details>
+<details>
 <summary><strong>zat</strong> - Code outline viewer for LLM coding agents — shows exported symbols with line numbers</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -147,6 +147,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 1682194;
         name = "Scott Trinh";
       };
+      hobr = {
+        github = "hobr";
+        githubId = 13460388;
+        name = "Hobr";
+      };
     };
   }
 )

--- a/packages/trellis/default.nix
+++ b/packages/trellis/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/trellis/default.nix
+++ b/packages/trellis/default.nix
@@ -1,8 +1,10 @@
 {
   pkgs,
+  flake,
   perSystem,
   ...
 }:
 pkgs.callPackage ./package.nix {
+  inherit flake;
   inherit (perSystem.self) versionCheckHomeHook;
 }

--- a/packages/trellis/nix-update-args
+++ b/packages/trellis/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/trellis/package.nix
+++ b/packages/trellis/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  pnpm = pnpm_10;
+
+  pnpmWorkspaces = [
+    "@mindfoldhq/trellis-core"
+    "@mindfoldhq/trellis"
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "trellis";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "mindfold-ai";
+    repo = "trellis";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GX9EnmiCC+jTupx/Ahjmfkt/Ct3YAnu9UERVhv4tuTg=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm pnpmWorkspaces;
+    hash = "sha256-DFPIIQbxJpN6FTcOUBEWu5E5lEotGX2eqzIlieTMlyY=";
+    fetcherVersion = 3;
+  };
+
+  inherit pnpmWorkspaces;
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter @mindfoldhq/trellis-core build
+    pnpm --filter @mindfoldhq/trellis build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm config set inject-workspace-packages true
+    pnpm --filter @mindfoldhq/trellis --prod --ignore-scripts deploy $out/lib/trellis
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/trellis \
+      --add-flags $out/lib/trellis/bin/trellis.js \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+    ln -s $out/bin/trellis $out/bin/tl
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Memory & Code Intelligence";
+
+  meta = {
+    description = "An out-of-the-box engineering framework for AI coding.";
+    homepage = "https://github.com/mindfold-ai/trellis";
+    changelog = "https://github.com/mindfold-ai/trellis/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    mainProgram = "trellis";
+    platforms = lib.platforms.all;
+  };
+})

--- a/packages/trellis/package.nix
+++ b/packages/trellis/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake,
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
@@ -84,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/mindfold-ai/trellis/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ hobr ];
     mainProgram = "trellis";
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
## Summary

Add [Trellis](https://github.com/mindfold-ai/Trellis), an out-of-the-box engineering framework for AI coding. Category: Memory & Code Intelligence.

## Test plan

- [x] `nix build .#trellis` succeeds
- [x] `./scripts/generate-package-docs.py` succeeds
- [x] `nix fmt` clean
- [x] Package updates via `nix-update`
- [x] `trellis init`
