### PR TITLE
updater: extract shared update flows to deduplicate update scripts

### DIFF
--- a/packages/backlog-md/update.py
+++ b/packages/backlog-md/update.py
@@ -3,9 +3,8 @@
 
 """Update script for backlog-md package.
 
-Custom updater needed because backlog-md uses bun2nix: after each version
-bump the bun.nix lockfile must be regenerated from the upstream bun.lock
-using the bun2nix CLI.
+Custom updater needed because backlog-md uses bun2nix: after each version bump the
+bun.nix lockfile must be regenerated from the upstream bun.lock.
 """
 
 import sys
@@ -13,60 +12,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    clone_and_generate_bun_nix,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_bun_github
+
+update_bun_github(
+    Path(__file__).parent,
+    "MrLesk",
+    "Backlog.md",
 )
-from updater.nix import nix_prefetch_url
-
-PKG_DIR = Path(__file__).parent
-FLAKE_ROOT = PKG_DIR.parent.parent
-HASHES_FILE = PKG_DIR / "hashes.json"
-BUN_NIX = PKG_DIR / "bun.nix"
-
-OWNER = "MrLesk"
-REPO = "Backlog.md"
-
-
-def main() -> None:
-    """Update the backlog-md package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release(OWNER, REPO)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating backlog-md from {current} to {latest}")
-
-    # Step 1: Calculate new source hash
-    print("Calculating source hash...")
-    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
-    src_hash = nix_prefetch_url(url, unpack=True)
-    print(f"  source hash: {src_hash}")
-
-    # Step 2: Update hashes.json
-    save_hashes(HASHES_FILE, {"version": latest, "hash": src_hash})
-    print("Updated hashes.json")
-
-    # Step 3: Regenerate bun.nix from upstream bun.lock
-    clone_and_generate_bun_nix(
-        OWNER,
-        REPO,
-        latest,
-        BUN_NIX,
-        FLAKE_ROOT,
-        ref_prefix="v",
-    )
-
-    print(f"Updated backlog-md to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/catnip/update.py
+++ b/packages/catnip/update.py
@@ -1,49 +1,23 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for catnip package."""
+"""Update script for catnip package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_github_latest_release, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_github_latest_release("wandb", "catnip"),
+    url_template="https://github.com/wandb/catnip/releases/download/v{version}/catnip_{version}_{platform}.tar.gz",
+    platforms={
+        "x86_64-linux": "linux_amd64",
+        "aarch64-linux": "linux_arm64",
+        "x86_64-darwin": "darwin_amd64",
+        "aarch64-darwin": "darwin_arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux_amd64",
-    "aarch64-linux": "linux_arm64",
-    "x86_64-darwin": "darwin_amd64",
-    "aarch64-darwin": "darwin_arm64",
-}
-
-
-def main() -> None:
-    """Update the catnip package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("wandb", "catnip")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"https://github.com/wandb/catnip/releases/download/v{latest}/catnip_{latest}_{{platform}}.tar.gz"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/cli-proxy-api/update.py
+++ b/packages/cli-proxy-api/update.py
@@ -8,47 +8,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_github_source
+
+update_github_source(
+    Path(__file__).parent,
+    "router-for-me",
+    "CLIProxyAPI",
+    ".#cli-proxy-api",
+    "vendorHash",
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-
-def main() -> None:
-    """Update the cli-proxy-api package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("router-for-me", "CLIProxyAPI")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url = f"https://github.com/router-for-me/CLIProxyAPI/archive/refs/tags/v{latest}.tar.gz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(url, unpack=True)
-
-    data = {
-        "version": latest,
-        "hash": source_hash,
-        "vendorHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    update_dependency_hash(".#cli-proxy-api", "vendorHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/coderabbit-cli/update.py
+++ b/packages/coderabbit-cli/update.py
@@ -1,56 +1,25 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for coderabbit-cli package."""
+"""Update script for coderabbit-cli package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_text,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_text, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_text(
+        "https://cli.coderabbit.ai/releases/latest/VERSION"
+    ).strip(),
+    url_template="https://cli.coderabbit.ai/releases/{version}/coderabbit-{platform}.zip",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-x64",
+        "aarch64-darwin": "darwin-arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux-x64",
-    "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
-    "aarch64-darwin": "darwin-arm64",
-}
-
-
-def fetch_version() -> str:
-    """Fetch the latest version from CodeRabbit's VERSION endpoint."""
-    return fetch_text("https://cli.coderabbit.ai/releases/latest/VERSION").strip()
-
-
-def main() -> None:
-    """Update the coderabbit-cli package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_version()
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = (
-        f"https://cli.coderabbit.ai/releases/{latest}/coderabbit-{{platform}}.zip"
-    )
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/crush/update.py
+++ b/packages/crush/update.py
@@ -8,47 +8,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_github_source
+
+update_github_source(
+    Path(__file__).parent,
+    "charmbracelet",
+    "crush",
+    ".#crush",
+    "vendorHash",
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-
-def main() -> None:
-    """Update the crush package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("charmbracelet", "crush")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url = f"https://github.com/charmbracelet/crush/archive/refs/tags/v{latest}.tar.gz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(url, unpack=True)
-
-    data = {
-        "version": latest,
-        "hash": source_hash,
-        "vendorHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    update_dependency_hash(".#crush", "vendorHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/cubic/update.py
+++ b/packages/cubic/update.py
@@ -1,58 +1,25 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for cubic package."""
+"""Update script for cubic package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_text,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_text, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_text(
+        "https://mcafvrhahbqdwfrtncql.supabase.co/storage/v1/object/public/releases/latest.txt"
+    ).strip(),
+    url_template="https://mcafvrhahbqdwfrtncql.supabase.co/storage/v1/object/public/releases/v{version}/cubic-{platform}.zip",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-x64",
+        "aarch64-darwin": "darwin-arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-STORAGE_URL = (
-    "https://mcafvrhahbqdwfrtncql.supabase.co/storage/v1/object/public/releases"
-)
-
-PLATFORMS = {
-    "x86_64-linux": "linux-x64",
-    "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
-    "aarch64-darwin": "darwin-arm64",
-}
-
-
-def fetch_version() -> str:
-    """Fetch the latest version from cubic's release manifest."""
-    return fetch_text(f"{STORAGE_URL}/latest.txt").strip()
-
-
-def main() -> None:
-    """Update the cubic package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_version()
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"{STORAGE_URL}/v{latest}/cubic-{{platform}}.zip"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/forgecode/update.py
+++ b/packages/forgecode/update.py
@@ -1,49 +1,23 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for forgecode package."""
+"""Update script for forgecode package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_github_latest_release, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_github_latest_release("tailcallhq", "forgecode"),
+    url_template="https://github.com/tailcallhq/forgecode/releases/download/v{version}/forge-{platform}",
+    platforms={
+        "x86_64-linux": "x86_64-unknown-linux-gnu",
+        "aarch64-linux": "aarch64-unknown-linux-gnu",
+        "x86_64-darwin": "x86_64-apple-darwin",
+        "aarch64-darwin": "aarch64-apple-darwin",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "x86_64-unknown-linux-gnu",
-    "aarch64-linux": "aarch64-unknown-linux-gnu",
-    "x86_64-darwin": "x86_64-apple-darwin",
-    "aarch64-darwin": "aarch64-apple-darwin",
-}
-
-
-def main() -> None:
-    """Update the forgecode package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("tailcallhq", "forgecode")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"https://github.com/tailcallhq/forgecode/releases/download/v{latest}/forge-{{platform}}"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/gno/update.py
+++ b/packages/gno/update.py
@@ -3,9 +3,8 @@
 
 """Update script for gno package.
 
-Custom updater needed because gno uses bun2nix: after each version
-bump the bun.nix lockfile must be regenerated from the upstream bun.lock
-using the bun2nix CLI.
+Custom updater needed because gno uses bun2nix: after each version bump the
+bun.nix lockfile must be regenerated from the upstream bun.lock.
 """
 
 import sys
@@ -13,60 +12,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    clone_and_generate_bun_nix,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_bun_github
+
+update_bun_github(
+    Path(__file__).parent,
+    "gmickel",
+    "gno",
 )
-from updater.nix import nix_prefetch_url
-
-PKG_DIR = Path(__file__).parent
-FLAKE_ROOT = PKG_DIR.parent.parent
-HASHES_FILE = PKG_DIR / "hashes.json"
-BUN_NIX = PKG_DIR / "bun.nix"
-
-OWNER = "gmickel"
-REPO = "gno"
-
-
-def main() -> None:
-    """Update the gno package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release(OWNER, REPO)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating gno from {current} to {latest}")
-
-    # Step 1: Calculate new source hash
-    print("Calculating source hash...")
-    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
-    src_hash = nix_prefetch_url(url, unpack=True)
-    print(f"  source hash: {src_hash}")
-
-    # Step 2: Update hashes.json
-    save_hashes(HASHES_FILE, {"version": latest, "hash": src_hash})
-    print("Updated hashes.json")
-
-    # Step 3: Regenerate bun.nix from upstream bun.lock
-    clone_and_generate_bun_nix(
-        OWNER,
-        REPO,
-        latest,
-        BUN_NIX,
-        FLAKE_ROOT,
-        ref_prefix="v",
-    )
-
-    print(f"Updated gno to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/grok/update.py
+++ b/packages/grok/update.py
@@ -1,49 +1,24 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for grok package."""
+"""Update script for grok package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_text,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_text, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_text(
+        "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable"
+    ).strip(),
+    url_template="https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-{version}-{platform}",
+    platforms={
+        "x86_64-linux": "linux-x86_64",
+        "aarch64-linux": "linux-aarch64",
+        "aarch64-darwin": "macos-aarch64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-BASE_URL = "https://storage.googleapis.com/grok-build-public-artifacts/cli"
-
-PLATFORMS = {
-    "x86_64-linux": "linux-x86_64",
-    "aarch64-linux": "linux-aarch64",
-    "aarch64-darwin": "macos-aarch64",
-}
-
-
-def main() -> None:
-    """Update the grok package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_text(f"{BASE_URL}/stable").strip()
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"{BASE_URL}/grok-{latest}-{{platform}}"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/iflow-cli/update.py
+++ b/packages/iflow-cli/update.py
@@ -8,60 +8,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+update_npm_package(
+    Path(__file__).parent,
+    "@iflow-ai/iflow-cli",
+    ".#iflow-cli",
+    require_lockfile=False,
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@iflow-ai/iflow-cli"
-
-
-def main() -> None:
-    """Update the iflow-cli package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/iflow-cli-{latest}.tgz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    print("Extracting/generating lockfile...")
-    lockfile_ok = extract_or_generate_lockfile(
-        tarball_url, SCRIPT_DIR / "package-lock.json"
-    )
-    if not lockfile_ok:
-        print("Warning: Failed to generate lockfile, continuing anyway...")
-
-    # Update hashes.json with dummy npmDepsHash first
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    print("Calculating npm dependencies hash...")
-    update_dependency_hash(".#iflow-cli", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/letta-code/update.py
+++ b/packages/letta-code/update.py
@@ -8,60 +8,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+# Use legacy-peer-deps to resolve ink version conflicts (ink-link requires >=6,
+# but the package uses ^5).
+update_npm_package(
+    Path(__file__).parent,
+    "@letta-ai/letta-code",
+    ".#letta-code",
+    lockfile_env={"NPM_CONFIG_LEGACY_PEER_DEPS": "true"},
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@letta-ai/letta-code"
-
-
-def main() -> None:
-    """Update the letta-code package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/letta-code-{latest}.tgz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    if not extract_or_generate_lockfile(
-        tarball_url,
-        SCRIPT_DIR / "package-lock.json",
-        # Use legacy-peer-deps to resolve ink version conflicts (ink-link requires >=6, but package uses ^5)
-        env={"NPM_CONFIG_LEGACY_PEER_DEPS": "true"},
-    ):
-        return
-
-    # Update hashes.json
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    update_dependency_hash(".#letta-code", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/mimo-code/update.py
+++ b/packages/mimo-code/update.py
@@ -1,52 +1,23 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for mimo-code package binary releases."""
+"""Update script for mimo-code package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_github_latest_release, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_github_latest_release("XiaomiMiMo", "MiMo-Code"),
+    url_template="https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v{version}/{platform}",
+    platforms={
+        "x86_64-linux": "mimocode-linux-x64.tar.gz",
+        "aarch64-linux": "mimocode-linux-arm64.tar.gz",
+        "x86_64-darwin": "mimocode-darwin-x64.zip",
+        "aarch64-darwin": "mimocode-darwin-arm64.zip",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "mimocode-linux-x64.tar.gz",
-    "aarch64-linux": "mimocode-linux-arm64.tar.gz",
-    "x86_64-darwin": "mimocode-darwin-x64.zip",
-    "aarch64-darwin": "mimocode-darwin-arm64.zip",
-}
-
-
-def main() -> None:
-    """Update the mimo-code package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("XiaomiMiMo", "MiMo-Code")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = (
-        f"https://github.com/XiaomiMiMo/MiMo-Code/releases/download/"
-        f"v{latest}/{{platform}}"
-    )
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/open-code-review/update.py
+++ b/packages/open-code-review/update.py
@@ -1,49 +1,23 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for open-code-review package."""
+"""Update script for open-code-review package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_github_latest_release, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_github_latest_release("alibaba", "open-code-review"),
+    url_template="https://github.com/alibaba/open-code-review/releases/download/v{version}/opencodereview-{platform}",
+    platforms={
+        "x86_64-linux": "linux-amd64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-amd64",
+        "aarch64-darwin": "darwin-arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux-amd64",
-    "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-amd64",
-    "aarch64-darwin": "darwin-arm64",
-}
-
-
-def main() -> None:
-    """Update the open-code-review package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("alibaba", "open-code-review")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"https://github.com/alibaba/open-code-review/releases/download/v{latest}/opencodereview-{{platform}}"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/opencode/update.py
+++ b/packages/opencode/update.py
@@ -1,50 +1,23 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for opencode package (binary releases)."""
+"""Update script for opencode package (prebuilt binaries)."""
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_github_latest_release, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_github_latest_release("anomalyco", "opencode"),
+    url_template="https://github.com/anomalyco/opencode/releases/download/v{version}/{platform}",
+    platforms={
+        "x86_64-linux": "opencode-linux-x64.tar.gz",
+        "aarch64-linux": "opencode-linux-arm64.tar.gz",
+        "x86_64-darwin": "opencode-darwin-x64.zip",
+        "aarch64-darwin": "opencode-darwin-arm64.zip",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-# Map nix platforms to release asset names
-PLATFORMS = {
-    "x86_64-linux": "opencode-linux-x64.tar.gz",
-    "aarch64-linux": "opencode-linux-arm64.tar.gz",
-    "x86_64-darwin": "opencode-darwin-x64.zip",
-    "aarch64-darwin": "opencode-darwin-arm64.zip",
-}
-
-
-def main() -> None:
-    """Update the opencode package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release("anomalyco", "opencode")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"https://github.com/anomalyco/opencode/releases/download/v{latest}/{{platform}}"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/openspec/update.py
+++ b/packages/openspec/update.py
@@ -8,55 +8,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+update_npm_package(
+    Path(__file__).parent,
+    "@fission-ai/openspec",
+    ".#openspec",
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@fission-ai/openspec"
-
-
-def main() -> None:
-    """Update the openspec package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/openspec-{latest}.tgz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
-        return
-
-    # Update hashes.json
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    update_dependency_hash(".#openspec", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/openspecui/update.py
+++ b/packages/openspecui/update.py
@@ -8,64 +8,14 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+# openspecui is published from a workspace; its devDependencies use the
+# workspace:* protocol that npm cannot resolve here. package.nix strips them
+# via `del(.devDependencies)`, so do the same when generating the lock.
+update_npm_package(
+    Path(__file__).parent,
+    "openspecui",
+    ".#openspecui",
+    strip_dev_dependencies=True,
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "openspecui"
-
-
-def main() -> None:
-    """Update the openspecui package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = (
-        f"https://registry.npmjs.org/{NPM_PACKAGE}/-/{NPM_PACKAGE}-{latest}.tgz"
-    )
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    # openspecui is published from a workspace; its devDependencies use the
-    # workspace:* protocol that npm cannot resolve here. package.nix strips
-    # them via `del(.devDependencies)`, so do the same when generating the lock.
-    if not extract_or_generate_lockfile(
-        tarball_url,
-        SCRIPT_DIR / "package-lock.json",
-        strip_dev_dependencies=True,
-    ):
-        return
-
-    # Update hashes.json
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    update_dependency_hash(".#openspecui", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/pi/update.py
+++ b/packages/pi/update.py
@@ -8,57 +8,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+update_npm_package(
+    Path(__file__).parent,
+    "@earendil-works/pi-coding-agent",
+    ".#pi",
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@earendil-works/pi-coding-agent"
-
-
-def main() -> None:
-    """Update the pi package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = (
-        f"https://registry.npmjs.org/{NPM_PACKAGE}/-/pi-coding-agent-{latest}.tgz"
-    )
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
-        sys.exit(1)
-
-    # Update hashes.json
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    update_dependency_hash(".#pi", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/qmd/update.py
+++ b/packages/qmd/update.py
@@ -3,9 +3,8 @@
 
 """Update script for qmd package.
 
-Custom updater needed because qmd uses bun2nix: after each version
-bump the bun.nix lockfile must be regenerated from the upstream bun.lock
-using the bun2nix CLI.
+Custom updater needed because qmd uses bun2nix: after each version bump the
+bun.nix lockfile must be regenerated from the upstream bun.lock.
 """
 
 import sys
@@ -13,60 +12,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    clone_and_generate_bun_nix,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_bun_github
+
+update_bun_github(
+    Path(__file__).parent,
+    "tobi",
+    "qmd",
 )
-from updater.nix import nix_prefetch_url
-
-PKG_DIR = Path(__file__).parent
-FLAKE_ROOT = PKG_DIR.parent.parent
-HASHES_FILE = PKG_DIR / "hashes.json"
-BUN_NIX = PKG_DIR / "bun.nix"
-
-OWNER = "tobi"
-REPO = "qmd"
-
-
-def main() -> None:
-    """Update the qmd package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release(OWNER, REPO)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating qmd from {current} to {latest}")
-
-    # Step 1: Calculate new source hash
-    print("Calculating source hash...")
-    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
-    src_hash = nix_prefetch_url(url, unpack=True)
-    print(f"  source hash: {src_hash}")
-
-    # Step 2: Update hashes.json
-    save_hashes(HASHES_FILE, {"version": latest, "hash": src_hash})
-    print("Updated hashes.json")
-
-    # Step 3: Regenerate bun.nix from upstream bun.lock
-    clone_and_generate_bun_nix(
-        OWNER,
-        REPO,
-        latest,
-        BUN_NIX,
-        FLAKE_ROOT,
-        ref_prefix="v",
-    )
-
-    print(f"Updated qmd to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/ralph-tui/update.py
+++ b/packages/ralph-tui/update.py
@@ -3,9 +3,8 @@
 
 """Update script for ralph-tui package.
 
-Custom updater needed because ralph-tui uses bun2nix: after each version
-bump the bun.nix lockfile must be regenerated from the upstream bun.lock
-using the bun2nix CLI.
+Custom updater needed because ralph-tui uses bun2nix: after each version bump the
+bun.nix lockfile must be regenerated from the upstream bun.lock.
 """
 
 import sys
@@ -13,60 +12,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    clone_and_generate_bun_nix,
-    fetch_github_latest_release,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_bun_github
+
+update_bun_github(
+    Path(__file__).parent,
+    "subsy",
+    "ralph-tui",
 )
-from updater.nix import nix_prefetch_url
-
-PKG_DIR = Path(__file__).parent
-FLAKE_ROOT = PKG_DIR.parent.parent
-HASHES_FILE = PKG_DIR / "hashes.json"
-BUN_NIX = PKG_DIR / "bun.nix"
-
-OWNER = "subsy"
-REPO = "ralph-tui"
-
-
-def main() -> None:
-    """Update the ralph-tui package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_github_latest_release(OWNER, REPO)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating ralph-tui from {current} to {latest}")
-
-    # Step 1: Calculate new source hash
-    print("Calculating source hash...")
-    url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
-    src_hash = nix_prefetch_url(url, unpack=True)
-    print(f"  source hash: {src_hash}")
-
-    # Step 2: Update hashes.json
-    save_hashes(HASHES_FILE, {"version": latest, "hash": src_hash})
-    print("Updated hashes.json")
-
-    # Step 3: Regenerate bun.nix from upstream bun.lock
-    clone_and_generate_bun_nix(
-        OWNER,
-        REPO,
-        latest,
-        BUN_NIX,
-        FLAKE_ROOT,
-        ref_prefix="v",
-    )
-
-    print(f"Updated ralph-tui to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/zaly/update.py
+++ b/packages/zaly/update.py
@@ -8,61 +8,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+# The npm tarball ships without a lockfile; generate one (prod deps only,
+# dist/ is prebuilt so dev deps are not needed).
+update_npm_package(
+    Path(__file__).parent,
+    "@zaly/cli",
+    ".#zaly",
+    lockfile_env={"NPM_CONFIG_OMIT": "dev"},
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@zaly/cli"
-
-
-def main() -> None:
-    """Update the zaly package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/cli-{latest}.tgz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
-
-    # The npm tarball ships without a lockfile; generate one (prod deps only,
-    # dist/ is prebuilt so dev deps are not needed).
-    if not extract_or_generate_lockfile(
-        tarball_url,
-        SCRIPT_DIR / "package-lock.json",
-        env={"NPM_CONFIG_OMIT": "dev"},
-    ):
-        return
-
-    # Update hashes.json
-    data = {
-        "version": latest,
-        "sourceHash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-    save_hashes(HASHES_FILE, data)
-
-    # Calculate npmDepsHash
-    update_dependency_hash(".#zaly", "npmDepsHash", HASHES_FILE, data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/updater/__init__.py
+++ b/scripts/updater/__init__.py
@@ -14,6 +14,14 @@ from .bun import (
 # Dependency hash calculation
 from .deps import calculate_dependency_hash, update_dependency_hash
 
+# High-level update flows
+from .flows import (
+    update_bun_github,
+    update_github_source,
+    update_npm_package,
+    update_platform_binaries,
+)
+
 # Hash utilities
 from .hash import calculate_url_hash
 
@@ -63,5 +71,9 @@ __all__ = [
     "save_hashes",
     "should_update",
     "strip_workspace_entries",
+    "update_bun_github",
     "update_dependency_hash",
+    "update_github_source",
+    "update_npm_package",
+    "update_platform_binaries",
 ]

--- a/scripts/updater/flows/__init__.py
+++ b/scripts/updater/flows/__init__.py
@@ -1,0 +1,18 @@
+"""High-level update flows shared by packages/*/update.py scripts.
+
+Each module implements one common update pattern (npm tarball, GitHub source
+tarball with a dependency hash, prebuilt platform binaries, bun2nix) so that
+per-package update scripts only need to supply their configuration.
+"""
+
+from .bun_github import update_bun_github
+from .github_source import update_github_source
+from .npm_package import update_npm_package
+from .platform_binaries import update_platform_binaries
+
+__all__ = [
+    "update_bun_github",
+    "update_github_source",
+    "update_npm_package",
+    "update_platform_binaries",
+]

--- a/scripts/updater/flows/bun_github.py
+++ b/scripts/updater/flows/bun_github.py
@@ -1,0 +1,58 @@
+"""Update flow for bun2nix packages built from GitHub sources."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from updater.bun import clone_and_generate_bun_nix
+from updater.hashes_file import load_hashes, save_hashes
+from updater.nix import nix_prefetch_url
+from updater.version import fetch_github_latest_release, should_update
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def update_bun_github(
+    pkg_dir: Path,
+    owner: str,
+    repo: str,
+    *,
+    ref_prefix: str = "v",
+) -> None:
+    """Update a bun2nix package built from a GitHub release source tarball.
+
+    Bumps version/hash in hashes.json and regenerates bun.nix from the
+    upstream bun.lock.
+    """
+    flake_root = pkg_dir.parent.parent
+    hashes_file = pkg_dir / "hashes.json"
+    data = load_hashes(hashes_file)
+    current = data["version"]
+    latest = fetch_github_latest_release(owner, repo)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    print("Calculating source hash...")
+    url = (
+        f"https://github.com/{owner}/{repo}/archive/refs/tags/"
+        f"{ref_prefix}{latest}.tar.gz"
+    )
+    src_hash = nix_prefetch_url(url, unpack=True)
+
+    save_hashes(hashes_file, {"version": latest, "hash": src_hash})
+
+    clone_and_generate_bun_nix(
+        owner,
+        repo,
+        latest,
+        pkg_dir / "bun.nix",
+        flake_root,
+        ref_prefix=ref_prefix,
+    )
+
+    print(f"Updated to {latest}")

--- a/scripts/updater/flows/github_source.py
+++ b/scripts/updater/flows/github_source.py
@@ -1,0 +1,53 @@
+"""Update flow for packages built from a GitHub release source tarball."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from updater.deps import update_dependency_hash
+from updater.hash import DUMMY_SHA256_HASH, calculate_url_hash
+from updater.hashes_file import load_hashes, save_hashes
+from updater.version import fetch_github_latest_release, should_update
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def update_github_source(
+    pkg_dir: Path,
+    owner: str,
+    repo: str,
+    flake_attr: str,
+    dep_hash_key: str,
+) -> None:
+    """Update a package built from a GitHub release source tarball.
+
+    Bumps version/hash in hashes.json and recalculates the given dependency
+    hash (e.g. vendorHash for Go packages).
+    """
+    hashes_file = pkg_dir / "hashes.json"
+    data = load_hashes(hashes_file)
+    current = data["version"]
+    latest = fetch_github_latest_release(owner, repo)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    url = f"https://github.com/{owner}/{repo}/archive/refs/tags/v{latest}.tar.gz"
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(url, unpack=True)
+
+    data = {
+        "version": latest,
+        "hash": source_hash,
+        dep_hash_key: DUMMY_SHA256_HASH,
+    }
+    save_hashes(hashes_file, data)
+
+    update_dependency_hash(flake_attr, dep_hash_key, hashes_file, data)
+
+    print(f"Updated to {latest}")

--- a/scripts/updater/flows/npm_package.py
+++ b/scripts/updater/flows/npm_package.py
@@ -1,0 +1,73 @@
+"""Update flow for packages built from an npm registry tarball."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from updater.deps import update_dependency_hash
+from updater.hash import DUMMY_SHA256_HASH, calculate_url_hash
+from updater.hashes_file import load_hashes, save_hashes
+from updater.npm import extract_or_generate_lockfile
+from updater.version import fetch_npm_version, should_update
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def update_npm_package(
+    pkg_dir: Path,
+    npm_package: str,
+    flake_attr: str,
+    *,
+    lockfile_env: dict[str, str] | None = None,
+    strip_dev_dependencies: bool = False,
+    require_lockfile: bool = True,
+) -> None:
+    """Update a package built from an npm registry tarball.
+
+    Bumps version/sourceHash in hashes.json, refreshes package-lock.json from
+    the tarball, and recalculates npmDepsHash.
+    """
+    hashes_file = pkg_dir / "hashes.json"
+    data = load_hashes(hashes_file)
+    current = data["version"]
+    latest = fetch_npm_version(npm_package)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    tarball_name = npm_package.rsplit("/", 1)[-1]
+    tarball_url = (
+        f"https://registry.npmjs.org/{npm_package}/-/{tarball_name}-{latest}.tgz"
+    )
+
+    print("Calculating source hash...")
+    source_hash = calculate_url_hash(tarball_url)
+
+    if not extract_or_generate_lockfile(
+        tarball_url,
+        pkg_dir / "package-lock.json",
+        env=lockfile_env,
+        strip_dev_dependencies=strip_dev_dependencies,
+    ):
+        if require_lockfile:
+            sys.exit(1)
+        print("Warning: Failed to generate lockfile, continuing anyway...")
+
+    # Dummy npmDepsHash: update_dependency_hash builds the package and
+    # replaces it with the hash reported by the failed build.
+    data = {
+        "version": latest,
+        "sourceHash": source_hash,
+        "npmDepsHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(hashes_file, data)
+
+    print("Calculating npm dependencies hash...")
+    update_dependency_hash(flake_attr, "npmDepsHash", hashes_file, data)
+
+    print(f"Updated to {latest}")

--- a/scripts/updater/flows/platform_binaries.py
+++ b/scripts/updater/flows/platform_binaries.py
@@ -1,0 +1,41 @@
+"""Update flow for packages that repackage prebuilt per-platform binaries."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from updater.hashes_file import load_hashes, save_hashes
+from updater.platforms import calculate_platform_hashes
+from updater.version import should_update
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+def update_platform_binaries(
+    pkg_dir: Path,
+    *,
+    fetch_latest: Callable[[], str],
+    url_template: str,
+    platforms: dict[str, str],
+) -> None:
+    """Update a package that repackages prebuilt per-platform binaries.
+
+    ``url_template`` may use ``{version}`` and ``{platform}`` placeholders.
+    """
+    hashes_file = pkg_dir / "hashes.json"
+    data = load_hashes(hashes_file)
+    current = data["version"]
+    latest = fetch_latest()
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    hashes = calculate_platform_hashes(url_template, platforms, version=latest)
+
+    save_hashes(hashes_file, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")


### PR DESCRIPTION

jscpd reported ~22% duplicated Python across packages/*/update.py because
many packages copy the same npm-tarball, GitHub-source+vendorHash, prebuilt
platform-binary, or bun2nix update logic verbatim.

Move these four flows into scripts/updater/flows.py so per-package update
scripts only declare their configuration (package name, repo, URL template,
platform map). This drops duplication to ~6% and makes future updater fixes
apply to all packages at once.

Behavior change: npm-tarball updaters now exit non-zero when lockfile
extraction/generation fails (previously some silently returned), except
iflow-cli which keeps the warn-and-continue behavior via require_lockfile.
