### PR TITLE
jscpd: init at 5.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>jscpd</strong> - Copy/paste detector for programming source code</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://jscpd.dev
+- **Usage**: `nix run github:numtide/llm-agents.nix#jscpd -- --help`
+- **Nix**: [packages/jscpd/package.nix](packages/jscpd/package.nix)
+
+</details>
+<details>
 <summary><strong>plannotator</strong> - Interactive plan and code review tool for AI coding agents</summary>
 
 - **Source**: source

--- a/packages/jscpd/default.nix
+++ b/packages/jscpd/default.nix
@@ -1,0 +1,4 @@
+{ pkgs, perSystem, ... }:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/jscpd/package.nix
+++ b/packages/jscpd/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jscpd";
+  version = "5.0.11";
+
+  src = fetchFromGitHub {
+    owner = "kucherenko";
+    repo = "jscpd";
+    tag = "v${version}";
+    hash = "sha256-O1hfk/pmdStZrcHN2d806eBffpDyoolUORQZf5tJHY8=";
+  };
+
+  sourceRoot = "${src.name}/rust";
+
+  cargoHash = "sha256-nau+k19dCHWtkX9C+b1KwDqiQexkF+KbceWEKlFeu6k=";
+
+  cargoBuildFlags = [
+    "-p"
+    "jscpd"
+  ];
+
+  # Workspace tests exercise fixtures outside the rust/ source root.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Code Review";
+
+  meta = {
+    description = "Copy/paste detector for programming source code";
+    homepage = "https://jscpd.dev";
+    changelog = "https://github.com/kucherenko/jscpd/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ mic92 ];
+    mainProgram = "jscpd";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds [jscpd](https://github.com/kucherenko/jscpd), a copy/paste detector for source code.

Packages the Rust CLI shipped upstream since v5 via `rustPlatform.buildRustPackage`, so no Node.js runtime is required.

- builds on x86_64-linux, `--version` install check passes
- nix-update compatible (inline version/hashes)