### PR TITLE
omp: Use `--generate` flag to generate docs so `omp://` file reads work

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -211,11 +211,8 @@ stdenv.mkDerivation {
       bun packages/natives/scripts/gen-enums.ts || true
     fi
 
-    # Embed the omp:// harness docs index. Without --generate this script is a
-    # no-op (it only writes the index with --generate, or restores the empty
-    # placeholder with --reset), so the compiled binary would ship no docs and
-    # omp:// / `omp read omp://...` would fail. Mirrors the --generate stats and
-    # tool-views embeds below.
+    # --generate embeds the omp:// docs index; without it the script is a no-op
+    # and the binary ships no docs, breaking omp:// reads.
     echo "Generating docs index..."
     bun packages/coding-agent/scripts/generate-docs-index.ts --generate
 

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -211,9 +211,13 @@ stdenv.mkDerivation {
       bun packages/natives/scripts/gen-enums.ts || true
     fi
 
-    # Generate the docs index (prepack script in coding-agent)
+    # Embed the omp:// harness docs index. Without --generate this script is a
+    # no-op (it only writes the index with --generate, or restores the empty
+    # placeholder with --reset), so the compiled binary would ship no docs and
+    # omp:// / `omp read omp://...` would fail. Mirrors the --generate stats and
+    # tool-views embeds below.
     echo "Generating docs index..."
-    bun packages/coding-agent/scripts/generate-docs-index.ts
+    bun packages/coding-agent/scripts/generate-docs-index.ts --generate
 
     # Generate the embedded stats dashboard client bundle
     echo "Generating embedded stats dashboard..."


### PR DESCRIPTION
## Summary

`packages/omp`: the build invoked the `omp://` docs-index prepack step without
`--generate`. The script (`packages/coding-agent/scripts/generate-docs-index.ts`)
treats a no-flag run as a no-op — it only embeds the index with `--generate`, or
restores the checked-in empty placeholder with `--reset`. As a result the
compiled binary shipped an **empty** documentation index, so every `omp://`
documentation URL failed (`omp read omp://…`, in-app harness docs, the
`omp://` autocomplete/search targets) — falling through to an on-disk `docs/`
read that doesn't exist in the compiled bundle.

Fix: add `--generate` to the existing call, matching the `--generate` the
sibling stats-dashboard and tool-views embeds already use in the same
`buildPhase`. Build-phase change only — no `hashes.json` / `src` change.

```diff
   # Generate the docs index (prepack script in coding-agent)
   echo "Generating docs index..."
-  bun packages/coding-agent/scripts/generate-docs-index.ts
+  bun packages/coding-agent/scripts/generate-docs-index.ts --generate
```

## Test plan

- [x] `nix build .#omp` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work  <!-- packages/omp/update.py present, unchanged -->

Embed verified directly in the source checkout:

- Without `--generate`: `Skipping …/docs-index.generated.txt; pass --generate to embed docs` → 0 bytes embedded.
- With `--generate`: `Generated …/docs-index.generated.txt (114 docs, 666955 bytes)`.
- After build: `result/bin/omp read omp://theme.md` returns the doc and `omp read omp://` lists 114 files (both previously failed — `Documentation file not found` / missing-`docs/` path).
