### PR TITLE
Drop x86_64-darwin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1475,18 +1475,7 @@ All packages support:
 
 - `x86_64-linux`
 - `aarch64-linux`
-- `x86_64-darwin`
 - `aarch64-darwin`
-
-## Experimental Features
-
-This repository serves as a laboratory for exploring how Nix can enhance AI-powered development:
-
-### Current Experiments
-
-- **Sandboxed execution**: claudebox demonstrates transparent, sandboxed AI agent execution
-- **Provider abstraction**: claude-code-router explores decoupling AI interfaces from specific providers
-- **Tool composition**: Investigating how multiple AI agents can work together in Nix environments
 
 ## Contributing
 

--- a/packages/amp/hashes.json
+++ b/packages/amp/hashes.json
@@ -3,7 +3,6 @@
   "binaryHashes": {
     "x86_64-linux": "sha256-CUlspv5Lmo6dUiOlm/49UT0LFmSIF3DGL1H/G5w8t5E=",
     "aarch64-linux": "sha256-cmkb2PokZRrUnfji3zO3NiFrnxFYJ7hgGZzpQ//eU/U=",
-    "x86_64-darwin": "sha256-kujkwX9AFyzeE4IUjYOKThuDTHUIBEPw+mLs9ClIzjw=",
     "aarch64-darwin": "sha256-lHhpaPDuNApcW2UUMjHr7ia4VEIxyRzEsSW/RcAwJsw="
   }
 }

--- a/packages/amp/package.nix
+++ b/packages/amp/package.nix
@@ -21,7 +21,6 @@ let
   platformMap = {
     x86_64-linux = "linux-x64";
     aarch64-linux = "linux-arm64";
-    x86_64-darwin = "darwin-x64";
     aarch64-darwin = "darwin-arm64";
   };
 
@@ -96,7 +95,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "amp";

--- a/packages/amp/update.py
+++ b/packages/amp/update.py
@@ -25,7 +25,6 @@ STORAGE_BASE = "https://static.ampcode.com/cli"
 BINARY_PLATFORMS = {
     "x86_64-linux": "linux-x64",
     "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
     "aarch64-darwin": "darwin-arm64",
 }
 

--- a/packages/antigravity-cli/hashes.json
+++ b/packages/antigravity-cli/hashes.json
@@ -3,13 +3,11 @@
   "urls": {
     "x86_64-linux": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/linux-x64/cli_linux_x64.tar.gz",
     "aarch64-linux": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/linux-arm/cli_linux_arm64.tar.gz",
-    "x86_64-darwin": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/darwin-x64/cli_mac_x64.tar.gz",
     "aarch64-darwin": "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/darwin-arm/cli_mac_arm64.tar.gz"
   },
   "hashes": {
     "x86_64-linux": "sha512-kGv/Wcc77WMCdPZ+/Hfj+iBk/hJvTXUhx+WNxnc9jR886GiPEXj372V3Zyj3gqjrwhEYlhfPu0Ln30j1YUrR9Q==",
     "aarch64-linux": "sha512-YF4TlwfhC87P1BXykLN+4xlnGCyQmRi/gQP7kCzRKE1orw1jAolPxY6E9HaQ8lnYEJQ0fESGt+pBmmCO6v/r7g==",
-    "x86_64-darwin": "sha512-jvG3Qk5FBfI2MX4HUt+snfd5C8JgpizjT7aypRlmEOPRDTsmN0xepeXSp7mWOOIXNPRVlU81e9R5Dg5AJ/ilIA==",
     "aarch64-darwin": "sha512-1OM/UqvYpP0JTsOhKzG7G2V8pPsrn4qndAxA/kf1dSZ+sKJNNSY/3dQCdXUBNnAAHJX21cI/39/CzlCYbcY4xA=="
   }
 }

--- a/packages/antigravity-cli/package.nix
+++ b/packages/antigravity-cli/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/packages/antigravity-cli/update.py
+++ b/packages/antigravity-cli/update.py
@@ -24,7 +24,6 @@ MANIFEST_BASE = (
 PLATFORMS = {
     "x86_64-linux": "linux_amd64",
     "aarch64-linux": "linux_arm64",
-    "x86_64-darwin": "darwin_amd64",
     "aarch64-darwin": "darwin_arm64",
 }
 

--- a/packages/aperant/package.nix
+++ b/packages/aperant/package.nix
@@ -106,7 +106,6 @@ buildNpmPackage rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/packages/bernstein/package.nix
+++ b/packages/bernstein/package.nix
@@ -165,7 +165,6 @@ python.pkgs.buildPythonApplication rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "bernstein";

--- a/packages/catnip/hashes.json
+++ b/packages/catnip/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "x86_64-linux": "sha256-tEYvPnhoWM3aeG5u/tTL7plchg8ijIq6hTx7D5Bav+A=",
     "aarch64-linux": "sha256-d77CyanWQDnGKEu1SHxQ4obX7XAHTa0uHVwP8xWio7Y=",
-    "x86_64-darwin": "sha256-laICXlpO0tjzCqEnBsa+5If2X5Zv8s4BBv4NsZ3bgF0=",
     "aarch64-darwin": "sha256-if50wwKwt+gAvEenKBrDzu/IguokuQ/T3hNL0TvWvvo="
   }
 }

--- a/packages/catnip/package.nix
+++ b/packages/catnip/package.nix
@@ -13,7 +13,6 @@ let
     platforms = {
       x86_64-linux = "linux_amd64";
       aarch64-linux = "linux_arm64";
-      x86_64-darwin = "darwin_amd64";
       aarch64-darwin = "darwin_arm64";
     };
     url =

--- a/packages/catnip/update.py
+++ b/packages/catnip/update.py
@@ -17,7 +17,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux_amd64",
         "aarch64-linux": "linux_arm64",
-        "x86_64-darwin": "darwin_amd64",
         "aarch64-darwin": "darwin_arm64",
     },
 )

--- a/packages/claude-code/hashes.json
+++ b/packages/claude-code/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "x86_64-linux": "sha256-dN7KRSILgIDsdasJm9WlmA5BorWHmEagCPsRXUNt4IU=",
     "aarch64-linux": "sha256-njpq7MUWT2B+EYOuogksfXcF0UblBKYgffKRd2mWqOo=",
-    "x86_64-darwin": "sha256-4XzcUUN716gM4CRNJQRfVo1nshLupP+BuD7pD4Zm5C8=",
     "aarch64-darwin": "sha256-0BtJIQ1y7L4neiZl0QS6zM3fLSIYW+mURtKSng7fxI0="
   }
 }

--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -17,7 +17,6 @@ let
     platforms = {
       x86_64-linux = "linux-x64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/claude-code/update.py
+++ b/packages/claude-code/update.py
@@ -27,7 +27,6 @@ BASE_URL = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8
 PLATFORMS = {
     "x86_64-linux": "linux-x64",
     "aarch64-linux": "linux-arm64",
-    "x86_64-darwin": "darwin-x64",
     "aarch64-darwin": "darwin-arm64",
 }
 

--- a/packages/code-review-graph/package.nix
+++ b/packages/code-review-graph/package.nix
@@ -66,7 +66,6 @@ python.pkgs.buildPythonApplication rec {
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ aldoborrero ];
-    # x86_64-darwin excluded: no upstream CI / not validated.
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/packages/coderabbit-cli/hashes.json
+++ b/packages/coderabbit-cli/hashes.json
@@ -2,7 +2,6 @@
   "version": "0.6.5",
   "hashes": {
     "aarch64-darwin": "sha256-V1MNVXym919ItsJkoQ2BabUjNL6ZHEhb4kApVL22zsw=",
-    "x86_64-darwin": "sha256-/y3hqI/tcrS+qYyAaoHGfpq/0dDMYkRdw19KlF9uVuo=",
     "aarch64-linux": "sha256-8FYSDvih62Qc+5tAu9NtrSg180Gh3KCep3Z6lMHoMJs=",
     "x86_64-linux": "sha256-goDc+CKNCHt4++iVW4xe8/g/c/1G2aAJRTlIVH0wSpk="
   }

--- a/packages/coderabbit-cli/package.nix
+++ b/packages/coderabbit-cli/package.nix
@@ -16,7 +16,6 @@ let
     platforms = {
       x86_64-linux = "linux-x64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/coderabbit-cli/update.py
+++ b/packages/coderabbit-cli/update.py
@@ -19,7 +19,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-x64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-x64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/codex/hashes.json
+++ b/packages/codex/hashes.json
@@ -7,14 +7,12 @@
     "hashes": {
       "x86_64-linux": "sha256-iu2YY323533Iv7i7R1nsW95HLQv3lD9Y4OYqNQlFxVk=",
       "aarch64-linux": "sha256-+XdRJ8pk3MSjZi0BpSGizvuluY+DOUOog9hHc7Kv88U=",
-      "x86_64-darwin": "sha256-eUlAo4o/ZrfvUqXwA8awlPdDrQQKZK+z082frUlADwc=",
       "aarch64-darwin": "sha256-+rsuyNO6Wm3qY9uaNalg3FypheujLzQrm6Sqocc0sv4="
     }
   },
   "livekit_webrtc": {
     "tag": "webrtc-24f6822-2",
     "hashes": {
-      "x86_64-darwin": "sha256-XapngujlXtcDEGd2hacmP3nHFycEVZRybO/ORHPc6Og=",
       "aarch64-darwin": "sha256-4IwJM6EzTFgQd2AdX+Hj9NWzmyqXrSioRax2L6GKL1U="
     }
   }

--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -54,7 +54,6 @@ let
   # it via LK_CUSTOM_WEBRTC so the build stays sandboxed.
   livekitWebrtcTriple =
     {
-      x86_64-darwin = "mac-x64";
       aarch64-darwin = "mac-arm64";
     }
     .${stdenv.hostPlatform.system} or null;

--- a/packages/codex/update.py
+++ b/packages/codex/update.py
@@ -31,14 +31,12 @@ HASHES_FILE = Path(__file__).parent / "hashes.json"
 RUSTY_V8_PLATFORMS = {
     "x86_64-linux": "x86_64-unknown-linux-gnu",
     "aarch64-linux": "aarch64-unknown-linux-gnu",
-    "x86_64-darwin": "x86_64-apple-darwin",
     "aarch64-darwin": "aarch64-apple-darwin",
 }
 
 # codex-realtime-webrtc only enables livekit/webrtc-sys on macOS, so we
 # only need to prefetch the darwin prebuilt archives.
 LIVEKIT_WEBRTC_PLATFORMS = {
-    "x86_64-darwin": "mac-x64",
     "aarch64-darwin": "mac-arm64",
 }
 

--- a/packages/copilot-cli/hashes.json
+++ b/packages/copilot-cli/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "x86_64-linux": "sha256-HXdvbENrMh5afTLoCBWG2vHw05kTG39Ou2HZciZDyNA=",
     "aarch64-darwin": "sha256-o5s0ngSbOPtAA531j+m3zUEXbQgk4822IgR0MQEYP6I=",
-    "x86_64-darwin": "sha256-8q7YHk2S3g7EOn5c3NkYuUKgOXSHEUrq2cfZgHFCG9k=",
     "aarch64-linux": "sha256-U1ZWuIMNC07WLPxEYMdoZxO52VNCCE9b91HaomH6hmU="
   }
 }

--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -19,7 +19,6 @@ let
     platforms = {
       x86_64-linux = "linux-x64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/copilot-cli/update.py
+++ b/packages/copilot-cli/update.py
@@ -21,7 +21,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-x64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-x64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/cubic/hashes.json
+++ b/packages/cubic/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "aarch64-darwin": "sha256-ctRpyJItUlbXzbNDfDXGyHvsN3MnW+MzKFORoYh6sAU=",
     "x86_64-linux": "sha256-f000/AgIKeSt0MOLU6tQNu7tbfn1PLiyKTBjhzruvlo=",
-    "aarch64-linux": "sha256-TR4u5YavZ+RZO/TXz6B8lWyq6EsNVlgxPwpNuecM33c=",
-    "x86_64-darwin": "sha256-9cdXoThhl4HUCd6px/Q4mzGrhlmOe6fM3XZ4sQB8Rf4="
+    "aarch64-linux": "sha256-TR4u5YavZ+RZO/TXz6B8lWyq6EsNVlgxPwpNuecM33c="
   }
 }

--- a/packages/cubic/package.nix
+++ b/packages/cubic/package.nix
@@ -15,7 +15,6 @@ let
     platforms = {
       x86_64-linux = "linux-x64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/cubic/update.py
+++ b/packages/cubic/update.py
@@ -19,7 +19,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-x64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-x64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/cursor-agent/hashes.json
+++ b/packages/cursor-agent/hashes.json
@@ -1,7 +1,6 @@
 {
   "version": "2026.07.17-3e2a980",
   "hashes": {
-    "x86_64-darwin": "sha256-bf361rzCPLuq1KBv5C122vE7T8qTQ/JtayrdpFmf3/k=",
     "aarch64-darwin": "sha256-ISP5Nre+duoMEvfrsFfK6460buRBi3GFdiT/4S5eBUY=",
     "aarch64-linux": "sha256-gnmXeF8NjOk6WvfDstTosGS6hUP6z87vmBxurU0njYw=",
     "x86_64-linux": "sha256-G9iyPPVXvKljWPhkznRM0HGV3Evr2lNOG/qi7sSP98M="

--- a/packages/cursor-agent/package.nix
+++ b/packages/cursor-agent/package.nix
@@ -18,7 +18,6 @@ let
     platforms = {
       x86_64-linux = "linux/x64";
       aarch64-linux = "linux/arm64";
-      x86_64-darwin = "darwin/x64";
       aarch64-darwin = "darwin/arm64";
     };
     url =

--- a/packages/cursor-agent/update.py
+++ b/packages/cursor-agent/update.py
@@ -25,7 +25,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux/x64",
         "aarch64-linux": "linux/arm64",
-        "x86_64-darwin": "darwin/x64",
         "aarch64-darwin": "darwin/arm64",
     },
 )

--- a/packages/eca/hashes.json
+++ b/packages/eca/hashes.json
@@ -2,7 +2,6 @@
   "version": "0.148.0",
   "x86_64-linux": "sha256-r7Ut90sfbbb2cWTb0UyJV430EKFrMJRp96lPgydNcPQ=",
   "aarch64-linux": "sha256-GPi00hT5+rw29lgWSFro1bsdpUg8f+lKFJh4AdBvOGE=",
-  "x86_64-darwin": "sha256-69yldN3D6NCMzPHFDhyumnwuIgP5nfkSoFqOAPvAA8E=",
   "aarch64-darwin": "sha256-Uvpnlnvztd6bK4FkeyJLGoLZeZHf3wlbqVPHFBzyC9I=",
   "jar": "sha256-fDXz+NIlT5wjkTwp66ov303FNaHLybIdv5adhwNwCoQ="
 }

--- a/packages/eca/package.nix
+++ b/packages/eca/package.nix
@@ -89,13 +89,6 @@ else if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then
     url = "https://github.com/editor-code-assistant/eca/releases/download/${version}/eca-native-linux-aarch64.zip";
     hash = hashes."aarch64-linux";
   }
-else if pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then
-  mkNativeBinary {
-    inherit wrapBuddy versionCheckHomeHook;
-    system = "x86_64-darwin";
-    url = "https://github.com/editor-code-assistant/eca/releases/download/${version}/eca-native-macos-amd64.zip";
-    hash = hashes."x86_64-darwin";
-  }
 else if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then
   mkNativeBinary {
     inherit wrapBuddy versionCheckHomeHook;

--- a/packages/eca/update.py
+++ b/packages/eca/update.py
@@ -21,7 +21,6 @@ HASHES_FILE = Path(__file__).parent / "hashes.json"
 PLATFORMS = {
     "x86_64-linux": "linux-amd64",
     "aarch64-linux": "linux-aarch64",
-    "x86_64-darwin": "macos-amd64",
     "aarch64-darwin": "macos-aarch64",
 }
 

--- a/packages/forgecode/hashes.json
+++ b/packages/forgecode/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "aarch64-darwin": "sha256-3zmNAgb2Vq6hcLLqHjPhditfXZtVR4EU4sJji0JPLd8=",
     "aarch64-linux": "sha256-CtGsyv/bwTIxYp53w+jMP8AB/kmxZTQdVRZogOnSjD8=",
-    "x86_64-linux": "sha256-aivxEmK8vYM04YB9gC24/nWqap8fde8t0kGIZqsbfps=",
-    "x86_64-darwin": "sha256-q7+e1GLlSH195ixKVmSpBsx0qxBo+FgDoSpUALyUuA4="
+    "x86_64-linux": "sha256-aivxEmK8vYM04YB9gC24/nWqap8fde8t0kGIZqsbfps="
   }
 }

--- a/packages/forgecode/package.nix
+++ b/packages/forgecode/package.nix
@@ -14,7 +14,6 @@ let
     platforms = {
       x86_64-linux = "x86_64-unknown-linux-gnu";
       aarch64-linux = "aarch64-unknown-linux-gnu";
-      x86_64-darwin = "x86_64-apple-darwin";
       aarch64-darwin = "aarch64-apple-darwin";
     };
     url =

--- a/packages/forgecode/update.py
+++ b/packages/forgecode/update.py
@@ -17,7 +17,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "x86_64-unknown-linux-gnu",
         "aarch64-linux": "aarch64-unknown-linux-gnu",
-        "x86_64-darwin": "x86_64-apple-darwin",
         "aarch64-darwin": "aarch64-apple-darwin",
     },
 )

--- a/packages/goose-cli/hashes.json
+++ b/packages/goose-cli/hashes.json
@@ -7,7 +7,6 @@
     "hashes": {
       "x86_64-linux": "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=",
       "aarch64-linux": "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=",
-      "x86_64-darwin": "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=",
       "aarch64-darwin": "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k="
     }
   }

--- a/packages/goose-cli/update.py
+++ b/packages/goose-cli/update.py
@@ -35,7 +35,6 @@ REPO = "goose"
 PLATFORMS = {
     "x86_64-linux": "x86_64-unknown-linux-gnu",
     "aarch64-linux": "aarch64-unknown-linux-gnu",
-    "x86_64-darwin": "x86_64-apple-darwin",
     "aarch64-darwin": "aarch64-apple-darwin",
 }
 

--- a/packages/handy/hashes.json
+++ b/packages/handy/hashes.json
@@ -2,7 +2,6 @@
   "version": "0.9.3",
   "hashes": {
     "x86_64-linux": "sha256-sWBzSkZchIqs7I7D5zhZbPQfGSeaUEjpbHQOW248sHM=",
-    "x86_64-darwin": "sha256-kUExmRh4p5KedOpED8Z1ocNVP061Hk1ow+Ut5Gd95iM=",
     "aarch64-darwin": "sha256-4mGlOxYaSgbvM5ITH5JBumk9ukI9CFJl7gbx8HtFFbc="
   }
 }

--- a/packages/handy/package.nix
+++ b/packages/handy/package.nix
@@ -34,10 +34,6 @@ let
       url = "https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb";
       hash = hashes.x86_64-linux;
     };
-    x86_64-darwin = fetchurl {
-      url = "https://github.com/cjpais/Handy/releases/download/v${version}/Handy_x64.app.tar.gz";
-      hash = hashes.x86_64-darwin;
-    };
     aarch64-darwin = fetchurl {
       url = "https://github.com/cjpais/Handy/releases/download/v${version}/Handy_aarch64.app.tar.gz";
       hash = hashes.aarch64-darwin;
@@ -46,7 +42,7 @@ let
 
   src =
     srcs.${stdenv.hostPlatform.system}
-      or (throw "Unsupported system: ${stdenv.hostPlatform.system}. Supported systems: x86_64-linux, x86_64-darwin, aarch64-darwin");
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}. Supported systems: x86_64-linux, aarch64-darwin");
 
   desktopItem = makeDesktopItem {
     name = "handy";
@@ -167,7 +163,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ ];
     platforms = [
       "x86_64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "handy";

--- a/packages/handy/update.py
+++ b/packages/handy/update.py
@@ -21,7 +21,6 @@ HASHES_FILE = Path(__file__).parent / "hashes.json"
 # Platform filenames use different patterns, not suitable for calculate_platform_hashes
 PLATFORMS = {
     "x86_64-linux": "Handy_{version}_amd64.deb",
-    "x86_64-darwin": "Handy_x64.app.tar.gz",
     "aarch64-darwin": "Handy_aarch64.app.tar.gz",
 }
 

--- a/packages/herdr/hashes.json
+++ b/packages/herdr/hashes.json
@@ -3,7 +3,6 @@
   "hash": "sha256-dBOQYLFitJ+E3XNz44Ag3CIrBxFj16CmVPp7qil0ssg=",
   "cargoHash": "sha256-XHzZy2tKLbMQy4POmXowUcGf77ZPunG/oQ3P2wOoVls=",
   "binaryHashes": {
-    "aarch64-darwin": "sha256-JJkuFiXb3LGDVKWeKZ5LJjwxJACzE5bNwHzUbtV/JKc=",
-    "x86_64-darwin": "sha256-3fQwEzNS4XEkE9XYZbNKSFVG9GWIk/yJmGJX1lp1hag="
+    "aarch64-darwin": "sha256-JJkuFiXb3LGDVKWeKZ5LJjwxJACzE5bNwHzUbtV/JKc="
   }
 }

--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -99,7 +99,6 @@ let
   });
 
   binaryAssetMap = {
-    x86_64-darwin = "herdr-macos-x86_64";
     aarch64-darwin = "herdr-macos-aarch64";
   };
 

--- a/packages/herdr/update.py
+++ b/packages/herdr/update.py
@@ -52,7 +52,6 @@ def update_vendored_zig_deps(version: str) -> None:
 
 DARWIN_PLATFORMS = {
     "aarch64-darwin": "macos-aarch64",
-    "x86_64-darwin": "macos-x86_64",
 }
 
 

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -418,7 +418,6 @@ python3.pkgs.buildPythonApplication {
     changelog = "https://github.com/NousResearch/hermes-agent/releases/tag/v${version}";
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    # x86_64-darwin: pyarrow (via faster-whisper chain) broken there.
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/packages/hunk/package.nix
+++ b/packages/hunk/package.nix
@@ -92,7 +92,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/packages/jules/hashes.json
+++ b/packages/jules/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "x86_64-linux": "sha256-c869LI+Jubsk703MuM15Q8y2npmzfeJnwvV5Mjen0QM=",
     "aarch64-linux": "sha256-cB0Eo25xUC3G6p/Jc0U7IsoIVQatLLqmwLZzkX7N+/w=",
-    "x86_64-darwin": "sha256-CYqHk6+o1pMJmM9rQvr4+/RKjTZS7jBcAzWltybhFnQ=",
     "aarch64-darwin": "sha256-iedh0tQC3dLObgY0Xf5HPfwCSxqYp2OZCQ9xPuKuklQ="
   }
 }

--- a/packages/jules/package.nix
+++ b/packages/jules/package.nix
@@ -14,7 +14,6 @@ let
     platforms = {
       x86_64-linux = "linux_amd64";
       aarch64-linux = "linux_arm64";
-      x86_64-darwin = "darwin_amd64";
       aarch64-darwin = "darwin_arm64";
     };
     url =

--- a/packages/jules/update.py
+++ b/packages/jules/update.py
@@ -24,7 +24,6 @@ NPM_PACKAGE = "@google/jules"
 PLATFORMS = {
     "x86_64-linux": "linux_amd64",
     "aarch64-linux": "linux_arm64",
-    "x86_64-darwin": "darwin_amd64",
     "aarch64-darwin": "darwin_arm64",
 }
 

--- a/packages/junie/hashes.json
+++ b/packages/junie/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "x86_64-linux": "sha256-XYZ8ALv7w2YElyWSYj5KGyZ3FQ5/IwkgOg2AnNNABSE=",
     "aarch64-linux": "sha256-b3sv0UGfdhXb894oYWOX0bjJDQVdaREC2kgpL8xRDa4=",
-    "x86_64-darwin": "sha256-Hic4cbRE4b79SA0Jxq2U1IjrAOkByTxNxzTSrCoc2sQ=",
     "aarch64-darwin": "sha256-yKCq0ZcUk46OLgmJ50sMS5s1PJakWd43Is7NdqcbLpk="
   }
 }

--- a/packages/junie/package.nix
+++ b/packages/junie/package.nix
@@ -17,7 +17,6 @@ let
     platforms = {
       x86_64-linux = "linux-amd64";
       aarch64-linux = "linux-aarch64";
-      x86_64-darwin = "macos-amd64";
       aarch64-darwin = "macos-aarch64";
     };
     url =

--- a/packages/junie/update.py
+++ b/packages/junie/update.py
@@ -21,7 +21,6 @@ UPDATE_INFO_URL = (
 PLATFORMS = {
     "x86_64-linux": "linux-amd64",
     "aarch64-linux": "linux-aarch64",
-    "x86_64-darwin": "macos-amd64",
     "aarch64-darwin": "macos-aarch64",
 }
 

--- a/packages/kilocode-cli/hashes.json
+++ b/packages/kilocode-cli/hashes.json
@@ -1,7 +1,6 @@
 {
   "version": "7.4.11",
   "hashes": {
-    "x86_64-darwin": "sha256-Ujj2fEwuOMHMWPq2nMq5uTfskA3d6uyCnz8WfZ15XnA=",
     "x86_64-linux": "sha256-zlMXlHfegcnVL0fWrZ1nsdpKgE4uJjzHJ+gZHqVsdUU=",
     "aarch64-linux": "sha256-CEQZRIZIuYG+RHYzn9fZcVnpzt1WRSZ/BkljcFoFiqQ=",
     "aarch64-darwin": "sha256-+3hILQQeZUfpIaBZn4fTIhc+e2ooxKkZXAkyeVjChaE="

--- a/packages/kilocode-cli/package.nix
+++ b/packages/kilocode-cli/package.nix
@@ -14,7 +14,6 @@ let
     platforms = {
       x86_64-linux = "linux-x64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/kilocode-cli/update.py
+++ b/packages/kilocode-cli/update.py
@@ -21,7 +21,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-x64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-x64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/mimo-code/hashes.json
+++ b/packages/mimo-code/hashes.json
@@ -2,7 +2,6 @@
   "version": "0.1.7",
   "hashes": {
     "aarch64-darwin": "sha256-i0vAcWTBcOnvcyCsm71TveUru8Gdrht/q22pbbwgFeA=",
-    "x86_64-darwin": "sha256-Qridn0IU6cHHnUO0J6ATknWEn135jd4TUKMKlLoMKyM=",
     "x86_64-linux": "sha256-H+tiDnRVIs1Dc3Cc7ZwVbcId1HAXP+tuVIIiGcOYCBQ=",
     "aarch64-linux": "sha256-+cFtmuK15k9krBSCLYc1thyXuRuRxX031DB+TgCBqK8="
   }

--- a/packages/mimo-code/package.nix
+++ b/packages/mimo-code/package.nix
@@ -27,10 +27,6 @@ let
       asset = "mimocode-linux-arm64.tar.gz";
       isZip = false;
     };
-    x86_64-darwin = {
-      asset = "mimocode-darwin-x64.zip";
-      isZip = true;
-    };
     aarch64-darwin = {
       asset = "mimocode-darwin-arm64.zip";
       isZip = true;

--- a/packages/mimo-code/update.py
+++ b/packages/mimo-code/update.py
@@ -17,7 +17,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "mimocode-linux-x64.tar.gz",
         "aarch64-linux": "mimocode-linux-arm64.tar.gz",
-        "x86_64-darwin": "mimocode-darwin-x64.zip",
         "aarch64-darwin": "mimocode-darwin-arm64.zip",
     },
 )

--- a/packages/mistral-vibe/package.nix
+++ b/packages/mistral-vibe/package.nix
@@ -256,7 +256,6 @@ python.pkgs.buildPythonApplication rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "vibe";

--- a/packages/oh-my-codex/package.nix
+++ b/packages/oh-my-codex/package.nix
@@ -31,14 +31,12 @@ let
   nodePlatformMap = {
     x86_64-linux = "linux";
     aarch64-linux = "linux";
-    x86_64-darwin = "darwin";
     aarch64-darwin = "darwin";
   };
 
   nodeArchMap = {
     x86_64-linux = "x64";
     aarch64-linux = "arm64";
-    x86_64-darwin = "x64";
     aarch64-darwin = "arm64";
   };
 
@@ -158,7 +156,6 @@ buildNpmPackage {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -30,11 +30,6 @@ let
       nativeLib = "libpi_natives.so";
       nodeTag = "linux-arm64";
     };
-    x86_64-darwin = {
-      bunTarget = "bun-darwin-x64";
-      nativeLib = "libpi_natives.dylib";
-      nodeTag = "darwin-x64";
-    };
     x86_64-linux = {
       bunTarget = "bun-linux-x64-modern";
       nativeLib = "libpi_natives.so";

--- a/packages/open-code-review/hashes.json
+++ b/packages/open-code-review/hashes.json
@@ -3,7 +3,6 @@
   "hashes": {
     "aarch64-darwin": "sha256-7dFKAeMXSEUOIDWjy+snbLLD/mAvpM24+QS2VuX+4i8=",
     "x86_64-linux": "sha256-Tw2M9otZx+NXP6gxJ3lAGqSO5JhzP7WSRetmR5GgnCA=",
-    "aarch64-linux": "sha256-SSdBNqm49SqEli6nvGOLm4uWhwTCFsVrNj5tVFx9N7o=",
-    "x86_64-darwin": "sha256-mBBwpzRD88BVVhaTkvV83rinpn0EJXn2SI/KFFnLYu4="
+    "aarch64-linux": "sha256-SSdBNqm49SqEli6nvGOLm4uWhwTCFsVrNj5tVFx9N7o="
   }
 }

--- a/packages/open-code-review/package.nix
+++ b/packages/open-code-review/package.nix
@@ -12,7 +12,6 @@ let
     platforms = {
       x86_64-linux = "linux-amd64";
       aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-amd64";
       aarch64-darwin = "darwin-arm64";
     };
     url =

--- a/packages/open-code-review/update.py
+++ b/packages/open-code-review/update.py
@@ -17,7 +17,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "linux-amd64",
         "aarch64-linux": "linux-arm64",
-        "x86_64-darwin": "darwin-amd64",
         "aarch64-darwin": "darwin-arm64",
     },
 )

--- a/packages/opencode/hashes.json
+++ b/packages/opencode/hashes.json
@@ -2,7 +2,6 @@
   "version": "1.18.4",
   "hashes": {
     "aarch64-darwin": "sha256-BPuIG2MrMjxxLf2m3LvG/Oc2OU8HunYXblLWZlkl1OY=",
-    "x86_64-darwin": "sha256-4XfFMmVFcgeZgdsdzkZKeK267ZZUoUKEiy6BvrjJ9cY=",
     "x86_64-linux": "sha256-urRjw/syJNOIu3z61j84cD35zwviz9LOjLSdiGtToXQ=",
     "aarch64-linux": "sha256-66h++6OXbVM6JMygMW+O83W1+OeXwKlcJe6RlwC3ujU="
   }

--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -27,10 +27,6 @@ let
       asset = "opencode-linux-arm64.tar.gz";
       isZip = false;
     };
-    x86_64-darwin = {
-      asset = "opencode-darwin-x64.zip";
-      isZip = true;
-    };
     aarch64-darwin = {
       asset = "opencode-darwin-arm64.zip";
       isZip = true;
@@ -140,7 +136,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "opencode";

--- a/packages/opencode/update.py
+++ b/packages/opencode/update.py
@@ -17,7 +17,6 @@ update_platform_binaries(
     platforms={
         "x86_64-linux": "opencode-linux-x64.tar.gz",
         "aarch64-linux": "opencode-linux-arm64.tar.gz",
-        "x86_64-darwin": "opencode-darwin-x64.zip",
         "aarch64-darwin": "opencode-darwin-arm64.zip",
     },
 )

--- a/packages/openfang/package.nix
+++ b/packages/openfang/package.nix
@@ -59,7 +59,6 @@ rustPlatform.buildRustPackage rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/packages/plannotator/package.nix
+++ b/packages/plannotator/package.nix
@@ -16,7 +16,6 @@ let
   platformMap = {
     x86_64-linux = "bun-linux-x64";
     aarch64-linux = "bun-linux-arm64";
-    x86_64-darwin = "bun-darwin-x64";
     aarch64-darwin = "bun-darwin-arm64";
   };
 
@@ -113,7 +112,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "plannotator";

--- a/packages/qoder-cli/hashes.json
+++ b/packages/qoder-cli/hashes.json
@@ -5,10 +5,6 @@
       "url": "https://qoder-ide.oss-accelerate.aliyuncs.com/qodercli/releases/1.1.1/qodercli-darwin-arm64.tar.gz",
       "hash": "sha256-X6shaUQm2rGRfeoBorOqQBRIGQAbry4miajW3IezZf4="
     },
-    "x86_64-darwin": {
-      "url": "https://qoder-ide.oss-accelerate.aliyuncs.com/qodercli/releases/1.1.1/qodercli-darwin-x64.tar.gz",
-      "hash": "sha256-DS9diKiaGlqe/Hc4m7WJUIPckUfXDBKKqVhyRBazkD0="
-    },
     "aarch64-linux": {
       "url": "https://qoder-ide.oss-accelerate.aliyuncs.com/qodercli/releases/1.1.1/qodercli-linux-arm64.tar.gz",
       "hash": "sha256-LUNUcP9ByzJRG2VC3jWXFkQyiC7xMJnLz06Qdoe7Llg="

--- a/packages/qoder-cli/package.nix
+++ b/packages/qoder-cli/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/packages/qoder-cli/update.py
+++ b/packages/qoder-cli/update.py
@@ -30,7 +30,6 @@ MANIFEST_URL = (
 PLATFORM_MAP = {
     ("linux", "amd64"): "x86_64-linux",
     ("linux", "arm64"): "aarch64-linux",
-    ("darwin", "amd64"): "x86_64-darwin",
     ("darwin", "arm64"): "aarch64-darwin",
 }
 

--- a/packages/semble/package.nix
+++ b/packages/semble/package.nix
@@ -222,12 +222,5 @@ python3.pkgs.buildPythonApplication rec {
     sourceProvenance = with sourceTypes; [ fromSource ];
     maintainers = with flake.lib.maintainers; [ murlakatam ];
     mainProgram = "semble";
-    # x86_64-darwin excluded: arrow-cpp (transitive via tree-sitter-language-pack)
-    # is marked broken on that platform in nixpkgs.
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
   };
 }

--- a/packages/spec-kit/package.nix
+++ b/packages/spec-kit/package.nix
@@ -47,7 +47,6 @@ python3.pkgs.buildPythonApplication rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     mainProgram = "specify";

--- a/rules/no-x86-64-darwin-python.yml
+++ b/rules/no-x86-64-darwin-python.yml
@@ -1,0 +1,8 @@
+id: no-x86-64-darwin-python
+language: python
+severity: error
+message: >-
+  x86_64-darwin is not a supported system in this repo (dropped from flake `systems`). Do not add it to update-script platform maps.
+rule:
+  kind: string_content
+  regex: 'x86_64-darwin'

--- a/rules/no-x86-64-darwin.yml
+++ b/rules/no-x86-64-darwin.yml
@@ -1,0 +1,8 @@
+id: no-x86-64-darwin
+language: nix
+severity: error
+message: >-
+  x86_64-darwin is not a supported system in this repo (dropped from flake `systems`). Do not add platform mappings, hashes, or meta.platforms entries for it.
+rule:
+  kind: string_fragment
+  regex: 'x86_64-darwin'


### PR DESCRIPTION

The flake never exposed x86_64-darwin outputs (it is absent from the
systems list), so per-package platform maps, hashes, update-script
mappings, and meta.platforms entries for it were dead weight that never
got built or tested. Remove them and add ast-grep rules (nix + python)
so the platform is not reintroduced by accident.
