### PR TITLE
README: regenerate for claude-code-router 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 <details>
 <summary><strong>claude-code-router</strong> - Use Claude Code without an Anthropics account and route it to another LLM provider</summary>
 
-- **Source**: bytecode
+- **Source**: source
 - **License**: MIT
 - **Homepage**: https://github.com/musistudio/claude-code-router
 - **Usage**: `nix run github:numtide/llm-agents.nix#claude-code-router -- --help`


### PR DESCRIPTION
The 3.x repackage in a7c641fc8 builds from source, so the generator
reports 'source' provenance. The README check is not a required status
so the PR merged with the stale entry.