### PR TITLE
flake: restore overlays.shared-nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,37 @@ Add to your system configuration:
 > from our [binary cache](#binary-cache) instead of rebuilding everything
 > against your nixpkgs.
 
+### Using Overlay
+
+`overlays.shared-nixpkgs` exposes all packages under the `llm-agents`
+namespace, built against your nixpkgs. Dependencies are shared with the rest
+of your system and your nixpkgs `config` (e.g. `allowUnfreePredicate`)
+applies. The binary cache only hits when your nixpkgs revision matches ours.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    llm-agents.url = "github:numtide/llm-agents.nix";
+  };
+
+  outputs = { nixpkgs, llm-agents, ... }: {
+    # NixOS / nix-darwin configuration
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [({ pkgs, ... }: {
+        nixpkgs.overlays = [ llm-agents.overlays.shared-nixpkgs ];
+        environment.systemPackages = [
+          pkgs.llm-agents.claude-code
+          pkgs.llm-agents.codex
+          pkgs.llm-agents.gemini-cli
+        ];
+      })];
+    };
+  };
+}
+```
+
 ### Try Without Installing
 
 Browse all available tools with the interactive launcher:

--- a/flake.nix
+++ b/flake.nix
@@ -59,12 +59,11 @@
 
       pkgsFor = eachSystem (system: import nixpkgs { inherit system; });
 
-      # Every package under packages/, independent of the current platform.
+      # Every package under packages/, built against the given package set.
       # Cross-package references go through `perSystem.self.<name>`.
-      allPackages = eachSystem (
-        system:
+      mkPackagesFor =
+        pkgs:
         let
-          pkgs = pkgsFor.${system};
           perSystem = {
             self = packages;
           };
@@ -76,13 +75,15 @@
                 perSystem
                 flake
                 inputs
-                system
                 ;
+              system = pkgs.stdenv.hostPlatform.system;
             } (import (./packages + "/${name}"))
           );
         in
-        packages
-      );
+        packages;
+
+      # Every package under packages/, independent of the current platform.
+      allPackages = eachSystem (system: mkPackagesFor pkgsFor.${system});
 
       # Only expose packages that build on the given platform.
       available =
@@ -105,6 +106,10 @@
       lib = import ./lib { inherit inputs; };
 
       inherit packages devShells;
+
+      overlays.shared-nixpkgs = import ./overlays/shared-nixpkgs.nix {
+        inherit mkPackagesFor;
+      };
 
       formatter = eachSystem (system: allPackages.${system}.formatter);
 

--- a/overlays/shared-nixpkgs.nix
+++ b/overlays/shared-nixpkgs.nix
@@ -1,0 +1,9 @@
+{
+  mkPackagesFor,
+}:
+# Builds the packages/ tree against the consumer's `final`, so dependencies
+# are shared with their system. Unlike the flake packages, the binary cache
+# only hits when the consumer's nixpkgs revision matches ours.
+final: _prev: {
+  llm-agents = mkPackagesFor final;
+}

--- a/packages/buildNpmPackage/default.nix
+++ b/packages/buildNpmPackage/default.nix
@@ -9,8 +9,8 @@
 #
 # The guard fires for every consumption path that swaps out nixpkgs
 # (overlays.shared-nixpkgs, `inputs.llm-agents.inputs.nixpkgs.follows`, direct
-# callPackage), because blueprint builds perSystem.self against whatever `pkgs`
-# is in effect.
+# callPackage), because perSystem.self is built against whatever `pkgs` is in
+# effect.
 let
   inherit (pkgs) lib;
   hasFetcherVersion = (lib.functionArgs pkgs.fetchNpmDeps) ? fetcherVersion;
@@ -22,8 +22,8 @@ let
     likely on nixos-25.11 or an early-2026 unstable via
     `overlays.shared-nixpkgs` or `inputs.llm-agents.inputs.nixpkgs.follows`.
 
-    Either use `overlays.default` / the flake packages directly, or bump
-    nixpkgs to at least 203662a570c4 (2026-02-15). See
+    Either use the flake packages directly, or bump nixpkgs to at least
+    203662a570c4 (2026-02-15). See
     https://github.com/numtide/llm-agents.nix/issues/4320.
   '';
 in


### PR DESCRIPTION
---

The blueprint removal (b195286b) dropped both overlay outputs and pointed consumers at `packages.${system}`. That path has two costs for NixOS/nix-darwin users:

- a second nixpkgs instance is evaluated per host
- the consumer's nixpkgs `config` is bypassed, so predicates like `allowUnfreePredicate` or `allowNonSourcePredicate` no longer apply to these packages

The new in-tree auto-import already has all the wiring needed. This extracts it into `mkPackagesFor` and rebuilds the `shared-nixpkgs` overlay on top of it, with the same interface as before (`pkgs.llm-agents.<name>`). `overlays.default` stays gone, it offered nothing over using the flake packages directly.

Also updates the `buildNpmPackage` guard message that still pointed to `overlays.default`, and restores the README section for the overlay.

Tested:

- `nix eval .#packages.x86_64-linux.pi.drvPath` / `.#packages.x86_64-linux.tuicr.drvPath`
- `nix eval .#checks.x86_64-linux --apply builtins.attrNames`
- overlay applied to a fresh `import nixpkgs`, evaluating `pkgs.llm-agents.pi.drvPath` and `pkgs.llm-agents.tuicr.drvPath`
- `nix fmt` (no changes)
