### PR TITLE
sem: init at 0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>sem</strong> - Semantic version control CLI built on Git</summary>
+
+- **Source**: source
+- **License**: MIT / Apache-2.0
+- **Homepage**: https://github.com/Ataraxy-Labs/sem
+- **Usage**: `nix run github:numtide/llm-agents.nix#sem -- --help`
+- **Nix**: [packages/sem/package.nix](packages/sem/package.nix)
+
+</details>
+<details>
 <summary><strong>tuicr</strong> - Review AI-generated diffs like a GitHub pull request, right from your terminal</summary>
 
 - **Source**: source

--- a/packages/sem/default.nix
+++ b/packages/sem/default.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }:
+pkgs.callPackage ./package.nix { }

--- a/packages/sem/hashes.json
+++ b/packages/sem/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.20.0",
+  "hash": "sha256-91NPyzyC7cyB1Oivl3hJVJa78kKiyUgXcNPGo34W9TA=",
+  "cargoHash": "sha256-ctJsmTH55VDuofezBRbg8FLmr6c714FuBbyQY0jLlPs="
+}

--- a/packages/sem/package.nix
+++ b/packages/sem/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  versionCheckHook,
+  gitMinimal,
+  openssl,
+  zlib,
+  versionData ? builtins.fromJSON (builtins.readFile ./hashes.json),
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sem";
+  inherit (versionData) version cargoHash;
+
+  src = fetchFromGitHub {
+    owner = "Ataraxy-Labs";
+    repo = "sem";
+    tag = "v${version}";
+    hash = versionData.hash;
+  };
+
+  cargoRoot = "crates";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  buildAndTestSubdir = cargoRoot;
+
+  cargoBuildFlags = [
+    "--package"
+    "sem-cli"
+    "--no-default-features"
+  ];
+
+  cargoTestFlags = cargoBuildFlags;
+
+  # The upstream test suite creates many temporary git repositories and is
+  # expensive; the install check below verifies the packaged CLI starts and
+  # reports the expected version.
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/sem \
+      --argv0 sem \
+      --set-default SEM_NO_TELEMETRY 1 \
+      --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Code Review";
+
+  meta = with lib; {
+    description = "Semantic version control CLI built on Git";
+    homepage = "https://github.com/Ataraxy-Labs/sem";
+    changelog = "https://github.com/Ataraxy-Labs/sem/releases/tag/v${version}";
+    license = with licenses; [
+      mit
+      asl20
+    ];
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ nwjsmith ];
+    platforms = platforms.unix;
+    mainProgram = "sem";
+  };
+}

--- a/packages/sem/update.py
+++ b/packages/sem/update.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for sem package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+from updater.hash import DUMMY_SHA256_HASH
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+OWNER = "Ataraxy-Labs"
+REPO = "sem"
+
+
+def main() -> None:
+    """Update the sem package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release(OWNER, REPO)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    print(f"Updating sem from {current} to {latest}")
+
+    print("Calculating source hash...")
+    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
+    source_hash = calculate_url_hash(url, unpack=True)
+    print(f"  source hash: {source_hash}")
+
+    data = {
+        "version": latest,
+        "hash": source_hash,
+        "cargoHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(HASHES_FILE, data)
+
+    data["cargoHash"] = calculate_dependency_hash(
+        package_attr=".#sem",
+        hash_key="cargoHash",
+        hashes_file=HASHES_FILE,
+        data=data,
+    )
+    save_hashes(HASHES_FILE, data)
+    print(f"  cargoHash: {data['cargoHash']}")
+
+    print(f"Updated sem to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the `sem` CLI package at 0.20.0 from upstream source using `rustPlatform.buildRustPackage`.

## Test plan

- [x] `nix build --accept-flake-config --no-link path:.#sem`
- [x] `nix build --accept-flake-config --no-link path:.#checks.$system.pkgs-sem`
- [x] `./packages/sem/update.py` restores the current release from a temporary downgrade
- [x] `nix fmt`

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.