### PR TITLE
ci: run ast-grep lint on ubuntu-slim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 jobs:
   ast-grep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
The ast-grep lint job only builds a Nix check, so it doesn't need the full ubuntu-latest image. Switch it to ubuntu-slim, matching the update-flake jobs, to cut runner startup overhead.