### PR TITLE
open-code-review: init at 1.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>open-code-review</strong> - AI-powered code review CLI — battle-tested at Alibaba's scale. Hybrid architecture: deterministic pipelines + LLM Agent with line-level comments.</summary>
+<summary><strong>open-code-review</strong> - AI-powered code review CLI</summary>
 
 - **Source**: binary
 - **License**: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -870,6 +870,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>open-code-review</strong> - AI-powered code review CLI — battle-tested at Alibaba's scale. Hybrid architecture: deterministic pipelines + LLM Agent with line-level comments.</summary>
+
+- **Source**: binary
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/alibaba/open-code-review
+- **Usage**: `nix run github:numtide/llm-agents.nix#open-code-review -- --help`
+- **Nix**: [packages/open-code-review/package.nix](packages/open-code-review/package.nix)
+
+</details>
+<details>
 <summary><strong>plannotator</strong> - Interactive plan and code review tool for AI coding agents</summary>
 
 - **Source**: source

--- a/packages/open-code-review/default.nix
+++ b/packages/open-code-review/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/open-code-review/hashes.json
+++ b/packages/open-code-review/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.7.6",
+  "hashes": {
+    "x86_64-linux": "sha256-u2ftSG5nzzQZO3IEB5Gr7RNT9lCzYzQpPn0X8Db/Nq8=",
+    "aarch64-linux": "sha256-oTrkLsCJpgVFM8bRpXdHMmU+x5HhwiUh0kPanJ5bAe4=",
+    "x86_64-darwin": "sha256-vCv3OWpBPd2jCBjUrAAgG/RQc/XilhBHWzy8XoWkjXA=",
+    "aarch64-darwin": "sha256-mUt65SGhpArxCxKsaCck83c4V+oM8hIbQZ9CMj7YLic="
+  }
+}

--- a/packages/open-code-review/package.nix
+++ b/packages/open-code-review/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  autoPatchelfHook,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -31,10 +30,7 @@ stdenv.mkDerivation {
     hash = hashes.${platform};
   };
 
-  # Linux binaries are dynamically linked; use autoPatchelfHook to resolve libs.
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-
-  # Mark as prebuilt so Nix doesn't try to unpack an archive.
+  # Upstream releases are single statically linked Go binaries.
   dontUnpack = true;
 
   installPhase = ''
@@ -44,8 +40,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  # Disable installCheck when cross-compiling — can't execute foreign-arch binaries.
-  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  doInstallCheck = true;
   nativeInstallCheckInputs = [
     versionCheckHook
     versionCheckHomeHook
@@ -55,7 +50,7 @@ stdenv.mkDerivation {
   passthru.category = "Code Review";
 
   meta = with lib; {
-    description = "AI-powered code review CLI — battle-tested at Alibaba's scale. Hybrid architecture: deterministic pipelines + LLM Agent with line-level comments.";
+    description = "AI-powered code review CLI";
     homepage = "https://github.com/alibaba/open-code-review";
     changelog = "https://github.com/alibaba/open-code-review/releases/tag/v${version}";
     license = licenses.asl20;

--- a/packages/open-code-review/package.nix
+++ b/packages/open-code-review/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    "x86_64-linux" = "linux-amd64";
+    "aarch64-linux" = "linux-arm64";
+    "x86_64-darwin" = "darwin-amd64";
+    "aarch64-darwin" = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+
+in
+stdenv.mkDerivation {
+  pname = "open-code-review";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/alibaba/open-code-review/releases/download/v${version}/opencodereview-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+
+  # Linux binaries are dynamically linked; use autoPatchelfHook to resolve libs.
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # Mark as prebuilt so Nix doesn't try to unpack an archive.
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m755 $src $out/bin/ocr
+    runHook postInstall
+  '';
+
+  # Disable installCheck when cross-compiling — can't execute foreign-arch binaries.
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "version" ];
+
+  passthru.category = "Code Review";
+
+  meta = with lib; {
+    description = "AI-powered code review CLI — battle-tested at Alibaba's scale. Hybrid architecture: deterministic pipelines + LLM Agent with line-level comments.";
+    homepage = "https://github.com/alibaba/open-code-review";
+    changelog = "https://github.com/alibaba/open-code-review/releases/tag/v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "ocr";
+    maintainers = with maintainers; [ fridh ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/open-code-review/update.py
+++ b/packages/open-code-review/update.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for open-code-review package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+PLATFORMS = {
+    "x86_64-linux": "linux-amd64",
+    "aarch64-linux": "linux-arm64",
+    "x86_64-darwin": "darwin-amd64",
+    "aarch64-darwin": "darwin-arm64",
+}
+
+
+def main() -> None:
+    """Update the open-code-review package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release("alibaba", "open-code-review")
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url_template = f"https://github.com/alibaba/open-code-review/releases/download/v{latest}/opencodereview-{{platform}}"
+    hashes = calculate_platform_hashes(url_template, PLATFORMS)
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add `open-code-review` (Alibaba's AI-powered code review CLI) at v1.7.6.

- Pre-built binary from GitHub releases, installed as `ocr`
- Category: Code Review
- License: Apache 2.0
- Maintainer: @fridh
- Platforms: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin