### PR TITLE
kimi-code: 0.23.6 -> 0.24.1

### DIFF
--- a/packages/kimi-code/package.nix
+++ b/packages/kimi-code/package.nix
@@ -19,45 +19,24 @@
 
 let
   pnpm = pnpm_10.override { nodejs-slim = nodejs; };
-
-  pnpmWorkspaces = [
-    "."
-    "@moonshot-ai/acp-adapter"
-    "@moonshot-ai/agent-core"
-    "@moonshot-ai/server"
-    "@moonshot-ai/kaos"
-    "@moonshot-ai/kosong"
-    "@moonshot-ai/migration-legacy"
-    "@moonshot-ai/kimi-code-sdk"
-    "@moonshot-ai/kimi-code-oauth"
-    "@moonshot-ai/pi-tui"
-    "@moonshot-ai/protocol"
-    "@moonshot-ai/kimi-telemetry"
-    "@moonshot-ai/kimi-code"
-    "@moonshot-ai/kimi-web"
-    "@moonshot-ai/vis-server"
-    "@moonshot-ai/vis-web"
-  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "kimi-code";
-  version = "0.23.6";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "MoonshotAI";
     repo = "kimi-code";
     tag = "@moonshot-ai/kimi-code@${finalAttrs.version}";
-    hash = "sha256-bPVXVJ3+dNzSqSYvSEWDwFOtlZ8zN41AjqI41ulLBmc=";
+    hash = "sha256-Z+lSklmYrdf+6oaUXXKZn6tdPNhxTNizUreDwOumWgo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    inherit pnpm pnpmWorkspaces;
+    inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-8Dq5rC1/nJpm4VGUKbxBb5fEBTSG9N0IyTOUBNXBxLU=";
+    hash = "sha256-dqniDBWjKjtTcr+zKhtilkKXdNMfiwnfrqH/7Cg4eZ0=";
   };
-
-  inherit pnpmWorkspaces;
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
## Summary

https://github.com/MoonshotAI/kimi-code/releases/tag/%40moonshot-ai%2Fkimi-code%400.24.1

Closes #6811 

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
