### PR TITLE
cursor-agent: ensure libz.so.1 is loaded

### DIFF
--- a/packages/cursor-agent/package.nix
+++ b/packages/cursor-agent/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     wrapBuddy
   ];
 
+  wrapBuddyExtraNeeded = [ "libz.so.1" ];
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
## Summary

Despite #4264, `cursor-agent` still fails with the following currently:
```sh
Error: node-loader:
Error: libz.so.1: cannot open shared object file: No such file or directory
```

The dependency comes from the following node-loader module:
```
$ nix build .#cursor-agent
$ ldd result/file_service.linux-x64-gnu.node
        linux-vdso.so.1 (0x000074a14c595000)
        libz.so.1 => not found
        libgcc_s.so.1 => /nix/store/g54b6ghpnn98hfdz4yqw87w10c3hx8bv-xgcc-15.2.0-libgcc/lib/libgcc_s.so.1 (0x000074a14c560000)
        libpthread.so.0 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libpthread.so.0 (0x000074a14c55b000)
        libm.so.6 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libm.so.6 (0x000074a14c463000)
        libdl.so.2 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libdl.so.2 (0x000074a14c45e000)
        libc.so.6 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6 (0x000074a14aa00000)
        /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib64/ld-linux-x86-64.so.2 (0x000074a14c597000)
```

What I've done is add `libz.so.1` to `wrapBuddyExtraNeeded`, and this seems to fix the issue.

*Extra thought: I'm not sure if wrap-buddy could wrap the module itself but it would be nice, since now this is prone to break if a node-loader module gets new dependencies.*

## Test plan

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
