### PR TITLE
kimi-code: init at 0.23.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>kimi-code</strong> - The Starting Point for Next-Gen Agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/MoonshotAI/kimi-code
+- **Usage**: `nix run github:numtide/llm-agents.nix#kimi-code -- --help`
+- **Nix**: [packages/kimi-code/package.nix](packages/kimi-code/package.nix)
+
+</details>
+<details>
 <summary><strong>letta-code</strong> - Memory-first coding agent that learns and evolves across sessions</summary>
 
 - **Source**: bytecode

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -152,6 +152,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 13460388;
         name = "Hobr";
       };
+      mnixry = {
+        github = "mnixry";
+        githubId = 32300164;
+        name = "Mix";
+      };
     };
   }
 )

--- a/packages/kimi-code/default.nix
+++ b/packages/kimi-code/default.nix
@@ -1,0 +1,10 @@
+{
+  flake,
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/kimi-code/nix-update-args
+++ b/packages/kimi-code/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^@moonshot-ai/kimi-code@([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/kimi-code/package.nix
+++ b/packages/kimi-code/package.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  fd,
+  makeWrapper,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  ripgrep,
+  runCommand,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  pnpm = pnpm_10.override { nodejs-slim = nodejs; };
+
+  pnpmWorkspaces = [
+    "."
+    "@moonshot-ai/acp-adapter"
+    "@moonshot-ai/agent-core"
+    "@moonshot-ai/server"
+    "@moonshot-ai/kaos"
+    "@moonshot-ai/kosong"
+    "@moonshot-ai/migration-legacy"
+    "@moonshot-ai/kimi-code-sdk"
+    "@moonshot-ai/kimi-code-oauth"
+    "@moonshot-ai/pi-tui"
+    "@moonshot-ai/protocol"
+    "@moonshot-ai/kimi-telemetry"
+    "@moonshot-ai/kimi-code"
+    "@moonshot-ai/kimi-web"
+    "@moonshot-ai/vis-server"
+    "@moonshot-ai/vis-web"
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kimi-code";
+  version = "0.23.5";
+
+  src = fetchFromGitHub {
+    owner = "MoonshotAI";
+    repo = "kimi-code";
+    tag = "@moonshot-ai/kimi-code@${finalAttrs.version}";
+    hash = "sha256-WzNNLkgSWs+LyI3iE28GwI9IDLXNieD4qEKx9n1rccI=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm pnpmWorkspaces;
+    fetcherVersion = 3;
+    hash = "sha256-8Dq5rC1/nJpm4VGUKbxBb5fEBTSG9N0IyTOUBNXBxLU=";
+  };
+
+  inherit pnpmWorkspaces;
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    (pnpmConfigHook.override { inherit pnpm; })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter @moonshot-ai/kimi-code build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm config set inject-workspace-packages true
+    pnpm --filter @moonshot-ai/kimi-code --prod --ignore-scripts deploy $out/lib/kimi-code
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/kimi \
+      --add-flags $out/lib/kimi-code/dist/main.mjs \
+      --set KIMI_CODE_NO_AUTO_UPDATE 1 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fd
+          ripgrep
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru = {
+    category = "AI Coding Agents";
+    tests.smoke =
+      runCommand "kimi-code-smoke-test" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+        ''
+          export HOME=$(mktemp -d)
+          grep -F ${lib.getBin fd}/bin ${finalAttrs.finalPackage}/bin/kimi
+          grep -F ${lib.getBin ripgrep}/bin ${finalAttrs.finalPackage}/bin/kimi
+          kimi --version | grep -Fx ${lib.escapeShellArg finalAttrs.version}
+          kimi provider list | grep -Fx "No providers configured."
+          touch $out
+        '';
+  };
+
+  meta = {
+    description = "The Starting Point for Next-Gen Agents";
+    homepage = "https://github.com/MoonshotAI/kimi-code";
+    changelog = "https://github.com/MoonshotAI/kimi-code/releases/tag/%40moonshot-ai%2Fkimi-code%40${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mnixry ];
+    mainProgram = "kimi";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/packages/kimi-code/package.nix
+++ b/packages/kimi-code/package.nix
@@ -6,7 +6,9 @@
   fetchPnpmDeps,
   fd,
   makeWrapper,
+  node-gyp,
   nodejs,
+  python3,
   pnpm_10,
   pnpmConfigHook,
   ripgrep,
@@ -62,6 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pnpm
     (pnpmConfigHook.override { inherit pnpm; })
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # to compile node-pty (see installPhase)
+    node-gyp
+    python3
   ];
 
   buildPhase = ''
@@ -77,6 +84,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     pnpm config set inject-workspace-packages true
     pnpm --filter @moonshot-ai/kimi-code --prod --ignore-scripts deploy $out/lib/kimi-code
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # node-pty ships prebuilds only for darwin/win32 and the deploy above
+      # skips install scripts, so compile the Linux addon here.
+      pushd $out/lib/kimi-code/node_modules/.pnpm/node-pty@*/node_modules/node-pty
+      node-gyp rebuild --nodedir=${nodejs}
+      # keep only the compiled addon
+      find build -mindepth 1 -maxdepth 1 ! -name Release -exec rm -rf {} +
+      find build/Release -mindepth 1 ! -name '*.node' -exec rm -rf {} +
+      popd
+    ''}
 
     mkdir -p $out/bin
     makeWrapper ${nodejs}/bin/node $out/bin/kimi \


### PR DESCRIPTION
## Summary

Init https://github.com/MoonshotAI/kimi-code.

Assisted-By: OpenAI Codex (GPT-5.6 Sol)

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
