### PR TITLE
pi: run with Bun instead of Node

### DIFF
--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildNpmPackage,
+  bun,
   fetchurl,
   fd,
   ripgrep,
@@ -12,6 +13,7 @@
 let
   versionData = lib.importJSON ./hashes.json;
   version = versionData.version;
+  packageRoot = "$out/lib/node_modules/@earendil-works/pi-coding-agent";
 
   # Create a source with package-lock.json included
   srcWithLock = runCommand "pi-src-with-lock" { } ''
@@ -39,16 +41,27 @@ buildNpmPackage {
   # The package from npm is already built
   dontNpmBuild = true;
 
+  # Run upstream's Bun entry point with Bun; keeps Node out of the closure
+  # and adds aarch64-linux support.
   postInstall = ''
-    wrapProgram $out/bin/pi \
+    rm -f "$out/bin/pi"
+
+    makeWrapper ${lib.getExe bun} "$out/bin/pi" \
+      --add-flags "${packageRoot}/dist/bun/cli.js" \
       --prefix PATH : ${
         lib.makeBinPath [
           fd
           ripgrep
         ]
       } \
+      --set PI_PACKAGE_DIR ${packageRoot} \
       --set PI_SKIP_VERSION_CHECK 1 \
       --set PI_TELEMETRY 0
+  '';
+
+  # The npm install hook patches shebangs to Node; point them at Bun instead.
+  postFixup = ''
+    grep -rlE '^#!.*/node$' "$out/lib" | xargs -r sed -i '1s|.*|#!${lib.getExe bun}|'
   '';
 
   doInstallCheck = true;
@@ -66,7 +79,7 @@ buildNpmPackage {
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ aos ];
-    platforms = lib.platforms.all;
+    platforms = bun.meta.platforms;
     mainProgram = "pi";
   };
 }


### PR DESCRIPTION
Make the default `pi` package use Bun instead of Node, as discussed in #6652, but without a separate `pi-bun` package.

- wrap upstream's Bun entry point (`dist/bun/cli.js`) with `bun`, set `PI_PACKAGE_DIR`
- rewrite Node shebangs to Bun so Node is not in the runtime closure
- `platforms = bun.meta.platforms` (adds aarch64-linux)

Tested: `nix build .#pi` + `pi --version` on x86_64-linux; aarch64-linux eval; closure has Bun, no Node.

Supersedes #6652.