### PR TITLE
devshell: unpin nix-update

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -9,17 +9,7 @@ pkgs.mkShellNoCC {
     pkgs.gnugrep
     pkgs.gnused
     pkgs.jq
-    # Pin nix-update 1.16.0 for buildDotnetModule fetch-deps flake support
-    # (https://github.com/Mic92/nix-update/pull/615). Remove once nixpkgs catches up.
-    (pkgs.nix-update.overrideAttrs (_: {
-      version = "1.16.0";
-      src = pkgs.fetchFromGitHub {
-        owner = "Mic92";
-        repo = "nix-update";
-        rev = "v1.16.0";
-        hash = "sha256-LT66e5NtAJRp0E8QXKeePdTCNpH+CMvJNF1ayzBr4rw=";
-      };
-    }))
+    pkgs.nix-update
     pkgs.nodejs
 
     # Formatter

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782118813,
-        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Reverts changes in #5759, bumps nixpkgs to `'github:NixOS/nixpkgs/89570f2' (2026-06-23)`.
Fixes #5760 

## Test plan

<!-- How did you test this change? -->

ran `nix develop` and `which nix-update` returned `/nix/store/xfk1vcxpd79v5kr3kr6ja8zwmf0gzk9v-nix-update-1.16.0/bin/nix-update`
