### PR TITLE
chrome-devtools-mcp: init at 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,17 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>chrome-devtools-mcp</strong> - MCP server that lets coding agents debug web pages in a live Chrome browser via Chrome DevTools</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/ChromeDevTools/chrome-devtools-mcp
+- **Usage**: `nix run github:numtide/llm-agents.nix#chrome-devtools-mcp -- --help`
+- **Nix**: [packages/chrome-devtools-mcp/package.nix](packages/chrome-devtools-mcp/package.nix)
+- **Documentation**: See [packages/chrome-devtools-mcp/README.md](packages/chrome-devtools-mcp/README.md) for detailed usage
+
+</details>
+<details>
 <summary><strong>cli-proxy-api</strong> - Unified proxy providing OpenAI/Gemini/Claude/Codex compatible APIs for AI coding CLI tools</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -152,6 +152,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 13460388;
         name = "Hobr";
       };
+      aldoborrero = {
+        github = "aldoborrero";
+        githubId = 82811;
+        name = "Aldo Borrero";
+      };
     };
   }
 )

--- a/packages/chrome-devtools-mcp/README.md
+++ b/packages/chrome-devtools-mcp/README.md
@@ -37,6 +37,14 @@ Point it at a Nix-provided browser instead. Any of these work:
 Add `chromium` (or `google-chrome`) to your own configuration so the binary is
 available; this package intentionally leaves that choice to you.
 
+## Telemetry
+
+This package disables upstream's telemetry by default — it wraps the server
+with `--no-usage-statistics` (usage data sent to Google) and
+`--no-performance-crux` (performance-trace URLs sent to the CrUX API). Both
+stay overridable: pass `--usage-statistics` or `--performance-crux` to
+re-enable them.
+
 ## MCP client configuration
 
 Configure your agent to launch the server over stdio, supplying the browser

--- a/packages/chrome-devtools-mcp/README.md
+++ b/packages/chrome-devtools-mcp/README.md
@@ -1,0 +1,66 @@
+# chrome-devtools-mcp
+
+An [MCP](https://modelcontextprotocol.io) server that gives coding agents a
+live Chrome browser to drive through the Chrome DevTools Protocol: navigate
+pages, click and fill elements, capture screenshots, read the console and
+network, and run performance traces.
+
+This package builds the server from source with all of its runtime
+dependencies (Puppeteer, Lighthouse, the DevTools frontend) bundled in, so it
+runs on NixOS without pulling anything at runtime.
+
+## Providing a browser
+
+The package **does not bundle a browser**. Upstream defaults to launching the
+stable Chrome it discovers at well-known filesystem paths
+(`/opt/google/chrome`, `/usr/bin/google-chrome`, ...), none of which exist on
+NixOS, so the default `--channel stable` fails to find a browser here.
+
+Point it at a Nix-provided browser instead. Any of these work:
+
+- **Explicit executable** — pass a Chromium/Chrome binary directly:
+
+  ```bash
+  nix run github:numtide/llm-agents.nix#chrome-devtools-mcp -- \
+    --executablePath "$(command -v chromium)"
+  ```
+
+- **Running instance** — start Chrome yourself with remote debugging enabled
+  and connect over the DevTools endpoint:
+
+  ```bash
+  chromium --remote-debugging-port=9222 &
+  nix run github:numtide/llm-agents.nix#chrome-devtools-mcp -- \
+    --browserUrl http://127.0.0.1:9222
+  ```
+
+Add `chromium` (or `google-chrome`) to your own configuration so the binary is
+available; this package intentionally leaves that choice to you.
+
+## MCP client configuration
+
+Configure your agent to launch the server over stdio, supplying the browser
+path. For example:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "chrome-devtools-mcp",
+      "args": ["--executablePath", "/run/current-system/sw/bin/chromium"]
+    }
+  }
+}
+```
+
+## Try without installing
+
+```bash
+nix run github:numtide/llm-agents.nix#chrome-devtools-mcp -- --help
+```
+
+## Links
+
+- [chrome-devtools-mcp GitHub repository](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+- [Available tools reference](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md)
+- [Model Context Protocol](https://modelcontextprotocol.io)

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  flake,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  nodejs = pkgs.nodejs_24;
+  inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
+}

--- a/packages/chrome-devtools-mcp/nix-update-args
+++ b/packages/chrome-devtools-mcp/nix-update-args
@@ -1,0 +1,2 @@
+--version-regex
+^chrome-devtools-mcp-v([0-9.]+)$

--- a/packages/chrome-devtools-mcp/package.nix
+++ b/packages/chrome-devtools-mcp/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  flake,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+buildNpmPackage rec {
+  pname = "chrome-devtools-mcp";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "ChromeDevTools";
+    repo = "chrome-devtools-mcp";
+    tag = "chrome-devtools-mcp-v${version}";
+    hash = "sha256-qDji1ZA46H3+jEZ5SL7ga/pyRhJ9SAdBWYH1jKC/TVg=";
+  };
+
+  inherit nodejs;
+
+  npmDepsHash = "sha256-t9PwLvjcUaGFBZpW504+V96TbEVukOp3skomtTFs8cA=";
+
+  # puppeteer is a build-time dependency that upstream bundles into the
+  # server via rollup; its postinstall would otherwise download a Chrome
+  # binary the Nix sandbox cannot fetch. chrome-devtools-mcp does not ship a
+  # browser: point it at one with `--executablePath`, `--channel`, or
+  # `--browser-url` at runtime.
+  env.PUPPETEER_SKIP_DOWNLOAD = "true";
+
+  # buildNpmPackage installs with `--ignore-scripts`, so the root `prepare`
+  # script does not run automatically. It patches a conflicting global type
+  # declaration in a dependency that otherwise breaks the `tsc` build.
+  preBuild = ''
+    npm run prepare
+  '';
+
+  # `bundle` runs tsc + rollup to produce the self-contained build/ output
+  # with all runtime dependencies vendored into build/src/third_party.
+  npmBuildScript = "bundle";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "MCP server that lets coding agents debug web pages in a live Chrome browser via Chrome DevTools";
+    homepage = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
+    changelog = "https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ aldoborrero ];
+    mainProgram = "chrome-devtools-mcp";
+    platforms = platforms.all;
+  };
+}

--- a/packages/chrome-devtools-mcp/package.nix
+++ b/packages/chrome-devtools-mcp/package.nix
@@ -3,6 +3,7 @@
   flake,
   buildNpmPackage,
   fetchFromGitHub,
+  makeWrapper,
   nodejs,
   versionCheckHook,
   versionCheckHomeHook,
@@ -40,6 +41,18 @@ buildNpmPackage rec {
   # `bundle` runs tsc + rollup to produce the self-contained build/ output
   # with all runtime dependencies vendored into build/src/third_party.
   npmBuildScript = "bundle";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Opt out of upstream's telemetry by default: usage statistics sent to
+  # Google and performance-trace URLs sent to the CrUX API. Both flags stay
+  # overridable (yargs is last-wins), e.g. `--usage-statistics` re-enables it.
+  # Only the chrome-devtools-mcp server accepts these; the chrome-devtools
+  # CLI does not, so it is left unwrapped.
+  postInstall = ''
+    wrapProgram $out/bin/chrome-devtools-mcp \
+      --add-flags "--no-usage-statistics --no-performance-crux"
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [


### PR DESCRIPTION
## What

Adds [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), an MCP server that lets coding agents drive a live Chrome browser over the Chrome DevTools Protocol — navigate pages, click/fill elements, capture screenshots, read console/network, and run performance traces.

Categorized under **Utilities**.

## How it's built

- `buildNpmPackage` from the GitHub tag `chrome-devtools-mcp-v${version}` (tags are prefixed, so `nix-update-args` pins `--version-regex`).
- Upstream's real runtime deps (Puppeteer, Lighthouse, the DevTools frontend) are all `devDependencies` that the `bundle` script (tsc → rollup) vendors into `build/src/third_party`, so the built output is self-contained with no runtime fetches.
- `env.PUPPETEER_SKIP_DOWNLOAD = "true"` — stops puppeteer's postinstall from downloading a Chrome the sandbox can't fetch (the key NixOS blocker).
- `preBuild = "npm run prepare"` — `buildNpmPackage` installs with `--ignore-scripts`, so the root `prepare` script (which patches a dependency's conflicting type declaration, otherwise `tsc` fails) is run manually.
- `nodejs_24` for build (upstream runs `.ts` build scripts directly) and runtime shebang.

## Browser handling on NixOS

The package **does not bundle a browser**. Upstream's default `--channel stable` searches FHS paths (`/opt/google/chrome`, `/usr/bin/google-chrome`, …) that don't exist on NixOS. Users supply a Nix-provided browser at runtime via `--executablePath`, `--channel`, or `--browserUrl`. This is documented in the package README.

## Telemetry

Disabled by default: the server is wrapped with `--no-usage-statistics` (usage data to Google) and `--no-performance-crux` (performance-trace URLs to the CrUX API). Both stay overridable — `--usage-statistics` / `--performance-crux` re-enable them. Only the `chrome-devtools-mcp` server accepts these flags; the `chrome-devtools` CLI is left unwrapped.

## Testing

- `nix build .#chrome-devtools-mcp` succeeds; `versionCheckHook` reports `1.5.0`.
- `ast-grep`, `pkgs-formatter-check` (treefmt), and `pkgs-chrome-devtools-mcp` flake checks pass.
- `nix-update` correctly resolves the prefixed tag (verified `1.4.0 → 1.5.0`).
- Telemetry opt-out verified: the usage-statistics banner is absent by default and returns with `--usage-statistics`.
- End-to-end MCP handshake against a Nix-provided Chromium launched the browser and opened a page:

```
$ ... | chrome-devtools-mcp --headless --isolated -e /path/to/chromium
{"result":{...,"serverInfo":{"name":"chrome_devtools","version":"1.5.0"}},"jsonrpc":"2.0","id":1}
{"result":{"content":[{"type":"text","text":"## Pages\n1: about:blank\n2: about:blank [selected]"}]},"jsonrpc":"2.0","id":2}
```