### PR TITLE
Improve hermes-agent managed via nix

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -328,6 +328,13 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_OPTIONAL_SKILLS"
     "${placeholder "out"}/share/hermes/optional-skills"
+    # Mark as package-manager-managed so `hermes update` refuses with the
+    # NixOS-specific error (is_managed() in hermes_cli/config.py reads
+    # HERMES_MANAGED and maps "nixos" → "NixOS"). Prevents the in-place
+    # git-pull updater from clobbering the Nix-managed store path.
+    "--set"
+    "HERMES_MANAGED"
+    "nixos"
     # Disable runtime pip installs; absent extras disable cleanly.
     "--set"
     "HERMES_DISABLE_LAZY_INSTALLS"
@@ -397,6 +404,7 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
     grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
+    grep -q HERMES_MANAGED $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
     test -d $out/share/hermes/skills

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -318,20 +318,14 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
-    # Bundled skills live outside the Python package tree (setup.py
-    # data_files). setuptools drops setup.py data_files when pyproject.toml
-    # declares [tool.setuptools.data-files], so postInstall copies them
-    # manually and the wrapper points hermes at the installed copy.
+    # Skills are copied to $out/share/hermes in postInstall; point hermes at them.
     "--set"
     "HERMES_BUNDLED_SKILLS"
     "${placeholder "out"}/share/hermes/skills"
     "--set"
     "HERMES_OPTIONAL_SKILLS"
     "${placeholder "out"}/share/hermes/optional-skills"
-    # Mark as package-manager-managed so `hermes update` refuses with the
-    # NixOS-specific error (is_managed() in hermes_cli/config.py reads
-    # HERMES_MANAGED and maps "nixos" → "NixOS"). Prevents the in-place
-    # git-pull updater from clobbering the Nix-managed store path.
+    # Prevent `hermes update` from trying to modify the Nix store.
     "--set"
     "HERMES_MANAGED"
     "nixos"
@@ -346,12 +340,8 @@ python3.pkgs.buildPythonApplication {
     "${nodejs}/bin"
   ];
 
-  # setup.py declares skills/ and optional-skills/ as data_files, but
-  # pyproject.toml's [tool.setuptools.data-files] takes precedence and
-  # silently drops them from the wheel. Copy the trees from source so
-  # get_bundled_skills_dir / get_optional_skills_dir (hermes_constants.py)
-  # resolve via the HERMES_BUNDLED_SKILLS / HERMES_OPTIONAL_SKILLS env vars
-  # set in makeWrapperArgs.
+  # Skills are shipped as setup.py data_files, which the wheel build drops;
+  # install them manually.
   postInstall = ''
     mkdir -p $out/share/hermes
     cp -r ${src}/skills $out/share/hermes/skills

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -318,6 +318,16 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
+    # Bundled skills live outside the Python package tree (setup.py
+    # data_files). setuptools drops setup.py data_files when pyproject.toml
+    # declares [tool.setuptools.data-files], so postInstall copies them
+    # manually and the wrapper points hermes at the installed copy.
+    "--set"
+    "HERMES_BUNDLED_SKILLS"
+    "${placeholder "out"}/share/hermes/skills"
+    "--set"
+    "HERMES_OPTIONAL_SKILLS"
+    "${placeholder "out"}/share/hermes/optional-skills"
     # Disable runtime pip installs; absent extras disable cleanly.
     "--set"
     "HERMES_DISABLE_LAZY_INSTALLS"
@@ -328,6 +338,18 @@ python3.pkgs.buildPythonApplication {
     ":"
     "${nodejs}/bin"
   ];
+
+  # setup.py declares skills/ and optional-skills/ as data_files, but
+  # pyproject.toml's [tool.setuptools.data-files] takes precedence and
+  # silently drops them from the wheel. Copy the trees from source so
+  # get_bundled_skills_dir / get_optional_skills_dir (hermes_constants.py)
+  # resolve via the HERMES_BUNDLED_SKILLS / HERMES_OPTIONAL_SKILLS env vars
+  # set in makeWrapperArgs.
+  postInstall = ''
+    mkdir -p $out/share/hermes
+    cp -r ${src}/skills $out/share/hermes/skills
+    cp -r ${src}/optional-skills $out/share/hermes/optional-skills
+  '';
 
   pythonRelaxDeps = [
     "openai"
@@ -373,8 +395,12 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_WEB_DIST $out/bin/hermes
     grep -q HERMES_PYTHON $out/bin/hermes
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
+    grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
+    grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
+    test -d $out/share/hermes/skills
+    test -d $out/share/hermes/optional-skills
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
## Summary

Enable `HERMES_MANAGED` so hermes doesn't try to self update.
It also installs and sets the required environment variables to make the bundeled skill available to hermes.


## Test plan

1. `hermes update` fails with a clear error message
2. Bundled skills are available in hermes

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

