### PR TITLE
pi: add Bun runtime variant for aarch64-linux

### DIFF
--- a/.github/ci/discovery.py
+++ b/.github/ci/discovery.py
@@ -23,10 +23,11 @@ let
   pkgs = flake.packages.${config.system};
   isHidden = pkg: pkg.passthru.hideFromDocs or false;
   updateEvenIfHidden = pkg: pkg.passthru.updateEvenIfHidden or false;
-  shouldDiscover = pkg: !(isHidden pkg) || updateEvenIfHidden pkg;
+  skipUpdate = pkg: pkg.passthru.skipUpdate or false;
+  shouldDiscover = pkg: (!(isHidden pkg) || updateEvenIfHidden pkg) && !(skipUpdate pkg);
   getVersion = name:
-    if pkgs ? ${name} && pkgs.${name} ? version && shouldDiscover pkgs.${name}
-    then { inherit name; value = pkgs.${name}.version; }
+    if pkgs ? ${name} && pkgs.${name} ? version
+    then { inherit name; value = if shouldDiscover pkgs.${name} then pkgs.${name}.version else null; }
     else null;
 in
   if config.filter == null then

--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>pi-bun</strong> - Pi coding agent with Bun runtime support</summary>
+
+- **Source**: bytecode
+- **License**: MIT
+- **Homepage**: https://github.com/earendil-works/pi
+- **Usage**: `nix run github:numtide/llm-agents.nix#pi-bun -- --help`
+- **Nix**: [packages/pi-bun/package.nix](packages/pi-bun/package.nix)
+
+</details>
+<details>
 <summary><strong>qoder-cli</strong> - Qoder AI CLI tool - Terminal-based AI assistant for code development</summary>
 
 - **Source**: binary

--- a/packages/pi-bun/default.nix
+++ b/packages/pi-bun/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) buildNpmPackage versionCheckHomeHook;
+}

--- a/packages/pi-bun/package.nix
+++ b/packages/pi-bun/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNpmPackage,
+  bun,
+  makeWrapper,
+  nodejs,
+  fetchurl,
+  fd,
+  ripgrep,
+  runCommand,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+(import ../pi/package.nix {
+  inherit
+    lib
+    buildNpmPackage
+    bun
+    makeWrapper
+    nodejs
+    fetchurl
+    fd
+    ripgrep
+    runCommand
+    versionCheckHook
+    versionCheckHomeHook
+    ;
+
+  runtime = "bun";
+  pname = "pi-bun";
+  description = "Pi coding agent with Bun runtime support";
+  longDescription = ''
+    A variant of the Pi coding agent that starts the upstream Bun-specific
+    entry point with the Bun JavaScript runtime. It shares the same source,
+    lockfile, dependency hash, and updater as the default pi package; only the
+    runtime wrapper differs.
+  '';
+})

--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -1,17 +1,26 @@
 {
   lib,
   buildNpmPackage,
+  bun,
+  makeWrapper,
+  nodejs,
   fetchurl,
   fd,
   ripgrep,
   runCommand,
   versionCheckHook,
   versionCheckHomeHook,
+  runtime ? "node",
+  pname ? "pi",
+  description ? "A terminal-based coding agent with multi-model support",
+  longDescription ? null,
 }:
 
 let
+  isBunRuntime = runtime == "bun";
   versionData = lib.importJSON ./hashes.json;
   version = versionData.version;
+  packageRoot = "$out/lib/node_modules/@earendil-works/pi-coding-agent";
 
   # Create a source with package-lock.json included
   srcWithLock = runCommand "pi-src-with-lock" { } ''
@@ -26,10 +35,14 @@ let
     cp ${./package-lock.json} $out/package-lock.json
   '';
 in
+assert lib.assertOneOf "runtime" runtime [
+  "node"
+  "bun"
+];
 buildNpmPackage {
   npmDepsFetcherVersion = 2;
   inherit version;
-  pname = "pi";
+  inherit pname;
 
   src = srcWithLock;
 
@@ -39,16 +52,48 @@ buildNpmPackage {
   # The package from npm is already built
   dontNpmBuild = true;
 
-  postInstall = ''
-    wrapProgram $out/bin/pi \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          fd
-          ripgrep
-        ]
-      } \
-      --set PI_SKIP_VERSION_CHECK 1 \
-      --set PI_TELEMETRY 0
+  nativeBuildInputs = lib.optionals isBunRuntime [
+    makeWrapper
+  ];
+
+  postInstall =
+    if isBunRuntime then
+      ''
+        rm -f "$out/bin/pi" "$out/bin/.pi-wrapped" 2>/dev/null || true
+
+        find "$out" -path "*/node_modules/.bin/*" -type f -delete 2>/dev/null || true
+        find "$out" -path "*/node_modules/.bin" -type d -empty -delete 2>/dev/null || true
+
+        makeWrapper ${lib.getExe bun} "$out/bin/pi" \
+          --add-flags "${packageRoot}/dist/bun/cli.js" \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              fd
+              ripgrep
+            ]
+          } \
+          --set PI_PACKAGE_DIR ${packageRoot} \
+          --set PI_SKIP_VERSION_CHECK 1 \
+          --set PI_TELEMETRY 0
+      ''
+    else
+      ''
+        wrapProgram $out/bin/pi \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              fd
+              ripgrep
+            ]
+          } \
+          --set PI_PACKAGE_DIR ${packageRoot} \
+          --set PI_SKIP_VERSION_CHECK 1 \
+          --set PI_TELEMETRY 0
+      '';
+
+  postFixup = lib.optionalString isBunRuntime ''
+    while IFS= read -r script; do
+      sed -i "1s|^#!${lib.getExe nodejs}$|#!${lib.getExe bun}|" "$script"
+    done < <(find "$out" -type f -perm -0100 -exec grep -l "^#!${lib.getExe nodejs}$" {} +)
   '';
 
   doInstallCheck = true;
@@ -58,15 +103,19 @@ buildNpmPackage {
   ];
 
   passthru.category = "AI Coding Agents";
+  passthru.skipUpdate = isBunRuntime;
 
   meta = {
-    description = "A terminal-based coding agent with multi-model support";
+    inherit description;
     homepage = "https://github.com/earendil-works/pi";
     changelog = "https://github.com/earendil-works/pi/releases";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ aos ];
-    platforms = lib.platforms.all;
+    platforms = if isBunRuntime then bun.meta.platforms else lib.platforms.all;
     mainProgram = "pi";
+  }
+  // lib.optionalAttrs (longDescription != null) {
+    inherit longDescription;
   };
 }


### PR DESCRIPTION
## Summary

Adds `pi-bun`, a Bun-runtime variant of the existing `pi` package.

The main motivation is Raspberry Pi / `aarch64-linux` support through Nixpkgs’ Bun runtime. Upstream Pi already ships a Bun-specific entrypoint at `dist/bun/cli.js` and builds standalone Bun binaries from that path, so this package reuses the existing npm tarball and runs that official Bun entrypoint with Nix’s `bun`.

## Implementation

- Extends `packages/pi/package.nix` with a small `runtime` parameter:
  - `runtime = "node"` keeps the existing `pi` behavior
  - `runtime = "bun"` builds the `pi-bun` variant
- Adds `packages/pi-bun` as a thin wrapper over `packages/pi`
- Keeps one source/hash/lock/update path via `packages/pi`
- Uses `bun.meta.platforms` for the Bun variant, which includes `aarch64-linux`
- Sets `PI_PACKAGE_DIR` in the wrapper, matching upstream’s documented Nix/Guix support path
- Runs the upstream Bun entrypoint directly:
  - `dist/bun/cli.js`
- Rewrites final executable JS shebangs from Node to Bun for the Bun variant, so the runtime closure does not pull in Node
- Adds `passthru.skipUpdate` support to updater discovery so `pi-bun` is not updated separately from `pi`

## Why a separate package?

`pi-bun` gives users an explicit package to select when they want the Bun runtime, while avoiding duplicated packaging state. The actual source, lockfile, dependency hash, and updater remain owned by `pi`.

This avoids maintaining two independent copies of the same upstream package while still exposing a clear user-facing runtime choice:

```bash
nix run .#pi
nix run .#pi-bun
```

## Validation

- `nix build --accept-flake-config .#pi`
- `nix build --accept-flake-config .#pi-bun`
- `nix build --accept-flake-config .#checks.$system.pkgs-pi`
- `nix build --accept-flake-config .#checks.$system.pkgs-pi-bun`
- `nix build --accept-flake-config .#checks.$system.meta-completeness`
- `nix build --accept-flake-config .#checks.$system.meta-maintainers`
- `nix build --accept-flake-config .#checks.$system.ast-grep`
- `nix build --accept-flake-config .#packages.aarch64-linux.pi-bun --dry-run`
- `nix fmt -- --ci`
- `./result-pi/bin/pi --version`
- `./result-pi-bun/bin/pi --version`
- `./result-pi-bun/bin/pi --help`
- Verified `pi-bun` runtime closure contains Bun and does not pull in Node
- Verified updater discovery selects `pi` and skips `pi-bun`
- Regenerated README package docs