### PR TITLE
ctx: init at 0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,6 +1225,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>ctx</strong> - Search the coding agent history already on your machine</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/ctxrs/ctx
+- **Usage**: `nix run github:numtide/llm-agents.nix#ctx -- --help`
+- **Nix**: [packages/ctx/package.nix](packages/ctx/package.nix)
+
+</details>
+<details>
 <summary><strong>git-surgeon</strong> - Git primitives for autonomous coding agents</summary>
 
 - **Source**: source

--- a/packages/ctx/default.nix
+++ b/packages/ctx/default.nix
@@ -1,0 +1,10 @@
+{
+  pkgs,
+  perSystem,
+  flake,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit flake;
+  inherit (perSystem.self) versionCheckHomeHook;
+}

--- a/packages/ctx/package.nix
+++ b/packages/ctx/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  flake,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  stdenv,
+  libiconv,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ctx";
+  version = "0.25.0";
+
+  src = fetchFromGitHub {
+    owner = "ctxrs";
+    repo = "ctx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BaZvBlRE8PkUgacWDoNhR14YoenfKKKAoCZQUrv6TQk=";
+  };
+
+  cargoHash = "sha256-aOd7zN8U2w/nkoTxUUDrllngtUWZ/3KhGYIAJDa5F5w=";
+
+  cargoBuildFlags = [
+    "--package"
+    "ctx"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  # CoreML acquisition tests fail in Nix sandbox.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "Search the coding agent history already on your machine";
+    homepage = "https://github.com/ctxrs/ctx";
+    changelog = "https://github.com/ctxrs/ctx/releases/tag/v${finalAttrs.version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mulatta ];
+    mainProgram = "ctx";
+    platforms = platforms.unix;
+  };
+})

--- a/packages/ctx/package.nix
+++ b/packages/ctx/package.nix
@@ -3,10 +3,6 @@
   fetchFromGitHub,
   flake,
   rustPlatform,
-  pkg-config,
-  openssl,
-  stdenv,
-  libiconv,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -29,12 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "ctx"
   ];
 
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
-
-  cargoTestFlags = finalAttrs.cargoBuildFlags;
-
   # CoreML acquisition tests fail in Nix sandbox.
   doCheck = false;
 
@@ -46,14 +36,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.category = "Utilities";
 
-  meta = with lib; {
+  meta = {
     description = "Search the coding agent history already on your machine";
     homepage = "https://github.com/ctxrs/ctx";
     changelog = "https://github.com/ctxrs/ctx/releases/tag/v${finalAttrs.version}";
-    license = licenses.asl20;
-    sourceProvenance = with sourceTypes; [ fromSource ];
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ mulatta ];
     mainProgram = "ctx";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Summary

Add [ctx](https://github.com/ctxrs/ctx), a local CLI for searching coding-agent history already on your machine. It is packaged from source with `rustPlatform.buildRustPackage`, uses the upstream `v0.25.0` tag, and is categorized under Utilities.

## Test plan

- [x] `nix build .#ctx` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
