### PR TITLE
gemini-cli: guard pin alignment on node so npm-deps FOD builds

### DIFF
--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -49,17 +49,21 @@ buildNpmPackage (finalAttrs: {
   preConfigure = ''
     mkdir -p packages/generated
     echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" > packages/generated/git-commit.ts
-  '';
 
-  postPatch = ''
     # gemini-cli 0.49.0 ships an inconsistent lockfile: several workspace
     # package.json files pin exact dependency versions that differ from the
     # versions package-lock.json actually resolves (e.g. tar 7.5.8 vs 7.5.11,
     # clipboardy 5.2.0 vs 5.2.1). The offline npm cache is built from the
     # lockfile, so `npm ci` cannot satisfy the package.json pins and fails with
     # ETARGET. Rewrite each exact pin to the version the lockfile resolves.
+    # Runs in preConfigure, not postPatch: postPatch also executes inside the
+    # npm-deps fetcher FOD, where node is unavailable (node: command not found).
+    # The cache is built from the lockfile, so the alignment only needs to take
+    # effect before `npm ci` in the main build.
     node ${./align-pins-to-lock.mjs}
+  '';
 
+  postPatch = ''
     # Point resolveRipgrepPath() at our ripgrep: no bundled rg binaries exist
     # and the trusted-path check rejects /nix/store, so allow the store dir.
     substituteInPlace packages/core/src/tools/ripGrep.ts \

--- a/packages/gemini-cli/package.nix
+++ b/packages/gemini-cli/package.nix
@@ -49,21 +49,23 @@ buildNpmPackage (finalAttrs: {
   preConfigure = ''
     mkdir -p packages/generated
     echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" > packages/generated/git-commit.ts
+  '';
 
+  postPatch = ''
     # gemini-cli 0.49.0 ships an inconsistent lockfile: several workspace
     # package.json files pin exact dependency versions that differ from the
     # versions package-lock.json actually resolves (e.g. tar 7.5.8 vs 7.5.11,
     # clipboardy 5.2.0 vs 5.2.1). The offline npm cache is built from the
     # lockfile, so `npm ci` cannot satisfy the package.json pins and fails with
     # ETARGET. Rewrite each exact pin to the version the lockfile resolves.
-    # Runs in preConfigure, not postPatch: postPatch also executes inside the
-    # npm-deps fetcher FOD, where node is unavailable (node: command not found).
-    # The cache is built from the lockfile, so the alignment only needs to take
-    # effect before `npm ci` in the main build.
-    node ${./align-pins-to-lock.mjs}
-  '';
+    # Guard on node: postPatch also runs inside the npm-deps fetcher FOD, where
+    # node is unavailable. The cache is built from the lockfile (independent of
+    # these package.json edits), so skipping the alignment there is harmless;
+    # it only needs to run before `npm ci` in the main build.
+    if command -v node > /dev/null; then
+      node ${./align-pins-to-lock.mjs}
+    fi
 
-  postPatch = ''
     # Point resolveRipgrepPath() at our ripgrep: no bundled rg binaries exist
     # and the trusted-path check rejects /nix/store, so allow the store dir.
     substituteInPlace packages/core/src/tools/ripGrep.ts \


### PR DESCRIPTION
### Problem

Since f2b28ba3 ("gemini-cli: align workspace pins to lockfile", 0.47.0 → 0.49.0), gemini-cli fails to build:

    gemini-cli-0.49.0-npm-deps> Running phase: patchPhase
    gemini-cli-0.49.0-npm-deps> .../stdenv-linux/setup: line 265: node: command not found
    error: builder for '...-gemini-cli-0.49.0-npm-deps.drv' failed with exit code 127

That commit added `node ${./align-pins-to-lock.mjs}` to `postPatch`. With `npmDepsFetcherVersion = 2`, `postPatch` also runs inside the npm-deps fetcher FOD, where `nodejs` is not available — only the main build has it.

Closes #6303.

### Fix

Guard the pin alignment on `node` being present. The npm cache is built from the lockfile, independent of these `package.json` edits, so skipping the alignment in the FOD is harmless; it only needs to run before `npm ci` in the main build.

An earlier attempt moved the call to `preConfigure`, but `npmConfigHook` runs `npm ci` during `patchPhase` (before `preConfigure`), so the alignment ran too late and `npm ci` failed with ETARGET (tar@7.5.8). Keeping it in `postPatch` behind a `command -v node` guard fixes both failure modes.

### Verification

Built end-to-end against nixpkgs `e73de5be04e0` (nixos-unstable tip, nodejs-slim 24.16.0): npm-deps FOD builds, `npm ci` succeeds, tsc build and `gemini --version` install check pass. `npmDepsHash` is unchanged (the FOD output is lockfile-derived).
