### PR TITLE
updater: fail hard when dependency hash calculation fails

### DIFF
--- a/packages/agentsview/update.py
+++ b/packages/agentsview/update.py
@@ -11,15 +11,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 
@@ -77,27 +76,9 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    try:
-        print("Calculating npmDepsHash...")
-        npm_deps_hash = calculate_dependency_hash(
-            ".#agentsview", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error calculating npmDepsHash: {e}")
-        return
+    update_dependency_hash(".#agentsview", "npmDepsHash", HASHES_FILE, data)
 
-    try:
-        print("Calculating vendorHash...")
-        vendor_hash = calculate_dependency_hash(
-            ".#agentsview", "vendorHash", HASHES_FILE, data
-        )
-        data["vendorHash"] = vendor_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error calculating vendorHash: {e}")
-        return
+    update_dependency_hash(".#agentsview", "vendorHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/beads-rust/update.py
+++ b/packages/beads-rust/update.py
@@ -16,13 +16,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     fetch_json,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
@@ -92,12 +92,8 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Recalculate cargoHash via dummy-hash build
-    cargo_hash = calculate_dependency_hash(
-        ".#beads-rust", "cargoHash", HASHES_FILE, data
-    )
-    data["cargoHash"] = cargo_hash
+    update_dependency_hash(".#beads-rust", "cargoHash", HASHES_FILE, data)
 
-    save_hashes(HASHES_FILE, data)
     print(f"Updated beads-rust to {latest}")
 
 

--- a/packages/cc-sdd/update.py
+++ b/packages/cc-sdd/update.py
@@ -9,14 +9,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     fetch_github_latest_release,
     load_hashes,
-    save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError, nix_prefetch_url
+from updater.nix import nix_prefetch_url
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -51,15 +50,7 @@ def main() -> None:
     }
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#cc-sdd", "npmDepsHash", HASHES_FILE, new_data
-        )
-        new_data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, new_data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#cc-sdd", "npmDepsHash", HASHES_FILE, new_data)
 
     print(f"Updated to {latest}")
 

--- a/packages/cli-proxy-api/update.py
+++ b/packages/cli-proxy-api/update.py
@@ -9,15 +9,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 
@@ -46,15 +45,7 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    try:
-        vendor_hash = calculate_dependency_hash(
-            ".#cli-proxy-api", "vendorHash", HASHES_FILE, data
-        )
-        data["vendorHash"] = vendor_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#cli-proxy-api", "vendorHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/codex/update.py
+++ b/packages/codex/update.py
@@ -15,7 +15,6 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_platform_hashes,
     calculate_url_hash,
     fetch_github_latest_release,
@@ -23,9 +22,9 @@ from updater import (
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 
@@ -144,15 +143,7 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    try:
-        cargo_hash = calculate_dependency_hash(
-            ".#codex", "cargoHash", HASHES_FILE, data
-        )
-        data["cargoHash"] = cargo_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#codex", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/copilot-language-server/update.py
+++ b/packages/copilot-language-server/update.py
@@ -9,16 +9,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
-    save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -53,15 +51,9 @@ def main() -> None:
     }
 
     # Calculate npmDepsHash - only save if successful
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#copilot-language-server", "npmDepsHash", HASHES_FILE, new_data
-        )
-        new_data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, new_data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(
+        ".#copilot-language-server", "npmDepsHash", HASHES_FILE, new_data
+    )
 
     print(f"Updated to {latest}")
 

--- a/packages/crush/update.py
+++ b/packages/crush/update.py
@@ -9,15 +9,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 
@@ -46,15 +45,7 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    try:
-        vendor_hash = calculate_dependency_hash(
-            ".#crush", "vendorHash", HASHES_FILE, data
-        )
-        data["vendorHash"] = vendor_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#crush", "vendorHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/goose-cli/update.py
+++ b/packages/goose-cli/update.py
@@ -16,7 +16,6 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_platform_hashes,
     calculate_url_hash,
     fetch_github_latest_release,
@@ -24,9 +23,9 @@ from updater import (
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 # Upstream moved from block/goose to aaif-goose/goose.
@@ -96,14 +95,7 @@ def main() -> None:
     update_librusty_v8(data, latest)
     save_hashes(HASHES_FILE, data)
 
-    try:
-        data["cargoHash"] = calculate_dependency_hash(
-            ".#goose-cli", "cargoHash", HASHES_FILE, data
-        )
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        sys.exit(1)
-    save_hashes(HASHES_FILE, data)
+    update_dependency_hash(".#goose-cli", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/happy-coder/update.py
+++ b/packages/happy-coder/update.py
@@ -17,12 +17,11 @@ from typing import Any, cast
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     fetch_json,
     fetch_npm_version,
     load_hashes,
-    save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.nix import nix_command
 
@@ -97,13 +96,7 @@ def main() -> None:
         "pnpmDepsHash": data.get("pnpmDepsHash", ""),
     }
 
-    new_data["pnpmDepsHash"] = calculate_dependency_hash(
-        ".#happy-coder",
-        "pnpmDepsHash",
-        HASHES_FILE,
-        new_data,
-    )
-    save_hashes(HASHES_FILE, new_data)
+    update_dependency_hash(".#happy-coder", "pnpmDepsHash", HASHES_FILE, new_data)
     print(f"Updated to {latest}")
 
 

--- a/packages/herdr/update.py
+++ b/packages/herdr/update.py
@@ -16,15 +16,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_platform_hashes,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
-from updater.nix import NixCommandError, run_command
+from updater.nix import run_command
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 FLAKE_ROOT = Path(__file__).parent.parent.parent
@@ -83,17 +83,7 @@ def main() -> None:
 
     update_vendored_zig_deps(latest)
 
-    try:
-        data["cargoHash"] = calculate_dependency_hash(
-            ".#herdr",
-            "cargoHash",
-            HASHES_FILE,
-            data,
-        )
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#herdr", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated herdr to {latest}")
 

--- a/packages/icm/update.py
+++ b/packages/icm/update.py
@@ -26,16 +26,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     regenerate_bun_nix,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 PKG_DIR = Path(__file__).parent
 FLAKE_ROOT = PKG_DIR.parent.parent
@@ -176,13 +175,7 @@ def main() -> None:
 
     # Step 3: Calculate cargoHash
     print("Calculating cargoHash...")
-    try:
-        cargo_hash = calculate_dependency_hash(".#icm", "cargoHash", HASHES_FILE, data)
-        data["cargoHash"] = cargo_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#icm", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated icm to {latest}")
 

--- a/packages/iflow-cli/update.py
+++ b/packages/iflow-cli/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -59,17 +58,7 @@ def main() -> None:
 
     # Calculate npmDepsHash
     print("Calculating npm dependencies hash...")
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#iflow-cli", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-        print(f"npmDepsHash: {npm_deps_hash}")
-    except (ValueError, NixCommandError) as e:
-        print(f"Error calculating npmDepsHash: {e}")
-        print("You may need to manually update the npmDepsHash")
-        return
+    update_dependency_hash(".#iflow-cli", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/letta-code/update.py
+++ b/packages/letta-code/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -59,15 +58,7 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#letta-code", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#letta-code", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/oh-my-codex/update.py
+++ b/packages/oh-my-codex/update.py
@@ -9,15 +9,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 
@@ -49,30 +48,14 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    try:
-        cargo_hash = calculate_dependency_hash(
-            ".#oh-my-codex.native.exploreHarness",
-            "cargoHash",
-            HASHES_FILE,
-            data,
-        )
-        data["cargoHash"] = cargo_hash
-        save_hashes(HASHES_FILE, data)
+    update_dependency_hash(
+        ".#oh-my-codex.native.exploreHarness", "cargoHash", HASHES_FILE, data
+    )
 
-        data["npmDepsHash"] = DUMMY_SHA256_HASH
-        save_hashes(HASHES_FILE, data)
+    data["npmDepsHash"] = DUMMY_SHA256_HASH
+    save_hashes(HASHES_FILE, data)
 
-        npm_deps_hash = calculate_dependency_hash(
-            ".#oh-my-codex",
-            "npmDepsHash",
-            HASHES_FILE,
-            data,
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#oh-my-codex", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/oh-my-opencode/update.py
+++ b/packages/oh-my-opencode/update.py
@@ -5,7 +5,7 @@
 
 Custom updater needed because oh-my-opencode uses bun2nix (bun.nix must be
 regenerated from upstream bun.lock) and fetches submodules, so the source
-hash is recovered from a failed build via calculate_dependency_hash
+hash is recovered from a failed build via update_dependency_hash
 instead of nix-prefetch-url.
 """
 
@@ -15,13 +15,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     clone_and_generate_bun_nix,
     fetch_github_latest_release,
     load_hashes,
     save_hashes,
     should_update,
     strip_workspace_entries,
+    update_dependency_hash,
 )
 
 PKG_DIR = Path(__file__).parent
@@ -67,15 +67,7 @@ def main() -> None:
     # Step 3: Source hash. nix-prefetch-url can't be used because the
     # GitHub tarball excludes submodule contents.
     print("Calculating source hash (with submodules)...")
-    src_hash = calculate_dependency_hash(
-        package_attr=".#oh-my-opencode",
-        hash_key="hash",
-        hashes_file=HASHES_FILE,
-        data=data,
-    )
-    data["hash"] = src_hash
-    save_hashes(HASHES_FILE, data)
-    print(f"  source hash: {src_hash}")
+    update_dependency_hash(".#oh-my-opencode", "hash", HASHES_FILE, data)
 
     print(f"Updated oh-my-opencode to {latest}")
 

--- a/packages/omp/update.py
+++ b/packages/omp/update.py
@@ -14,7 +14,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     clone_and_generate_bun_nix,
     fetch_github_latest_release,
@@ -22,9 +21,9 @@ from updater import (
     save_hashes,
     should_update,
     strip_workspace_entries,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 PKG_DIR = Path(__file__).parent
 FLAKE_ROOT = PKG_DIR.parent.parent
@@ -73,13 +72,7 @@ def main() -> None:
     strip_workspace_entries(BUN_NIX, "@oh-my-pi", FLAKE_ROOT)
 
     # Step 3: Calculate cargoHash
-    try:
-        cargo_hash = calculate_dependency_hash(".#omp", "cargoHash", HASHES_FILE, data)
-        data["cargoHash"] = cargo_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#omp", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated omp to {latest}")
 

--- a/packages/openspec/update.py
+++ b/packages/openspec/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -54,15 +53,7 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#openspec", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#openspec", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/openspecui/update.py
+++ b/packages/openspecui/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -63,15 +62,7 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#openspecui", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#openspecui", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/pi/update.py
+++ b/packages/pi/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -56,15 +55,7 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#pi", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    update_dependency_hash(".#pi", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/packages/sandbox-runtime/update.py
+++ b/packages/sandbox-runtime/update.py
@@ -9,16 +9,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
-    save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -55,15 +53,7 @@ def main() -> None:
     }
 
     # Calculate npmDepsHash - only save if successful
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#sandbox-runtime", "npmDepsHash", HASHES_FILE, new_data
-        )
-        new_data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, new_data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#sandbox-runtime", "npmDepsHash", HASHES_FILE, new_data)
 
     print(f"Updated to {latest}")
 

--- a/packages/vibe-kanban/update.py
+++ b/packages/vibe-kanban/update.py
@@ -16,15 +16,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     fetch_json,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 OWNER = "BloopAI"
@@ -68,17 +67,9 @@ def main() -> None:
     save_hashes(HASHES_FILE, new_data)
 
     # cargoHash and npmDepsHash both fall out of FOD build failures, so
-    # let calculate_dependency_hash trigger them sequentially.
-    try:
-        for key in ("cargoHash", "npmDepsHash"):
-            print(f"Calculating {key}...")
-            new_data[key] = calculate_dependency_hash(
-                ".#vibe-kanban", key, HASHES_FILE, new_data
-            )
-            save_hashes(HASHES_FILE, new_data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    # trigger them sequentially.
+    for key in ("cargoHash", "npmDepsHash"):
+        update_dependency_hash(".#vibe-kanban", key, HASHES_FILE, new_data)
 
     print(f"Updated to {latest} (tag {tag})")
 

--- a/packages/zaly/update.py
+++ b/packages/zaly/update.py
@@ -9,16 +9,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_dependency_hash,
     calculate_url_hash,
     extract_or_generate_lockfile,
     fetch_npm_version,
     load_hashes,
     save_hashes,
     should_update,
+    update_dependency_hash,
 )
 from updater.hash import DUMMY_SHA256_HASH
-from updater.nix import NixCommandError
 
 SCRIPT_DIR = Path(__file__).parent
 HASHES_FILE = SCRIPT_DIR / "hashes.json"
@@ -60,15 +59,7 @@ def main() -> None:
     save_hashes(HASHES_FILE, data)
 
     # Calculate npmDepsHash
-    try:
-        npm_deps_hash = calculate_dependency_hash(
-            ".#zaly", "npmDepsHash", HASHES_FILE, data
-        )
-        data["npmDepsHash"] = npm_deps_hash
-        save_hashes(HASHES_FILE, data)
-    except (ValueError, NixCommandError) as e:
-        print(f"Error: {e}")
-        return
+    update_dependency_hash(".#zaly", "npmDepsHash", HASHES_FILE, data)
 
     print(f"Updated to {latest}")
 

--- a/scripts/updater/__init__.py
+++ b/scripts/updater/__init__.py
@@ -12,7 +12,7 @@ from .bun import (
 )
 
 # Dependency hash calculation
-from .deps import calculate_dependency_hash
+from .deps import calculate_dependency_hash, update_dependency_hash
 
 # Hash utilities
 from .hash import calculate_url_hash
@@ -63,4 +63,5 @@ __all__ = [
     "save_hashes",
     "should_update",
     "strip_workspace_entries",
+    "update_dependency_hash",
 ]

--- a/scripts/updater/deps.py
+++ b/scripts/updater/deps.py
@@ -61,3 +61,32 @@ def calculate_dependency_hash(
             msg = f"Could not extract hash from build error:\n{e.args[0]}"
             raise ValueError(msg) from e
         return dep_hash
+
+
+def update_dependency_hash(
+    package_attr: str,
+    hash_key: str,
+    hashes_file: Path,
+    data: dict[str, Any],
+) -> None:
+    """Calculate a dependency hash and persist it to the hashes file.
+
+    Wraps calculate_dependency_hash so every updater fails the same way:
+    on error the process exits non-zero, which stops CI from committing a
+    placeholder hash and opening a broken update PR.
+
+    Args:
+        package_attr: Nix package attribute (e.g., ".#codex")
+        hash_key: Key in data dict for the hash (e.g., "cargoHash")
+        hashes_file: Path to hashes.json file
+        data: Dictionary containing package data (updated in place)
+
+    """
+    try:
+        data[hash_key] = calculate_dependency_hash(
+            package_attr, hash_key, hashes_file, data
+        )
+        save_hashes(hashes_file, data)
+    except (ValueError, NixCommandError) as e:
+        msg = f"Error calculating {hash_key} for {package_attr}: {e}"
+        raise SystemExit(msg) from e


### PR DESCRIPTION
Update scripts caught hash calculation errors, printed them and returned with exit code 0. The dummy hash was already written to hashes.json, so CI committed the placeholder and opened broken PRs (e.g. #6942).

- add `updater.update_dependency_hash`: calculate, save, exit non-zero on failure
- use it in all update.py scripts, dropping the per-script try/except

Testing: ruff check/format, mypy, py_compile of all update.py.