### PR TITLE
ci: run lint on merge_group to unblock merge queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,7 @@
 name: Lint package definitions
 on:
   pull_request:
-    paths:
-      - 'packages/**'
-      - 'rules/**'
-      - 'sgconfig.yml'
-      - 'checks/ast-grep.nix'
-      - '.github/workflows/lint.yml'
+  merge_group:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
The branch ruleset requires the `ast-grep` check, but the merge queue fires `merge_group` events which `lint.yml` did not listen for, so the check never ran in the queue and every entry stalled at https://github.com/numtide/llm-agents.nix/queue/main.

Trigger on `merge_group` too, and drop the `pull_request` paths filter so the required check is always reported (a path-filtered required check is *skipped*, not passed, when no matching files change, blocking unrelated PRs).

Front-loading via admin merge since the queue itself is broken.