### PR TITLE
claude-desktop: init at 1.17377.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>claude-desktop</strong> - Desktop application for Claude.ai</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://claude.ai
+- **Usage**: `nix run github:numtide/llm-agents.nix#claude-desktop -- --help`
+- **Nix**: [packages/claude-desktop/package.nix](packages/claude-desktop/package.nix)
+
+</details>
+<details>
 <summary><strong>claw-code</strong> - Claude Code rewrite CLI built from the official claw-code Rust workspace</summary>
 
 - **Source**: source

--- a/packages/claude-desktop/default.nix
+++ b/packages/claude-desktop/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/claude-desktop/hashes.json
+++ b/packages/claude-desktop/hashes.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.17377.2",
+  "urls": {
+    "x86_64-linux": "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.17377.2_amd64.deb",
+    "aarch64-linux": "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.17377.0_arm64.deb"
+  },
+  "hashes": {
+    "x86_64-linux": "sha256-7AjUGqeYjS06P19P/fONIHtBLmYmOfQNeiZbivriEqs=",
+    "aarch64-linux": "sha256-R1ms8ZtqyYH7rlzRwlqCjunG6Vz6nqTLjJzNfC/FOHE="
+  }
+}

--- a/packages/claude-desktop/package.nix
+++ b/packages/claude-desktop/package.nix
@@ -1,0 +1,236 @@
+{
+  fetchurl,
+  lib,
+  makeWrapper,
+  patchelf,
+  stdenvNoCC,
+  bintools,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  # Linked dynamic libraries.
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gcc-unwrapped,
+  glib,
+  gtk3,
+  libdrm,
+  libglvnd,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libxkbcommon,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  wayland,
+
+  # Provides libudev, which the main binary links directly. The libs-only
+  # build avoids pulling the whole systemd closure.
+  systemdLibs,
+
+  # Loaded at runtime via dlopen.
+  libsecret,
+  libnotify,
+  libpulseaudio,
+  libayatana-appindicator,
+  xdg-utils,
+
+  # Needed for XDG_ICON_DIRS and GSETTINGS_SCHEMAS_PATH.
+  adwaita-icon-theme,
+  gsettings-desktop-schemas,
+
+  # Command line arguments which are always passed to the application.
+  commandLineArgs ? "",
+}:
+
+let
+  pname = "claude-desktop";
+
+  # The version, download URLs, and hashes live in the sibling hashes.json,
+  # which update.py refreshes from Anthropic's APT index.
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version urls hashes;
+
+  # Anthropic publish separate Debian packages per architecture, and the two
+  # arches may sit at different versions when one lags behind the other.
+  platform = stdenvNoCC.hostPlatform.system;
+
+  deps = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gcc-unwrapped.lib
+    glib
+    gtk3
+    libayatana-appindicator
+    libdrm
+    libglvnd
+    libgbm
+    libnotify
+    libpulseaudio
+    libsecret
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libxkbcommon
+    libXrandr
+    nspr
+    nss
+    pango
+    pipewire
+    systemdLibs
+    wayland
+  ];
+
+  # The desktop entry reproduces the one Anthropic ship in the deb. The
+  # x-scheme-handler/claude MIME type registers the OAuth sign-in handler and
+  # must be preserved, and the two actions expose the New chat and New Claude
+  # Code session shortcuts.
+  desktopItem = makeDesktopItem {
+    name = "claude-desktop";
+    desktopName = "Claude";
+    genericName = "AI Assistant";
+    comment = "Desktop application for Claude.ai";
+    exec = "claude-desktop %U";
+    icon = "claude-desktop";
+    keywords = [
+      "AI"
+      "Chat"
+      "Assistant"
+      "Claude"
+      "Code"
+      "LLM"
+    ];
+    categories = [
+      "Utility"
+      "Development"
+    ];
+    startupNotify = true;
+    startupWMClass = "claude-desktop";
+    singleMainWindow = true;
+    mimeTypes = [ "x-scheme-handler/claude" ];
+    actions = {
+      NewChat = {
+        name = "New chat";
+        exec = "claude-desktop claude://claude.ai/new";
+      };
+      NewCode = {
+        name = "New Claude Code session";
+        exec = "claude-desktop claude://code/new";
+      };
+    };
+  };
+
+  passthru = {
+    category = "AI Coding Agents";
+  };
+
+  meta = with lib; {
+    description = "Desktop application for Claude.ai";
+    homepage = "https://claude.ai";
+    # Anthropic publish no versioned changelog or release tags for Claude
+    # Desktop, so this points at the canonical download and what's-new page.
+    changelog = "https://claude.ai/download";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ flexiondotorg ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "claude-desktop";
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
+
+  src = fetchurl {
+    url = urls.${platform} or (throw "Unsupported system: ${platform}");
+    hash = hashes.${platform} or (throw "Unsupported system: ${platform}");
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    patchelf
+  ];
+
+  buildInputs = [
+    adwaita-icon-theme
+    glib
+    gsettings-desktop-schemas
+    gtk3
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    ${lib.getExe' bintools "ar"} x $src
+    tar xf data.tar.xz
+    runHook postUnpack
+  '';
+
+  rpath = lib.makeLibraryPath deps;
+
+  installPhase = ''
+    runHook preInstall
+
+    # The whole Electron application ships under usr/lib; keep the upstream
+    # layout so bundled libraries such as libffmpeg.so resolve next to the
+    # main binary.
+    mkdir -p $out/lib $out/bin $out/share
+    cp -a usr/lib/claude-desktop $out/lib/claude-desktop
+    cp -a usr/share/icons $out/share/icons
+    cp -a usr/share/doc $out/share/doc
+
+    # The rpath must include the application directory so ANGLE and the bundled
+    # GL and Vulkan libraries can find each other and the system libGL.
+    app_rpath="$rpath:$out/lib/claude-desktop"
+
+    # Patch every dynamic ELF payload in the application tree. The interpreter
+    # and rpath fail on the statically linked cowork-linux-helper and on the
+    # smol-bin.x64.img disk image, so tolerate those failures.
+    while IFS= read -r -d "" elf; do
+      patchelf --set-interpreter ${bintools.dynamicLinker} "$elf" 2>/dev/null || true
+      patchelf --set-rpath "$app_rpath" "$elf" 2>/dev/null || true
+    done < <(find $out/lib/claude-desktop -type f \( -name "*.so" -o -name "*.so.*" -o -name "*.node" -o -executable \) -print0)
+
+    # The desktop file uses bare Exec and Icon names, so copyDesktopItems
+    # installs the generated item and the wrapper lands at $out/bin/claude-desktop.
+    makeWrapper "$out/lib/claude-desktop/claude-desktop" "$out/bin/claude-desktop" \
+      --prefix LD_LIBRARY_PATH : "$app_rpath" \
+      --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    runHook postInstall
+  '';
+}

--- a/packages/claude-desktop/package.nix
+++ b/packages/claude-desktop/package.nix
@@ -59,13 +59,10 @@
 let
   pname = "claude-desktop";
 
-  # The version, download URLs, and hashes live in the sibling hashes.json,
-  # which update.py refreshes from Anthropic's APT index.
+  # update.py refreshes version/urls/hashes from Anthropic's APT index.
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version urls hashes;
 
-  # Anthropic publish separate Debian packages per architecture, and the two
-  # arches may sit at different versions when one lags behind the other.
   platform = stdenvNoCC.hostPlatform.system;
 
   deps = [
@@ -103,10 +100,7 @@ let
     wayland
   ];
 
-  # The desktop entry reproduces the one Anthropic ship in the deb. The
-  # x-scheme-handler/claude MIME type registers the OAuth sign-in handler and
-  # must be preserved, and the two actions expose the New chat and New Claude
-  # Code session shortcuts.
+  # x-scheme-handler/claude registers the OAuth sign-in handler.
   desktopItem = makeDesktopItem {
     name = "claude-desktop";
     desktopName = "Claude";
@@ -149,8 +143,7 @@ let
   meta = with lib; {
     description = "Desktop application for Claude.ai";
     homepage = "https://claude.ai";
-    # Anthropic publish no versioned changelog or release tags for Claude
-    # Desktop, so this points at the canonical download and what's-new page.
+    # No upstream versioned changelog or release tags exist.
     changelog = "https://claude.ai/download";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
@@ -202,28 +195,24 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    # The whole Electron application ships under usr/lib; keep the upstream
-    # layout so bundled libraries such as libffmpeg.so resolve next to the
-    # main binary.
+    # Keep the upstream usr/lib layout so bundled libs (e.g. libffmpeg.so)
+    # resolve next to the main binary.
     mkdir -p $out/lib $out/bin $out/share
     cp -a usr/lib/claude-desktop $out/lib/claude-desktop
     cp -a usr/share/icons $out/share/icons
     cp -a usr/share/doc $out/share/doc
 
-    # The rpath must include the application directory so ANGLE and the bundled
-    # GL and Vulkan libraries can find each other and the system libGL.
+    # Include the app dir so ANGLE and the bundled GL/Vulkan libs find each
+    # other and the system libGL.
     app_rpath="$rpath:$out/lib/claude-desktop"
 
-    # Patch every dynamic ELF payload in the application tree. The interpreter
-    # and rpath fail on the statically linked cowork-linux-helper and on the
-    # smol-bin.x64.img disk image, so tolerate those failures.
+    # Patch every dynamic ELF in the app tree; tolerate failures on the
+    # statically linked cowork-linux-helper and the smol-bin.x64.img image.
     while IFS= read -r -d "" elf; do
       patchelf --set-interpreter ${bintools.dynamicLinker} "$elf" 2>/dev/null || true
       patchelf --set-rpath "$app_rpath" "$elf" 2>/dev/null || true
     done < <(find $out/lib/claude-desktop -type f \( -name "*.so" -o -name "*.so.*" -o -name "*.node" -o -executable \) -print0)
 
-    # The desktop file uses bare Exec and Icon names, so copyDesktopItems
-    # installs the generated item and the wrapper lands at $out/bin/claude-desktop.
     makeWrapper "$out/lib/claude-desktop/claude-desktop" "$out/bin/claude-desktop" \
       --prefix LD_LIBRARY_PATH : "$app_rpath" \
       --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \

--- a/packages/claude-desktop/update.py
+++ b/packages/claude-desktop/update.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+"""Update claude-desktop from Anthropic's APT index.
+
+Anthropic publish Claude Desktop as prebuilt Debian packages through an APT
+repository; there is no source tree and no GitHub releases. This script reads
+the per-architecture Packages index, picks the highest version for each arch,
+and records the download URLs and SRI hashes in hashes.json. The two arches may
+sit at different versions when one lags behind, so each arch is handled on its
+own and the top-level version follows x86_64-linux.
+"""
+
+import sys
+from pathlib import Path
+
+# The shared updater library lives in the repository's scripts directory.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import fetch_text, load_hashes, save_hashes, should_update
+from updater.hash import hex_to_sri
+
+# The APT repository base, the dist index base, and the arch name mapping from
+# Nix system to Debian architecture.
+APT_BASE = "https://downloads.claude.ai/claude-desktop/apt/stable"
+DIST_BASE = APT_BASE + "/dists/stable/main"
+PLATFORMS = {"x86_64-linux": "amd64", "aarch64-linux": "arm64"}
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Turn a dotted version string into a tuple of integers for sorting.
+
+    Non-numeric components fall back to zero so that comparison never fails on
+    an unexpected version string.
+    """
+    parts = []
+    for part in version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def latest_for_arch(arch: str) -> tuple[str, str, str]:
+    """Fetch the Packages index for one arch and return its newest release.
+
+    The index holds one RFC822-style stanza per published version, separated by
+    blank lines. This returns the (version, filename, sha256_hex) triple for the
+    highest version. It raises when the index yields no usable stanza.
+    """
+    text = fetch_text(f"{DIST_BASE}/binary-{arch}/Packages")
+
+    candidates = []
+    for stanza in text.split("\n\n"):
+        fields = {}
+        for line in stanza.splitlines():
+            if ": " in line:
+                key, value = line.split(": ", 1)
+                fields[key] = value
+        version = fields.get("Version")
+        filename = fields.get("Filename")
+        sha256 = fields.get("SHA256")
+        if version and filename and sha256:
+            candidates.append((version, filename, sha256))
+
+    if not candidates:
+        msg = f"No package stanza found for arch {arch}"
+        raise RuntimeError(msg)
+
+    candidates.sort(key=lambda entry: parse_version(entry[0]))
+    return candidates[-1]
+
+
+def main() -> None:
+    """Refresh hashes.json when a newer release is available for any arch."""
+    current = load_hashes(HASHES_FILE)
+
+    urls = {}
+    hashes = {}
+    versions = {}
+    for platform, arch in PLATFORMS.items():
+        version, filename, sha256_hex = latest_for_arch(arch)
+        versions[platform] = version
+        urls[platform] = f"{APT_BASE}/{filename}"
+        hashes[platform] = hex_to_sri(sha256_hex)
+
+    new_version = versions["x86_64-linux"]
+
+    # Update when the top-level version rises, or when any per-arch URL or hash
+    # changed (this catches an arm64 bump while amd64 stays put).
+    changed = (
+        should_update(current.get("version", ""), new_version)
+        or urls != current.get("urls", {})
+        or hashes != current.get("hashes", {})
+    )
+
+    if not changed:
+        print("claude-desktop: already up to date")
+        return
+
+    save_hashes(
+        HASHES_FILE,
+        {"version": new_version, "urls": urls, "hashes": hashes},
+    )
+    print(f"Updated to {new_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/claude-desktop/update.py
+++ b/packages/claude-desktop/update.py
@@ -13,14 +13,11 @@ own and the top-level version follows x86_64-linux.
 import sys
 from pathlib import Path
 
-# The shared updater library lives in the repository's scripts directory.
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import fetch_text, load_hashes, save_hashes, should_update
 from updater.hash import hex_to_sri
 
-# The APT repository base, the dist index base, and the arch name mapping from
-# Nix system to Debian architecture.
 APT_BASE = "https://downloads.claude.ai/claude-desktop/apt/stable"
 DIST_BASE = APT_BASE + "/dists/stable/main"
 PLATFORMS = {"x86_64-linux": "amd64", "aarch64-linux": "arm64"}
@@ -29,11 +26,7 @@ HASHES_FILE = Path(__file__).parent / "hashes.json"
 
 
 def parse_version(version: str) -> tuple[int, ...]:
-    """Turn a dotted version string into a tuple of integers for sorting.
-
-    Non-numeric components fall back to zero so that comparison never fails on
-    an unexpected version string.
-    """
+    """Turn a dotted version into an int tuple for sorting (non-numeric -> 0)."""
     parts = []
     for part in version.split("."):
         try:
@@ -44,11 +37,10 @@ def parse_version(version: str) -> tuple[int, ...]:
 
 
 def latest_for_arch(arch: str) -> tuple[str, str, str]:
-    """Fetch the Packages index for one arch and return its newest release.
+    """Return (version, filename, sha256_hex) of the newest release for arch.
 
-    The index holds one RFC822-style stanza per published version, separated by
-    blank lines. This returns the (version, filename, sha256_hex) triple for the
-    highest version. It raises when the index yields no usable stanza.
+    The Packages index holds one RFC822-style stanza per published version,
+    separated by blank lines.
     """
     text = fetch_text(f"{DIST_BASE}/binary-{arch}/Packages")
 
@@ -88,8 +80,7 @@ def main() -> None:
 
     new_version = versions["x86_64-linux"]
 
-    # Update when the top-level version rises, or when any per-arch URL or hash
-    # changed (this catches an arm64 bump while amd64 stays put).
+    # Also catch an arm64-only bump while amd64 stays put.
     changed = (
         should_update(current.get("version", ""), new_version)
         or urls != current.get("urls", {})


### PR DESCRIPTION
## Summary

Anthropic's Claude Desktop for Linux, an Electron app shipped only as a prebuilt `.deb` via their APT repository. Packages the `.deb` for `x86_64-linux` and `aarch64-linux`: unpacks it, patches the bundled ELF binaries, and wraps the launcher. The desktop entry preserves the `x-scheme-handler/claude` OAuth handler and the New chat / New Claude Code actions.

`nix-update` cannot handle a `.deb` from an APT index, so a custom `update.py` parses the `Packages` index and refreshes `hashes.json`. Unfree; I maintain it (`flexiondotorg`).

## Test plan

- `nix build .#claude-desktop` succeeds; the launcher runs and the `.desktop` file keeps the handler and actions.
- `nix fmt` and `ruff` clean; README regenerated.

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work