### PR TITLE
terminal-use: init at 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>terminal-use</strong> - Headless virtual terminal for AI agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/flipbit03/terminal-use
+- **Usage**: `nix run github:numtide/llm-agents.nix#terminal-use -- --help`
+- **Nix**: [packages/terminal-use/package.nix](packages/terminal-use/package.nix)
+
+</details>
+<details>
 <summary><strong>toon</strong> - Rust implementation of TOON - Token-Oriented Object Notation for LLM prompts</summary>
 
 - **Source**: source

--- a/packages/terminal-use/default.nix
+++ b/packages/terminal-use/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs,
+  ...
+}:
+pkgs.callPackage ./package.nix { }

--- a/packages/terminal-use/disable-self-update.patch
+++ b/packages/terminal-use/disable-self-update.patch
@@ -1,0 +1,32 @@
+From 20cdb774da566401f784db27dbe040362fc7d4d2 Mon Sep 17 00:00:00 2001
+From: x <a@b.c>
+Date: Mon, 29 Jun 2026 15:48:01 +0200
+Subject: [PATCH] disable self-update for Nix-managed installs
+
+tu self update rewrites its own binary or shells out to cargo install,
+which is wrong for a read-only Nix store install. Refuse and defer to
+the Nix configuration instead.
+
+Signed-off-by: x <a@b.c>
+---
+ src/commands/self_cmd.rs | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/commands/self_cmd.rs b/src/commands/self_cmd.rs
+index d101dbc..e43c9bc 100644
+--- a/src/commands/self_cmd.rs
++++ b/src/commands/self_cmd.rs
+@@ -23,6 +23,10 @@ pub async fn run(action: SelfAction) -> Result<()> {
+ }
+ 
+ async fn run_update(args: UpdateArgs) -> Result<()> {
++    eprintln!("tu was installed via Nix; update it through your Nix configuration.");
++    return Ok(());
++
++    #[allow(unreachable_code)]
+     if version_check::is_dev_build() {
+         eprintln!("Running a dev build (0.0.0) — self-update is not supported.");
+         return Ok(());
+-- 
+2.54.0
+

--- a/packages/terminal-use/package.nix
+++ b/packages/terminal-use/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  darwinMinVersionHook,
+  nix-update-script,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "terminal-use";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "flipbit03";
+    repo = "terminal-use";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wHu+L//x1NiXTxD2mas0niV/TbTezg4MC7wUWAfgxpY=";
+  };
+
+  cargoHash = "sha256-KapRznQ67o8H0aIMGvCMojwF/qSZ3rSlx6SEKbi12ig=";
+
+  # `tu self update` rewrites its own binary (or shells out to `cargo install`),
+  # which is wrong for a Nix-managed install. Make it refuse and defer to Nix.
+  patches = [ ./disable-self-update.patch ];
+
+  # The Cargo manifest ships a placeholder 0.0.0 version that the release
+  # workflow rewrites at tag time. Stamp the real version so `tu --version`
+  # (built from CARGO_PKG_VERSION) reports the packaged release.
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    (darwinMinVersionHook "11.0")
+  ];
+
+  # The Cargo manifest carries a placeholder 0.0.0 version that the release
+  # workflow rewrites at tag time, so `tu --version` reports the git tag.
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+    category = "Utilities";
+  };
+
+  meta = {
+    description = "Headless virtual terminal for AI agents";
+    longDescription = ''
+      tu is a full terminal emulator for AI agents. It spawns interactive
+      terminal apps and lets an agent read the rendered screen (as text or PNG
+      screenshot) and drive the keyboard and mouse — no GUI, X server, or
+      display needed. Multiple sessions can run at once, like tmux for an
+      agent.
+    '';
+    homepage = "https://github.com/flipbit03/terminal-use";
+    changelog = "https://github.com/flipbit03/terminal-use/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    mainProgram = "tu";
+    maintainers = with lib.maintainers; [ mic92 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Closes #6181.

Packages [terminal-use](https://github.com/flipbit03/terminal-use) (`tu`), a headless virtual terminal for AI agents: spawn interactive terminal apps and read the screen / drive keyboard and mouse with no GUI or display.

## Notes
- Pure-Rust `buildRustPackage`; rustls (no OpenSSL) and an embedded font, so no system deps beyond the darwin min-version hook.
- `disable-self-update.patch`: `tu self update` rewrites its own binary or shells out to `cargo install` — wrong for a read-only Nix store. It now refuses and defers to Nix.
- The Cargo manifest ships a placeholder `0.0.0` version that upstream rewrites at tag time; `postPatch` stamps the real version so `tu --version` reports the packaged release (and `versionCheckHook` passes).

## Test plan
- [x] `nix build .#terminal-use` succeeds
- [x] `tu --version` -> `tu 1.2.0`
- [x] `tu self update` refuses (defers to Nix)
- [x] `nix-update --flake terminal-use` updates version + hashes