### PR TITLE
handy: fix library conflict with whisper-cpp

### DIFF
--- a/packages/formatelf/default.nix
+++ b/packages/formatelf/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.callPackage ./package.nix { }

--- a/packages/formatelf/package.nix
+++ b/packages/formatelf/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  makeSetupHook,
+}:
+
+let
+  version = "0-unstable-2025-06-11";
+
+  # Nix packaging is vendored in-tree; the Rust source and the setup-hook shell
+  # script are fetched from upstream as a fixed-output derivation.
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "formatelf";
+    rev = "6f2d4362339ec0cb432956a05156ff483159f474";
+    hash = "sha256-90d7rLrnIAIAYEyxKBTlGNd/C246wPcZ23m8rCwuahw=";
+  };
+
+  formatelf = rustPlatform.buildRustPackage {
+    pname = "formatelf";
+    inherit version src;
+
+    cargoHash = "sha256-+chzNYelw+fcWhIMSbJgVyOD48vV/Z6Cg5nhbfs16Xs=";
+
+    # The test suite needs zig-built fixtures and a reference patchelf, neither
+    # of which exists in the build sandbox.
+    doCheck = false;
+
+    # auto-formatelf is the multi-call personality selected by argv[0].
+    postInstall = ''
+      ln -s formatelf $out/bin/auto-formatelf
+    '';
+
+    meta = {
+      description = "Modify the dynamic linker and RPATH of ELF executables";
+      homepage = "https://github.com/Mic92/formatelf";
+      license = lib.licenses.mit;
+      mainProgram = "formatelf";
+      platforms = lib.platforms.linux;
+    };
+  };
+
+  # Drop-in equivalent of nixpkgs' autoPatchelfHook, backed by auto-formatelf.
+  # The bintools dependency supplies $NIX_BINTOOLS, from which auto-formatelf
+  # reads the dynamic linker and libc.
+  hook = makeSetupHook {
+    name = "auto-formatelf-hook";
+    propagatedBuildInputs = [
+      formatelf
+      stdenv.cc.bintools
+    ];
+    passthru.hideFromDocs = true;
+    meta = {
+      description = "Setup hook that patches ELF binaries via formatelf";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.linux;
+    };
+  } "${src}/auto-formatelf-hook.sh";
+in
+hook

--- a/packages/handy/default.nix
+++ b/packages/handy/default.nix
@@ -1,1 +1,4 @@
-{ pkgs, ... }: pkgs.callPackage ./package.nix { }
+{ pkgs, perSystem, ... }:
+pkgs.callPackage ./package.nix {
+  autoPatchelfHook = perSystem.self.formatelf;
+}

--- a/packages/handy/package.nix
+++ b/packages/handy/package.nix
@@ -121,22 +121,18 @@ stdenv.mkDerivation {
       ''
         runHook preInstall
 
-        # Install the binary
         install -Dm755 usr/bin/handy $out/bin/handy
 
-        # Install the bundled shared libraries (libtranscribe, libggml,
-        # libonnxruntime, ...). handy links against these exact builds — e.g.
-        # onnxruntime tags its exports with a VERS_<exact-version> ELF symbol
-        # version, so the prebuilt binary cannot load nixpkgs' onnxruntime —
-        # so ship them and let autoPatchelf add $out/lib to the rpath.
-        mkdir -p $out/lib
-        cp -P usr/lib/*.so* $out/lib/
+        # Bundled libs go in a private dir, not $out/lib, to avoid clashing
+        # with identically named libraries from other packages (e.g.
+        # whisper-cpp's libggml-cpu-cascadelake.so) in shared profiles.
+        # The autoPatchelf hook (formatelf) rewrites the RPATHs to find them.
+        mkdir -p $out/lib/handy
+        cp -a usr/lib/*.so* $out/lib/handy/
 
-        # Install resources
         mkdir -p $out/lib/Handy/resources
         cp -r usr/lib/Handy/resources/* $out/lib/Handy/resources/
 
-        # Install icons
         mkdir -p $out/share/icons/hicolor
         if [ -d usr/share/icons/hicolor ]; then
           cp -r usr/share/icons/hicolor/* $out/share/icons/hicolor/
@@ -151,7 +147,6 @@ stdenv.mkDerivation {
         mkdir -p $out/Applications
         cp -r ./unpacked/Handy.app $out/Applications/
 
-        # Create a wrapper script in bin
         mkdir -p $out/bin
         makeWrapper $out/Applications/Handy.app/Contents/MacOS/Handy $out/bin/handy
 


### PR DESCRIPTION

The 0.9.0 deb ships its bundled onnxruntime and ggml/whisper runtime
(libggml-*, libtranscribe, ...) in usr/lib. Installing these into
$out/lib collided with other packages providing identically named
libraries (whisper-cpp's libggml-cpu-cascadelake.so), breaking shared
profiles (#6437).

Install them into a private $out/lib/handy instead; the formatelf
autoPatchelf hook rewrites the RPATHs. Add openblas for libtranscribe.


