### PR TITLE
claude-desktop: patch libraries with autoPatchelfHook

### DIFF
--- a/packages/claude-desktop/package.nix
+++ b/packages/claude-desktop/package.nix
@@ -1,14 +1,15 @@
 {
   fetchurl,
   lib,
+  autoPatchelfHook,
   makeWrapper,
-  patchelf,
   stdenvNoCC,
   bintools,
   copyDesktopItems,
   makeDesktopItem,
 
-  # Linked dynamic libraries.
+  # Directly linked (DT_NEEDED); autoPatchelfHook resolves these from
+  # buildInputs and fails the build if any are missing.
   alsa-lib,
   at-spi2-atk,
   at-spi2-core,
@@ -21,7 +22,6 @@
   glib,
   gtk3,
   libdrm,
-  libglvnd,
   libX11,
   libxcb,
   libXcomposite,
@@ -34,18 +34,20 @@
   nspr,
   nss,
   pango,
-  pipewire,
-  wayland,
 
   # Provides libudev, which the main binary links directly. The libs-only
   # build avoids pulling the whole systemd closure.
   systemdLibs,
 
-  # Loaded at runtime via dlopen.
+  # Loaded at runtime via dlopen. Nothing lists these in DT_NEEDED, so they go
+  # in runtimeDependencies to land on the RUNPATH regardless.
+  libglvnd,
   libsecret,
   libnotify,
   libpulseaudio,
   libayatana-appindicator,
+  pipewire,
+  wayland,
   xdg-utils,
 
   # Needed for XDG_ICON_DIRS and GSETTINGS_SCHEMAS_PATH.
@@ -64,41 +66,6 @@ let
   inherit (versionData) version urls hashes;
 
   platform = stdenvNoCC.hostPlatform.system;
-
-  deps = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    gcc-unwrapped.lib
-    glib
-    gtk3
-    libayatana-appindicator
-    libdrm
-    libglvnd
-    libgbm
-    libnotify
-    libpulseaudio
-    libsecret
-    libX11
-    libxcb
-    libXcomposite
-    libXdamage
-    libXext
-    libXfixes
-    libxkbcommon
-    libXrandr
-    nspr
-    nss
-    pango
-    pipewire
-    systemdLibs
-    wayland
-  ];
 
   # x-scheme-handler/claude registers the OAuth sign-in handler.
   desktopItem = makeDesktopItem {
@@ -169,16 +136,51 @@ stdenvNoCC.mkDerivation {
   };
 
   nativeBuildInputs = [
+    autoPatchelfHook
     copyDesktopItems
     makeWrapper
-    patchelf
   ];
 
   buildInputs = [
     adwaita-icon-theme
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gcc-unwrapped.lib
     glib
     gsettings-desktop-schemas
     gtk3
+    libdrm
+    libgbm
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libxkbcommon
+    nspr
+    nss
+    pango
+    systemdLibs
+  ];
+
+  # dlopen()ed at runtime, so autoPatchelfHook cannot discover them from
+  # DT_NEEDED; list them here to force them onto every payload's RUNPATH.
+  runtimeDependencies = [
+    libayatana-appindicator
+    libglvnd
+    libnotify
+    libpulseaudio
+    libsecret
+    pipewire
+    wayland
   ];
 
   desktopItems = [ desktopItem ];
@@ -190,8 +192,6 @@ stdenvNoCC.mkDerivation {
     runHook postUnpack
   '';
 
-  rpath = lib.makeLibraryPath deps;
-
   installPhase = ''
     runHook preInstall
 
@@ -202,19 +202,11 @@ stdenvNoCC.mkDerivation {
     cp -a usr/share/icons $out/share/icons
     cp -a usr/share/doc $out/share/doc
 
-    # Include the app dir so ANGLE and the bundled GL/Vulkan libs find each
-    # other and the system libGL.
-    app_rpath="$rpath:$out/lib/claude-desktop"
-
-    # Patch every dynamic ELF in the app tree; tolerate failures on the
-    # statically linked cowork-linux-helper and the smol-bin.x64.img image.
-    while IFS= read -r -d "" elf; do
-      patchelf --set-interpreter ${bintools.dynamicLinker} "$elf" 2>/dev/null || true
-      patchelf --set-rpath "$app_rpath" "$elf" 2>/dev/null || true
-    done < <(find $out/lib/claude-desktop -type f \( -name "*.so" -o -name "*.so.*" -o -name "*.node" -o -executable \) -print0)
-
+    # autoPatchelfHook sets the interpreter and RUNPATHs. The wrapper only adds
+    # the app dir (so the bundled GL/Vulkan libs find each other), xdg-utils on
+    # PATH, and the icon/schema data dirs.
     makeWrapper "$out/lib/claude-desktop/claude-desktop" "$out/bin/claude-desktop" \
-      --prefix LD_LIBRARY_PATH : "$app_rpath" \
+      --prefix LD_LIBRARY_PATH : "$out/lib/claude-desktop" \
       --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \


### PR DESCRIPTION
## Summary

The install phase currently patches every bundled ELF with a manual loop:

```sh
patchelf --set-interpreter … "$elf" 2>/dev/null || true
patchelf --set-rpath "$app_rpath" "$elf" 2>/dev/null || true
```

The redirected stderr and `|| true` mean a payload whose libraries are missing is patched into a broken state without failing the build; the missing library only surfaces when a user runs the affected component.

This switches to `autoPatchelfHook`, which discovers each payload's `DT_NEEDED` entries, resolves them against `buildInputs`, and **fails the build** when one can't be satisfied. Libraries reached only through `dlopen` (libGL, libsecret, the appindicator, PipeWire, Wayland) carry no `DT_NEEDED` entry, so they move to `runtimeDependencies` to stay on the RUNPATH. The wrapper keeps only the application directory on `LD_LIBRARY_PATH`, so the bundled GL/Vulkan libraries still find each other.

## This PR intentionally fails to build

Standing on its own, it surfaces a real gap rather than papering over it: the bundled `virtiofsd` (which backs Cowork's virtual machines) links `libseccomp.so.2` and `libcap-ng.so.0`, neither of which is in the closure today. The manual loop silently ships a `virtiofsd` that can't start; autoPatchelfHook makes it a build error:

```
auto-patchelf: 2 dependencies could not be satisfied
error: auto-patchelf could not satisfy dependency libseccomp.so.2 wanted by …/resources/virtiofsd
error: auto-patchelf could not satisfy dependency libcap-ng.so.0 wanted by …/resources/virtiofsd
```

#6497 adds those two libraries (plus `libXcursor`, which is `dlopen`ed and so is invisible to autoPatchelfHook — it has to be listed by hand either way). With that change in, this builds cleanly. The two PRs are independent; merging #6497 first (or folding it in here) makes CI green. I've kept them separate so this one's failure documents the gap it closes.

## Test plan

- `nix build .#claude-desktop` for `x86_64-linux` fails with exactly the two `virtiofsd` errors above, and nothing else.
- With #6497's libraries added on top, the same build succeeds; `virtiofsd`'s RUNPATH then resolves `libseccomp.so.2` and `libcap-ng.so.0`.
- `nix fmt` reports no changes.

- [ ] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work (unchanged; existing `update.py`)