### PR TITLE
updater: convert platform-binary and fetchzip npm updaters to shared flows

### DIFF
--- a/packages/copilot-cli/update.py
+++ b/packages/copilot-cli/update.py
@@ -12,45 +12,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_npm_version, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_npm_version("@github/copilot"),
+    url_template="https://registry.npmjs.org/@github/copilot-{platform}/-/copilot-{platform}-{version}.tgz",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-x64",
+        "aarch64-darwin": "darwin-arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux-x64",
-    "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
-    "aarch64-darwin": "darwin-arm64",
-}
-
-
-def main() -> None:
-    """Update the copilot-cli package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version("@github/copilot")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = (
-        "https://registry.npmjs.org/@github/copilot-{platform}/-/"
-        f"copilot-{{platform}}-{latest}.tgz"
-    )
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/copilot-language-server/update.py
+++ b/packages/copilot-language-server/update.py
@@ -8,55 +8,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+update_npm_package(
+    Path(__file__).parent,
+    "@github/copilot-language-server",
+    ".#copilot-language-server",
+    fetchzip=True,
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@github/copilot-language-server"
-
-
-def main() -> None:
-    """Update the copilot-language-server package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = f"https://registry.npmjs.org/{NPM_PACKAGE}/-/copilot-language-server-{latest}.tgz"
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url, unpack=True)
-
-    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
-        return
-
-    # Prepare new data with dummy hash for dependency calculation
-    new_data = {
-        "version": latest,
-        "hash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-
-    # Calculate npmDepsHash - only save if successful
-    update_dependency_hash(
-        ".#copilot-language-server", "npmDepsHash", HASHES_FILE, new_data
-    )
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/cursor-agent/update.py
+++ b/packages/cursor-agent/update.py
@@ -8,49 +8,24 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_version_from_text,
-    load_hashes,
-    save_hashes,
-    should_update,
-)
+from updater import fetch_version_from_text, update_platform_binaries
 
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux/x64",
-    "aarch64-linux": "linux/arm64",
-    "x86_64-darwin": "darwin/x64",
-    "aarch64-darwin": "darwin/arm64",
-}
-
-VERSION_URL = "https://cursor.com/install"
 # Build id suffix can contain hyphens (e.g. 2026.06.15-18-00-12-6f5a2cf);
 # match them and anchor on the trailing path separator.
 VERSION_PATTERN = (
     r"downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f-]+)/"
 )
 
-
-def main() -> None:
-    """Update the cursor-agent package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_version_from_text(VERSION_URL, VERSION_PATTERN)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    url_template = f"https://downloads.cursor.com/lab/{latest}/{{platform}}/agent-cli-package.tar.gz"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_version_from_text(
+        "https://cursor.com/install", VERSION_PATTERN
+    ),
+    url_template="https://downloads.cursor.com/lab/{version}/{platform}/agent-cli-package.tar.gz",
+    platforms={
+        "x86_64-linux": "linux/x64",
+        "aarch64-linux": "linux/arm64",
+        "x86_64-darwin": "darwin/x64",
+        "aarch64-darwin": "darwin/arm64",
+    },
+)

--- a/packages/kilocode-cli/update.py
+++ b/packages/kilocode-cli/update.py
@@ -12,44 +12,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_platform_hashes,
-    fetch_npm_version,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import fetch_npm_version, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_npm_version("@kilocode/cli"),
+    url_template="https://registry.npmjs.org/@kilocode/cli-{platform}/-/cli-{platform}-{version}.tgz",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-x64",
+        "aarch64-darwin": "darwin-arm64",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-
-PLATFORMS = {
-    "x86_64-linux": "linux-x64",
-    "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
-    "aarch64-darwin": "darwin-arm64",
-}
-
-
-def main() -> None:
-    """Update the kilocode-cli package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version("@kilocode/cli")
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating kilocode-cli from {current} to {latest}")
-
-    url_template = "https://registry.npmjs.org/@kilocode/cli-{platform}/-/cli-{platform}-{version}.tgz"
-    hashes = calculate_platform_hashes(url_template, PLATFORMS, version=latest)
-
-    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/sandbox-runtime/update.py
+++ b/packages/sandbox-runtime/update.py
@@ -8,55 +8,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    calculate_url_hash,
-    extract_or_generate_lockfile,
-    fetch_npm_version,
-    load_hashes,
-    should_update,
-    update_dependency_hash,
+from updater import update_npm_package
+
+update_npm_package(
+    Path(__file__).parent,
+    "@anthropic-ai/sandbox-runtime",
+    ".#sandbox-runtime",
+    fetchzip=True,
 )
-from updater.hash import DUMMY_SHA256_HASH
-
-SCRIPT_DIR = Path(__file__).parent
-HASHES_FILE = SCRIPT_DIR / "hashes.json"
-NPM_PACKAGE = "@anthropic-ai/sandbox-runtime"
-
-
-def main() -> None:
-    """Update the sandbox-runtime package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-    latest = fetch_npm_version(NPM_PACKAGE)
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    tarball_url = (
-        f"https://registry.npmjs.org/{NPM_PACKAGE}/-/sandbox-runtime-{latest}.tgz"
-    )
-
-    print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url, unpack=True)
-
-    if not extract_or_generate_lockfile(tarball_url, SCRIPT_DIR / "package-lock.json"):
-        return
-
-    # Prepare new data with dummy hash for dependency calculation
-    new_data = {
-        "version": latest,
-        "hash": source_hash,
-        "npmDepsHash": DUMMY_SHA256_HASH,
-    }
-
-    # Calculate npmDepsHash - only save if successful
-    update_dependency_hash(".#sandbox-runtime", "npmDepsHash", HASHES_FILE, new_data)
-
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/updater/flows/npm_package.py
+++ b/scripts/updater/flows/npm_package.py
@@ -23,11 +23,16 @@ def update_npm_package(
     lockfile_env: dict[str, str] | None = None,
     strip_dev_dependencies: bool = False,
     require_lockfile: bool = True,
+    fetchzip: bool = False,
 ) -> None:
     """Update a package built from an npm registry tarball.
 
-    Bumps version/sourceHash in hashes.json, refreshes package-lock.json from
-    the tarball, and recalculates npmDepsHash.
+    Bumps version and source hash in hashes.json, refreshes package-lock.json
+    from the tarball, and recalculates npmDepsHash.
+
+    Set ``fetchzip=True`` for packages whose derivation fetches the tarball
+    with fetchzip instead of fetchurl: the source hash is then calculated over
+    the unpacked tarball and stored under "hash" instead of "sourceHash".
     """
     hashes_file = pkg_dir / "hashes.json"
     data = load_hashes(hashes_file)
@@ -46,7 +51,7 @@ def update_npm_package(
     )
 
     print("Calculating source hash...")
-    source_hash = calculate_url_hash(tarball_url)
+    source_hash = calculate_url_hash(tarball_url, unpack=fetchzip)
 
     if not extract_or_generate_lockfile(
         tarball_url,
@@ -60,9 +65,10 @@ def update_npm_package(
 
     # Dummy npmDepsHash: update_dependency_hash builds the package and
     # replaces it with the hash reported by the failed build.
+    source_hash_key = "hash" if fetchzip else "sourceHash"
     data = {
         "version": latest,
-        "sourceHash": source_hash,
+        source_hash_key: source_hash,
         "npmDepsHash": DUMMY_SHA256_HASH,
     }
     save_hashes(hashes_file, data)


### PR DESCRIPTION

copilot-cli, kilocode-cli and cursor-agent duplicate the platform-hash
update loop already implemented by update_platform_binaries.
copilot-language-server and sandbox-runtime duplicate the npm tarball
flow, differing only in that their derivations use fetchzip.

Add a fetchzip option to update_npm_package (unpacked source hash,
stored under "hash") and rewrite these five update scripts as flow
calls.
