### PR TITLE
agent-browser: run pnpm on Node 22 to fix darwin EXC_GUARD kill

### DIFF
--- a/packages/agent-browser/package.nix
+++ b/packages/agent-browser/package.nix
@@ -5,7 +5,7 @@
   fetchurl,
   chromium,
   makeBinaryWrapper,
-  nodejs-slim,
+  nodejs-slim_22,
   pnpmConfigHook,
   pnpm_11,
   rustPlatform,
@@ -15,6 +15,13 @@
 let
   pname = "agent-browser";
   version = "0.32.3";
+
+  # Node 24's worker_threads teardown double-closes file descriptors
+  # (Environment::RunCleanup closing an fd number that the OS has already
+  # recycled into a guarded fd), which the Darwin kernel punishes with
+  # EXC_GUARD/SIGKILL, so pnpm dies with "Killed: 9" right after the
+  # download phase. Run pnpm on Node 22 LTS, which does not exhibit this.
+  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
 
   # Vendored Geist variable font (OFL-1.1) pinned to a specific upstream
   # commit so the dashboard's next/font/local build is fully offline.
@@ -37,26 +44,19 @@ let
     inherit version src;
 
     nativeBuildInputs = [
-      nodejs-slim
-      pnpm_11
+      nodejs-slim_22
+      pnpm
       pnpmConfigHook
     ];
 
-    # Restrict the install to the dashboard workspace: the full workspace
-    # install (1200 packages) gets OOM-killed on the aarch64-darwin builders.
+    # Restrict the install to the dashboard workspace; the full workspace
+    # install pulls in ~1200 packages the dashboard build never uses.
     pnpmWorkspaces = [ "dashboard" ];
 
     pnpmDeps = fetchPnpmDeps {
       pname = "${pname}-dashboard";
-      inherit version src;
-      pnpm = pnpm_11;
+      inherit version src pnpm;
       pnpmWorkspaces = [ "dashboard" ];
-      # The 0.32.2 lockfile makes pnpm exceed the darwin builders' memory
-      # budget and get SIGKILLed; cap the heap and unpack concurrency.
-      prePnpmInstall = ''
-        export NODE_OPTIONS=--max-old-space-size=2048
-      '';
-      pnpmInstallFlags = [ "--child-concurrency=2" ];
       hash = "sha256-tkEhkGO5/JTkzySDEsTmjr5+SEXzk8V0217iQhFhfCw=";
       fetcherVersion = 4;
     };


### PR DESCRIPTION
agent-browser: run pnpm on Node 22 to fix darwin EXC_GUARD kill

The darwin pnpm deps fetch has been dying with "Killed: 9" right after
the download phase. This was previously diagnosed as the builders
running out of memory (7a60f8e5), but the heap cap and unpack
concurrency limits did not stop the kills.

The crash report shows the real cause: an EXC_GUARD termination
(GUARD_TYPE_FD, violation CLOSE) with the faulting thread in

    __close_nocancel
    uv_fs_close / uv__fs_work
    node::Environment::RunCleanup()
    node::FreeEnvironment()
    node::worker::Worker::Run()

When pnpm shuts down its worker_threads pool after downloading, Node
24.16's per-environment cleanup closes fd numbers it believes it still
owns. Some of those numbers have already been closed and recycled by
the OS into guarded fds (libdispatch/XPC), and closing a guarded fd is
punished by the darwin kernel with an uncatchable SIGKILL. The
"File descriptor N closed but not opened in unmanaged mode" warnings
that spam the build log are the same double-close bug observed from JS.

Running pnpm on Node 22 LTS makes the fetch complete reliably
(3/3 consecutive successful builds on aarch64-darwin, where Node 24
failed 4/4). The FOD output hash is unchanged. Node 22 is build-time
only: the shipped artefact is the Rust CLI, and the dashboard is a
static Next.js export, so upstream's engines field (node >= 24) does
not apply to the built output.

The --max-old-space-size and --child-concurrency workarounds from
7a60f8e5 are dropped since they addressed a misdiagnosed cause; the
dashboard workspace filter is kept because it meaningfully shrinks the
dependency closure.
