### PR TITLE
opencode2: init at 0.0.0-next-15824

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>opencode2</strong> - OpenCode 2 preview CLI</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://opencode.ai
+- **Usage**: `nix run github:numtide/llm-agents.nix#opencode2 -- --help`
+- **Nix**: [packages/opencode2/package.nix](packages/opencode2/package.nix)
+
+</details>
+<details>
 <summary><strong>openfang</strong> - Open-source Agent OS built in Rust — CLI for the OpenFang platform</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -169,6 +169,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 32300164;
         name = "Mix";
       };
+      iainlane = {
+        github = "iainlane";
+        githubId = 321014;
+        name = "Iain Lane";
+      };
     };
   }
 )

--- a/packages/opencode2/default.nix
+++ b/packages/opencode2/default.nix
@@ -1,8 +1,0 @@
-{
-  pkgs,
-  perSystem,
-  ...
-}:
-pkgs.callPackage ./package.nix {
-  inherit (perSystem.self) wrapBuddy versionCheckHomeHook;
-}

--- a/packages/opencode2/default.nix
+++ b/packages/opencode2/default.nix
@@ -1,0 +1,8 @@
+{
+  pkgs,
+  perSystem,
+  ...
+}:
+pkgs.callPackage ./package.nix {
+  inherit (perSystem.self) wrapBuddy versionCheckHomeHook;
+}

--- a/packages/opencode2/hashes.json
+++ b/packages/opencode2/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "aarch64-darwin": "sha256-iRxacAPvdn63jVYZTHL4WIQ7sNjPy01D6b/P1nr0AUg=",
     "aarch64-linux": "sha256-4qzzZkU7uf0iMbrOjoYQw8NlMy38xyIJs6JwG3eAFSI=",
-    "x86_64-darwin": "sha256-MwZJ47L/9XaZxR25ay+pIH39SZ9PrxV2FcOG9gjihYQ=",
     "x86_64-linux": "sha256-aYjVmembYVA7CoeHB/N7RnfYWPHuELtngHbrzfkiUQw="
   }
 }

--- a/packages/opencode2/hashes.json
+++ b/packages/opencode2/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.0.0-next-15824",
+  "hashes": {
+    "aarch64-darwin": "sha256-iRxacAPvdn63jVYZTHL4WIQ7sNjPy01D6b/P1nr0AUg=",
+    "aarch64-linux": "sha256-4qzzZkU7uf0iMbrOjoYQw8NlMy38xyIJs6JwG3eAFSI=",
+    "x86_64-darwin": "sha256-MwZJ47L/9XaZxR25ay+pIH39SZ9PrxV2FcOG9gjihYQ=",
+    "x86_64-linux": "sha256-aYjVmembYVA7CoeHB/N7RnfYWPHuELtngHbrzfkiUQw="
+  }
+}

--- a/packages/opencode2/package.nix
+++ b/packages/opencode2/package.nix
@@ -1,36 +1,32 @@
 {
   lib,
   stdenv,
-  fetchurl,
   makeWrapper,
   wrapBuddy,
   ripgrep,
+  platformSource,
   versionCheckHook,
   versionCheckHomeHook,
 }:
 
 let
-  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  inherit (versionData) version hashes;
-
-  platformMap = {
-    x86_64-linux = "linux-x64";
-    aarch64-linux = "linux-arm64";
-    x86_64-darwin = "darwin-x64";
-    aarch64-darwin = "darwin-arm64";
+  # OpenCode 2 ships as platform-specific Bun executables on npm's next channel
+  # (@opencode-ai/cli-<platform>).
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    };
+    url =
+      { version, platform }:
+      "https://registry.npmjs.org/@opencode-ai/cli-${platform}/-/cli-${platform}-${version}.tgz";
   };
-
-  platform = stdenv.hostPlatform.system;
-  npmPlatform = platformMap.${platform} or (throw "Unsupported system: ${platform}");
 in
 stdenv.mkDerivation {
   pname = "opencode2";
-  inherit version;
-
-  src = fetchurl {
-    url = "https://registry.npmjs.org/@opencode-ai/cli-${npmPlatform}/-/cli-${npmPlatform}-${version}.tgz";
-    hash = hashes.${platform};
-  };
+  inherit (source) version src;
 
   sourceRoot = "package";
 
@@ -41,8 +37,11 @@ stdenv.mkDerivation {
   wrapBuddyExtraNeeded = lib.optionals stdenv.hostPlatform.isLinux [ "libstdc++.so.6" ];
 
   dontBuild = true;
+  # Bun-compiled executable; stripping corrupts the embedded payload.
   dontStrip = true;
 
+  # Install only the executable; the tarball also contains ~49 MiB of source
+  # maps that are not needed at runtime.
   installPhase = ''
     runHook preInstall
 
@@ -59,21 +58,6 @@ stdenv.mkDerivation {
     versionCheckHomeHook
   ];
   versionCheckProgramArg = "--version";
-  versionCheckKeepEnvironment = [
-    "HOME"
-    "XDG_CACHE_HOME"
-    "XDG_CONFIG_HOME"
-    "XDG_DATA_HOME"
-    "XDG_STATE_HOME"
-  ];
-  preInstallCheck = ''
-    export HOME="$NIX_BUILD_TOP/.version-check-home"
-    export XDG_CACHE_HOME="$HOME/.cache"
-    export XDG_CONFIG_HOME="$HOME/.config"
-    export XDG_DATA_HOME="$HOME/.local/share"
-    export XDG_STATE_HOME="$HOME/.local/state"
-    mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
-  '';
 
   passthru.category = "AI Coding Agents";
 
@@ -91,11 +75,6 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "opencode2";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    platforms = source.platforms;
   };
 }

--- a/packages/opencode2/package.nix
+++ b/packages/opencode2/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  wrapBuddy,
+  ripgrep,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  npmPlatform = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "opencode2";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/cli-${npmPlatform}/-/cli-${npmPlatform}-${version}.tgz";
+    hash = hashes.${platform};
+  };
+
+  sourceRoot = "package";
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  wrapBuddyExtraNeeded = lib.optionals stdenv.hostPlatform.isLinux [ "libstdc++.so.6" ];
+
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/opencode2 $out/bin/opencode2
+    wrapProgram $out/bin/opencode2 \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [
+    "HOME"
+    "XDG_CACHE_HOME"
+    "XDG_CONFIG_HOME"
+    "XDG_DATA_HOME"
+    "XDG_STATE_HOME"
+  ];
+  preInstallCheck = ''
+    export HOME="$NIX_BUILD_TOP/.version-check-home"
+    export XDG_CACHE_HOME="$HOME/.cache"
+    export XDG_CONFIG_HOME="$HOME/.config"
+    export XDG_DATA_HOME="$HOME/.local/share"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
+  '';
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "OpenCode 2 preview CLI";
+    longDescription = ''
+      OpenCode 2 is the preview of OpenCode's next-generation CLI. The single
+      executable includes the terminal interface and server, and can run with
+      a private server, reuse a background service, or connect to a remote
+      server.
+    '';
+    homepage = "https://opencode.ai";
+    changelog = "https://github.com/anomalyco/opencode/commits/v2";
+    downloadPage = "https://www.npmjs.com/package/@opencode-ai/cli?activeTab=versions";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "opencode2";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/opencode2/package.nix
+++ b/packages/opencode2/package.nix
@@ -7,6 +7,7 @@
   platformSource,
   versionCheckHook,
   versionCheckHomeHook,
+  flake,
 }:
 
 let
@@ -74,6 +75,7 @@ stdenv.mkDerivation {
     downloadPage = "https://www.npmjs.com/package/@opencode-ai/cli?activeTab=versions";
     license = lib.licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ iainlane ];
     mainProgram = "opencode2";
     platforms = source.platforms;
   };

--- a/packages/opencode2/update.py
+++ b/packages/opencode2/update.py
@@ -21,7 +21,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-x64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-x64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/opencode2/update.py
+++ b/packages/opencode2/update.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for the opencode2 package.
+
+OpenCode 2 ships through npm's next channel as platform-specific native binary
+packages (@opencode-ai/cli-{platform}).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import fetch_npm_version, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_npm_version("@opencode-ai/cli", tag="next"),
+    url_template="https://registry.npmjs.org/@opencode-ai/cli-{platform}/-/cli-{platform}-{version}.tgz",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "x86_64-darwin": "darwin-x64",
+        "aarch64-darwin": "darwin-arm64",
+    },
+)

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -2,6 +2,7 @@
 
 import re
 from typing import cast
+from urllib.parse import quote
 
 from .http import fetch_json, fetch_text
 from .nix import run_command
@@ -29,11 +30,12 @@ def fetch_github_latest_release(owner: str, repo: str) -> str:
     return tag.lstrip("v")
 
 
-def fetch_npm_version(package: str) -> str:
-    """Fetch the latest version from npm registry.
+def fetch_npm_version(package: str, *, tag: str = "latest") -> str:
+    """Fetch the version associated with an npm dist-tag.
 
     Args:
         package: npm package name
+        tag: npm dist-tag
 
     Returns:
         Latest version
@@ -41,12 +43,13 @@ def fetch_npm_version(package: str) -> str:
     """
     # Try using npm command first
     try:
-        cmd = ["npm", "view", package, "version"]
+        package_spec = package if tag == "latest" else f"{package}@{tag}"
+        cmd = ["npm", "view", package_spec, "version"]
         result = run_command(cmd)
         return result.stdout.strip()
     except (FileNotFoundError, OSError):
         # npm command not available, fallback to registry API
-        url = f"https://registry.npmjs.org/{package}/latest"
+        url = f"https://registry.npmjs.org/{quote(package, safe='')}/{tag}"
         data = fetch_json(url)
         if not isinstance(data, dict):
             msg = f"Expected dict from npm registry, got {type(data)}"


### PR DESCRIPTION
## Summary

_Not sure if you generally take prerelease/beta packages. I wanted it for myself, figured I might as well submit here too._

OpenCode 2 is the preview of OpenCode's next-generation CLI. It combines the terminal interface and server in one executable, so it can run with a private server, reuse a background service, or connect to a remote server.

Unlike stable OpenCode, v2 is published through npm's next channel. Its top-level package selects a platform-specific Bun executable, so the GitHub release packaging used for v1 cannot be reused.

Package the four supported native executables, patch their Linux ELF dependencies, add ripgrep to PATH, and provide writable XDG directories for the version check. The package output contains only the executable and its wrapper, avoiding approximately 49 MiB of non-runtime source maps.

Extend the shared npm version fetcher with dist-tag support and use the same platform-binary updater as Copilot and Kilocode while tracking next. Regenerate the package documentation.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
