### PR TITLE
claude-desktop: add libXcursor and virtiofsd's libraries

### DIFF
--- a/packages/claude-desktop/package.nix
+++ b/packages/claude-desktop/package.nix
@@ -46,7 +46,12 @@
   libnotify,
   libpulseaudio,
   libayatana-appindicator,
+  libXcursor,
   xdg-utils,
+
+  # Needed by the bundled virtiofsd, which backs Cowork's virtual machines.
+  libcap_ng,
+  libseccomp,
 
   # Needed for XDG_ICON_DIRS and GSETTINGS_SCHEMAS_PATH.
   adwaita-icon-theme,
@@ -78,15 +83,18 @@ let
     glib
     gtk3
     libayatana-appindicator
+    libcap_ng
     libdrm
     libglvnd
     libgbm
     libnotify
     libpulseaudio
     libsecret
+    libseccomp
     libX11
     libxcb
     libXcomposite
+    libXcursor
     libXdamage
     libXext
     libXfixes


### PR DESCRIPTION
## Summary

The `claude-desktop` binaries reach for a few libraries at runtime that aren't in the package's library path, so parts of the app fail even though it launches:

- The main binary `dlopen`s `libXcursor.so.1` for cursor themes; without it, cursor theming falls back.
- The bundled `virtiofsd`, which backs Cowork's virtual machines, links `libseccomp.so.2` and `libcap-ng.so.0`. The install phase rewrites its RPATH to the shared library path, so without these it can't start and Cowork VMs fail to launch.

This adds `libXcursor`, `libseccomp` and `libcap_ng` to `deps`, so all three resolve — both via the wrapper's `LD_LIBRARY_PATH` and via the RPATH patched onto the bundled ELF payloads.

## Test plan

Built for `x86_64-linux` and inspected the result:

- `virtiofsd`'s patched RPATH now resolves `libseccomp.so.2` → `libseccomp-2.6.0-lib` and `libcap-ng.so.0` → `libcap-ng-0.9.3`.
- The wrapper's `LD_LIBRARY_PATH` now contains `libxcursor-1.2.3/lib`.
- `nix fmt` reports no changes.

- [x] `nix build .#claude-desktop` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work (unchanged; existing `update.py`)