### PR TITLE
packages: pin GitHub sources by tag instead of rev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ meta = with lib; {
 };
 ```
 
+### Pinning GitHub Sources by Tag
+
+Use `fetchFromGitHub`'s `tag = "v${version}"`, not `rev = "v${version}"`. `rev`
+fetches the ambiguous `archive/v${version}.tar.gz`, which errors when a repo has
+a branch and tag of the same name; `tag` uses `refs/tags/` and is hash-identical.
+
 The `changelog` attribute is **required** — our updater uses it to generate release notes. Use a version-specific URL matching the upstream tag format (e.g. `v${version}`, `${version}`, `rust-v${version}`). Fall back to `/releases` when tags are inconsistent. Verify the URL doesn't 404.
 
 ### Package Categories

--- a/packages/agent-browser/package.nix
+++ b/packages/agent-browser/package.nix
@@ -14,7 +14,7 @@
 
 let
   pname = "agent-browser";
-  version = "0.31.0";
+  version = "0.31.1";
 
   # Vendored Geist variable font (OFL-1.1) pinned to a specific upstream
   # commit so the dashboard's next/font/local build is fully offline.
@@ -26,8 +26,10 @@ let
   src = fetchFromGitHub {
     owner = "vercel-labs";
     repo = "agent-browser";
-    rev = "v${version}";
-    hash = "sha256-kZKTt4eglj5WGUhxzHCu6pZogSy4nqxdj9F71artro8=";
+    # Upstream has a branch and a tag both named v<version>, so the plain
+    # archive URL is ambiguous ("multiple possibilities"). Pin the tag ref.
+    tag = "v${version}";
+    hash = "sha256-uCLzNQ0NAeg1TtA6tcBhTu5VTyjkumsyiEpAhYLPQD0=";
   };
 
   dashboard = stdenv.mkDerivation {
@@ -78,7 +80,7 @@ rustPlatform.buildRustPackage {
 
   sourceRoot = "source/cli";
 
-  cargoHash = "sha256-GKArksZqjWdCBijgopXr3YQ+KuM8LO9K0lRuRuk+VyA=";
+  cargoHash = "sha256-2td6rEG2uX8qDhcoZbvMZOjzOXTtnlxGvu4AzIALdtA=";
 
   nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux makeBinaryWrapper;
   buildInputs = lib.optional stdenv.hostPlatform.isLinux chromium;

--- a/packages/agent-deck/package.nix
+++ b/packages/agent-deck/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "asheshgoplani";
     repo = "agent-deck";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-4LbeRiaFIn4Nx/VtDvhJAaeA7YB6i2VX8wZhJ75qw5k=";
   };
 

--- a/packages/agentsview/package.nix
+++ b/packages/agentsview/package.nix
@@ -24,7 +24,7 @@ let
   src = fetchFromGitHub {
     owner = "kenn-io";
     repo = "agentsview";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/aperant/package.nix
+++ b/packages/aperant/package.nix
@@ -16,7 +16,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "AndyMik90";
     repo = "Aperant";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MwT/FGpnAbGjJAGoKJkyL0ngKWtPIpQiCSN2LzHSMAY=";
   };
 

--- a/packages/backlog-md/package.nix
+++ b/packages/backlog-md/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "MrLesk";
     repo = "Backlog.md";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/beads-viewer/package.nix
+++ b/packages/beads-viewer/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "Dicklesworthstone";
     repo = "beads_viewer";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-FLJ/jXC04rXaELwwO8Ph8OWgA0IuDyUuJheH5xWQR58=";
   };
 

--- a/packages/beads/package.nix
+++ b/packages/beads/package.nix
@@ -17,7 +17,7 @@ buildGoModule.override { go = go-bin; } rec {
   src = fetchFromGitHub {
     owner = "gastownhall";
     repo = "beads";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-+dFV//0N8ZDw9BHOJOoWZ+BvLmJKlnGtONHIYPRhfBE=";
   };
 

--- a/packages/cc-sdd/package.nix
+++ b/packages/cc-sdd/package.nix
@@ -18,7 +18,7 @@ buildNpmPackage {
   src = fetchFromGitHub {
     owner = "gotalab";
     repo = "cc-sdd";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "ryoppippi";
     repo = "ccusage";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-KtN0dJ183W9i9y+eyLl95WKXrtu7uF0D/sN6/hu6Sr4=";
   };
 

--- a/packages/claude-agent-acp/package.nix
+++ b/packages/claude-agent-acp/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "agentclientprotocol";
     repo = "claude-agent-acp";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-HVhXJJshq41qMqyaxWkNi//TeZUp+PZwKnppJ1lYaIw=";
   };
 

--- a/packages/cli-proxy-api/package.nix
+++ b/packages/cli-proxy-api/package.nix
@@ -19,7 +19,7 @@ buildGoModule.override { go = go_1_26; } {
   src = fetchFromGitHub {
     owner = "router-for-me";
     repo = "CLIProxyAPI";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -24,7 +24,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "tirth8205";
     repo = "code-review-graph";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-akuk4UHOTfw66dnuAeqoCkqF/JzsHqSzoTk5MQhEd0o=";
   };
 

--- a/packages/codegraph/package.nix
+++ b/packages/codegraph/package.nix
@@ -14,7 +14,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "colbymchenry";
     repo = "codegraph";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-JLyu6FG74R/3RwBFNhen3U9swA0AFyJh7q5obNA/ZpE=";
   };
 

--- a/packages/codex-acp/package.nix
+++ b/packages/codex-acp/package.nix
@@ -35,7 +35,7 @@ let
       fetchFromGitHub {
         owner = "zed-industries";
         repo = "codex-acp";
-        rev = "v${version}";
+        tag = "v${version}";
         inherit hash;
       };
 in

--- a/packages/context-hub/package.nix
+++ b/packages/context-hub/package.nix
@@ -14,7 +14,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "andrewyng";
     repo = "context-hub";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-BU6SIt5brANngEqVdquQEA6LZcCSH1PNLg5k2b94naM=";
   };
 

--- a/packages/crush/package.nix
+++ b/packages/crush/package.nix
@@ -19,7 +19,7 @@ in
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "crush";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/dolt/default.nix
+++ b/packages/dolt/default.nix
@@ -12,7 +12,7 @@ in
   src = pkgs.fetchFromGitHub {
     owner = "dolthub";
     repo = "dolt";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-svBAmp/gPHSa6HXmqiFFB31sbaQa6s3HIW1tti8G1pA=";
   };
   vendorHash = "sha256-tBvNKDBv86pGBhzPc9tGDVwR1tB/HmUMn2VH42B6QRc=";

--- a/packages/entire/package.nix
+++ b/packages/entire/package.nix
@@ -18,7 +18,7 @@
   src = fetchFromGitHub {
     owner = "entireio";
     repo = "cli";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-SqJnrvRwjuPMCEkd4d+ULIUOfDW6mPs6VeW84Tc5vN0=";
   };
 

--- a/packages/fence/package.nix
+++ b/packages/fence/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "fencesandbox";
     repo = "fence";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-uJfQFOKR3f8OjzA1z18IeKvhAgTmQQ7o4Y7K4CFbwko=";
   };
 

--- a/packages/gascity/package.nix
+++ b/packages/gascity/package.nix
@@ -24,7 +24,7 @@ assert lib.versionAtLeast dolt.version "2.1.0";
   src = fetchFromGitHub {
     owner = "gastownhall";
     repo = "gascity";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-hmgDFEU2+KOgJmHKUxHW5Kp/c1F7+qMLHzWNWjDQgcY=";
   };
 

--- a/packages/gastown/package.nix
+++ b/packages/gastown/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "gastownhall";
     repo = "gastown";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-U3spPM8tKp5aoWy+l1qpRtrfIppkQAPSp1z50FQUv2I=";
   };
 

--- a/packages/gitclaw/package.nix
+++ b/packages/gitclaw/package.nix
@@ -13,7 +13,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "open-gitagent";
     repo = "gitagent";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Dbi8zCTeSdR6HCqCPP5K/4cyHmNQes4ee9OFjbsdAoo=";
   };
 

--- a/packages/gitnexus/package.nix
+++ b/packages/gitnexus/package.nix
@@ -12,13 +12,13 @@ buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   forceGitDeps = true;
   pname = "gitnexus";
-  version = "1.6.8";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "abhigyanpatwari";
     repo = "GitNexus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2LvkIlQb4fk1DuI7sXjAm2xgNCQo/OX79A+Lw6xt6Js=";
+    hash = "sha256-lLO5+b/LqVDtOuJwqc4d6SmAtmKVfoHe7tXsYHRWrOw=";
   };
 
   sourceRoot = "source/gitnexus";
@@ -41,7 +41,7 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "path.join('node_modules', '.bin', 'tsc')" "'tsc'"
   '';
 
-  npmDepsHash = "sha256-qTQTi3KYyPhZib4WWDE5S+tk8iY5rvtCQzBI2P4CA90=";
+  npmDepsHash = "sha256-kVRy2o6r/2C3HR8Mdcb7WJXqJBsjmYdnePPRRQ6zhIU=";
   makeCacheWritable = true;
 
   npmFlags = [ "--ignore-scripts" ];

--- a/packages/gitnexus/system-onnxruntime-node.patch
+++ b/packages/gitnexus/system-onnxruntime-node.patch
@@ -1,23 +1,23 @@
 diff --git gitnexus/src/core/embeddings/embedder.ts gitnexus/src/core/embeddings/embedder.ts
-index 3ec5f08..67ae5ef 100644
+index 800652a..b7d8dba 100644
 --- gitnexus/src/core/embeddings/embedder.ts
 +++ gitnexus/src/core/embeddings/embedder.ts
-@@ -29,6 +29,7 @@ import { resolveEmbeddingConfig } from './config.js';
+@@ -25,6 +25,7 @@ import { resolveEmbeddingConfig } from './config.js';
  import { applyHfEnvOverrides, isHfDownloadFailure, withHfDownloadRetry } from './hf-env.js';
  import { getLocalEmbeddingRuntimeBlocker } from './runtime-support.js';
  import { ensureOnnxRuntimeCommonResolvable } from './onnxruntime-common-resolver.js';
 +import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
- import { logger } from '../logger.js';
- 
- /**
-@@ -183,6 +184,7 @@ export const initEmbedder = async (
+ import {
+   ensureOnnxRuntimeNodeMatchesSystem,
+   isEffectiveCudaAvailable,
+@@ -107,6 +108,7 @@ export const initEmbedder = async (
        // Under pnpm-strict / `pnpm dlx`, transformers' phantom `onnxruntime-common`
        // import is unresolvable; register the fallback resolver first (#307).
        ensureOnnxRuntimeCommonResolvable();
 +      applyOnnxruntimeNodeBindingOverride();
-       const { pipeline, env } = await import('@huggingface/transformers');
- 
-       // Configure transformers.js environment
+       // Registered AFTER the common fallback so this hook resolves FIRST (Node
+       // runs the most-recently-registered hook first): on CUDA-13 hosts it
+       // redirects onnxruntime-node (and its version-matched onnxruntime-common)
 diff --git gitnexus/src/core/embeddings/onnxruntime-node-loader.ts gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
 new file mode 100644
 index 0000000..252064f
@@ -78,7 +78,7 @@ index 0000000..252064f
 +  };
 +};
 diff --git gitnexus/src/mcp/core/embedder.ts gitnexus/src/mcp/core/embedder.ts
-index 4dd73f3..c10f73b 100644
+index f856446..f632fcd 100644
 --- gitnexus/src/mcp/core/embedder.ts
 +++ gitnexus/src/mcp/core/embedder.ts
 @@ -23,6 +23,7 @@ import {
@@ -86,14 +86,14 @@ index 4dd73f3..c10f73b 100644
  import { getLocalEmbeddingRuntimeBlocker } from '../../core/embeddings/runtime-support.js';
  import { ensureOnnxRuntimeCommonResolvable } from '../../core/embeddings/onnxruntime-common-resolver.js';
 +import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
+ import { ensureOnnxRuntimeNodeMatchesSystem } from '../../core/embeddings/onnxruntime-node-resolver.js';
  import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
  
- import { logger } from '../../core/logger.js';
-@@ -69,6 +70,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
+@@ -70,6 +71,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
        // Under pnpm-strict / `pnpm dlx`, transformers' phantom `onnxruntime-common`
        // import is unresolvable; register the fallback resolver first (#307).
        ensureOnnxRuntimeCommonResolvable();
 +      applyOnnxruntimeNodeBindingOverride();
-       const { pipeline, env } = await import('@huggingface/transformers');
- 
-       env.allowLocalModels = false;
+       // Registered AFTER the common fallback so this hook resolves FIRST (Node
+       // runs the most-recently-registered hook first): on CUDA-13 hosts it
+       // redirects onnxruntime-node to the system-matched build before

--- a/packages/goose-cli/package.nix
+++ b/packages/goose-cli/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     # Upstream moved from block/goose to aaif-goose/goose.
     owner = "aaif-goose";
     repo = "goose";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit (versionData) hash;
   };
 

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -128,7 +128,7 @@ let
   src = fetchFromGitHub {
     owner = "NousResearch";
     repo = "hermes-agent";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Wt72AQtA6Eizi7Ubj23JBhwZ7GKYcjY4mcV6upqHOaU=";
   };
 

--- a/packages/hermes-hud/package.nix
+++ b/packages/hermes-hud/package.nix
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "joeynyc";
     repo = "hermes-hud";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Osn/+7qnRQORBJLWgngLT2BU0EVu2xyRN7De619IDNI=";
   };
 

--- a/packages/hunk/package.nix
+++ b/packages/hunk/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "modem-dev";
     repo = "hunk";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/mardi-gras/package.nix
+++ b/packages/mardi-gras/package.nix
@@ -15,7 +15,7 @@ buildGoModule.override { go = go-bin; } rec {
   src = fetchFromGitHub {
     owner = "quietpublish";
     repo = "mardi-gras";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-TL6m3WaNomZ4VYXbbACQb9YtGNYB81N2xBBLGH5vlRw=";
   };
 

--- a/packages/mcporter/package.nix
+++ b/packages/mcporter/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "mcporter";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dfbNyvIbdhZOLuwRDNLqUJHVeMEemioanktD6nL0Pmk=";
   };
 

--- a/packages/mistral-vibe/package.nix
+++ b/packages/mistral-vibe/package.nix
@@ -164,7 +164,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mistralai";
     repo = "mistral-vibe";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-PODG/SQsZsixBz/j+k8ALBhXS1fPg3v/o6TXkTyzSIQ=";
   };
 

--- a/packages/nanocoder/package.nix
+++ b/packages/nanocoder/package.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "Nano-Collective";
     repo = "nanocoder";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-yQy+SBYvBB9x6EiriewQ1/SnHg7S3c395yNaTQdv2ic=";
   };
 

--- a/packages/nono/package.nix
+++ b/packages/nono/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "always-further";
     repo = "nono";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-8Bol6B3c0pb25FG7214e6rXSKcACeOOQAd+c+1lblV4=";
   };
 

--- a/packages/oh-my-claudecode/package.nix
+++ b/packages/oh-my-claudecode/package.nix
@@ -14,7 +14,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "yeachan-heo";
     repo = "oh-my-claudecode";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-YzMJSok+B1zKeKeDiBaiJLgEIrrCkzZHs06fXIcRGOw=";
   };
 

--- a/packages/oh-my-codex/package.nix
+++ b/packages/oh-my-codex/package.nix
@@ -24,7 +24,7 @@ let
   src = fetchFromGitHub {
     owner = "Yeachan-Heo";
     repo = "oh-my-codex";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/openclaw/package.nix
+++ b/packages/openclaw/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "openclaw";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Ryj+aJ4Daql/ILs3Z/Gi+ltBGQfOdtXKJoOqr3YNoQ0=";
   };
 

--- a/packages/openskills/package.nix
+++ b/packages/openskills/package.nix
@@ -13,7 +13,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "numman-ali";
     repo = "openskills";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rOrLi43J+w6XBRZYYwlDPl8RqU7Zhr45B9UyP6Xarj0=";
   };
 

--- a/packages/parallel-cli/package.nix
+++ b/packages/parallel-cli/package.nix
@@ -22,7 +22,7 @@ let
     src = fetchFromGitHub {
       owner = "parallel-web";
       repo = "parallel-sdk-python";
-      rev = "v${version}";
+      tag = "v${version}";
       hash = parallelWebData.hash;
     };
 
@@ -62,7 +62,7 @@ let
     src = fetchFromGitHub {
       owner = "googleapis";
       repo = "python-bigquery-sqlalchemy";
-      rev = "v${version}";
+      tag = "v${version}";
       hash = sqlalchemyBigqueryData.hash;
     };
 
@@ -117,7 +117,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "parallel-web";
     repo = "parallel-web-tools";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/ralph-tui/package.nix
+++ b/packages/ralph-tui/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "subsy";
     repo = "ralph-tui";
-    rev = "v${version}";
+    tag = "v${version}";
     inherit hash;
   };
 

--- a/packages/reasonix/package.nix
+++ b/packages/reasonix/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "esengine";
     repo = "DeepSeek-Reasonix";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-trnEe0PJ6M9KZeJlv3cSeZb+HMMGtoxbA0gLSU1gl4c=";
   };
 

--- a/packages/rtk/package.nix
+++ b/packages/rtk/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "rtk";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-n5bkPPsrdM4fE5ltocTjlq+JwRgp39yib6S79fci4m4=";
   };
 

--- a/packages/semble/package.nix
+++ b/packages/semble/package.nix
@@ -139,7 +139,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "MinishLab";
     repo = "semble";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-o1Rb1rHvrE7IZ8fHQFxKIDryVe1FBTG1KxfNyibvPiM=";
   };
 

--- a/packages/showboat/package.nix
+++ b/packages/showboat/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "showboat";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-yYK6j6j7OgLABHLOSKlzNnm2AWzM2Ig76RJypBsBnkI=";
   };
 

--- a/packages/sidecar/package.nix
+++ b/packages/sidecar/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "marcus";
     repo = "sidecar";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-zhSWGKmTgDKSwQLhax2XoXJXnyJ+cdhK4M0bcHAW8lE=";
   };
 

--- a/packages/spec-kit/package.nix
+++ b/packages/spec-kit/package.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "github";
     repo = "spec-kit";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-sAFcdLa1g5LSXDccdrIrJb2CdnU4Jry1lAFVDKyiKik=";
   };
 

--- a/packages/td/package.nix
+++ b/packages/td/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "marcus";
     repo = "td";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-tsBS3X2S3gVmeSlQzYYlBS0S18Ee/Ze9yj67bJghSRw=";
   };
 

--- a/packages/trellis/nix-update-args
+++ b/packages/trellis/nix-update-args
@@ -1,3 +1,2 @@
---use-github-releases
 --version-regex
 ^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/trellis/package.nix
+++ b/packages/trellis/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mindfold-ai";
     repo = "trellis";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-GX9EnmiCC+jTupx/Ahjmfkt/Ct3YAnu9UERVhv4tuTg=";
   };
 

--- a/packages/vix/package.nix
+++ b/packages/vix/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "get-vix";
     repo = "vix";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-z0Vd+HP4FFqzQgoqLhxd+yVdE6gHCQK1yli8nOwtI34=";
   };
 

--- a/packages/workmux/package.nix
+++ b/packages/workmux/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "raine";
     repo = "workmux";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-iMpS+Xye2ecVonsC1YMK0UkuDMVtWvO3eoJ/PA4gq7A=";
   };
 


### PR DESCRIPTION

Using rev = "v${version}" fetches the ambiguous archive/v${version}.tar.gz
URL. When a repo has both a branch and a tag with that name (e.g.
agent-browser), GitHub returns a "multiple possibilities" error page
instead of the tarball, breaking builds and nix-update. The tag attribute
resolves to refs/tags/ and is hash-identical to the equivalent rev.

Also fix three failing updaters:
- agent-browser: bump to 0.31.1 (branch/tag name clash)
- gitnexus: regenerate onnxruntime-node patch against 1.6.9
- trellis: drop --use-github-releases; repo publishes tags, not releases


