### PR TITLE
fix(mistral-vibe): vibe ModuleNotFoundError

### DIFF
--- a/packages/mistral-vibe/agent-client-protocol.nix
+++ b/packages/mistral-vibe/agent-client-protocol.nix
@@ -6,13 +6,13 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "agent-client-protocol";
-  version = "0.9.0";
+  version = "0.10.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "agent_client_protocol";
     inherit version;
-    hash = "sha256-90TEirmvDwtEUuWrVJjWG8q5fCbb59b+7F/TbeSb4ws=";
+    hash = "sha256-NVxlyhnwVoNEqvwsFVK3BmqPxJHfI6so5+JTxsmoWiU=";
   };
 
   build-system = with python3.pkgs; [ pdm-backend ];

--- a/packages/mistral-vibe/mistralai.nix
+++ b/packages/mistral-vibe/mistralai.nix
@@ -6,12 +6,12 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "mistralai";
-  version = "2.1.3";
+  version = "2.5.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-DF3khVsEPNBYJAbVwd39keF29IShWObuC0oAVCMb4mY=";
+    hash = "sha256-snJBVPYvZQXSICfL20FOK7FDR0u1H4ncNir7GxQdK64=";
   };
 
   build-system = with python3.pkgs; [ hatchling ];

--- a/packages/mistral-vibe/package.nix
+++ b/packages/mistral-vibe/package.nix
@@ -114,11 +114,11 @@ let
       # mistral-vibe 2.7.5 imports `deep_update` from
       # `pydantic_settings.sources.base`, a re-export added in 2.13.
       pydantic-settings = pyprev.pydantic-settings.overridePythonAttrs (_: rec {
-        version = "2.13.1";
+        version = "2.14.2";
         src = fetchPypi {
           pname = "pydantic_settings";
           inherit version;
-          hash = "sha256-tMEYR7FSN/sBceFGK/VA4pSv+5uG202apcAXML2+QCU=";
+          hash = "sha256-wZ3WSxkJfx3oAYTwzHsCcqE65uFwy/JAo+J+OB7RSl8=";
         };
       });
 


### PR DESCRIPTION
## Summary

This PR fixes a startup crash in `mistral-vibe` version 2.19.0. Running the `vibe` command previously failed with:
`ModuleNotFoundError: No module named 'mistralai.extra.observability.telemetry'`.

This was caused by outdated python SDK dependencies in the local overrides. I have updated the dependencies to match the exact versions pinned by upstream in its `pyproject.toml`:
- Updated `mistralai` SDK to `2.5.0` (which adds the missing `extra.observability.telemetry` module).
- Updated `agent-client-protocol` to `0.10.1`.
- Updated overridden `pydantic-settings` to `2.14.2`.

## Test plan

- [x] `nix build .#mistral-vibe` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

I built the package locally and verified that the `vibe` CLI works and outputs its version properly without crashing:
```bash
$ ./result/bin/vibe --version
vibe 2.19.0
```

______________________________________________________________________