### PR TITLE
codex: also build the codex-code-mode-host binary

### DIFF
--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -75,6 +75,8 @@ rustPlatform.buildRustPackage (
     cargoBuildFlags = [
       "--package"
       "codex-cli"
+      "--package"
+      "codex-code-mode-host"
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
## Problem

`codex` spawns a separate **`codex-code-mode-host`** binary for its command backend (shell execution + file edits). The package builds only `--package codex-cli`, so `codex-code-mode-host` is never built or installed. At runtime, no shell or file-edit command can start:

> The command backend broke … `codex-code-mode-host` is missing from its Nix store path, so no shell or file-edit command can start.

The `code-mode-host` crate (package name `codex-code-mode-host`) has been in the workspace since at least `rust-v0.142.5`; the command backend just didn't exercise it until recently, so the gap was latent.

## Fix

Add `--package codex-code-mode-host` to `cargoBuildFlags` so its binary is built and installed next to `codex` in `$out/bin` (codex resolves the host as a sibling of its own executable).

```diff
     cargoBuildFlags = [
       "--package"
       "codex-cli"
+      "--package"
+      "codex-code-mode-host"
     ];
```

I hit this on 0.144 and fixed it downstream by overriding `cargoBuildFlags` with the same addition; `codex-code-mode-host` then installs into `$out/bin` and the command backend works.
