### PR TITLE
Revert "hermes-agent: set HERMES_MANAGED so hermes update fails cleanly"

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -325,10 +325,6 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_OPTIONAL_SKILLS"
     "${placeholder "out"}/share/hermes/optional-skills"
-    # Prevent `hermes update` from trying to modify the Nix store.
-    "--set"
-    "HERMES_MANAGED"
-    "nixos"
     # Disable runtime pip installs; absent extras disable cleanly.
     "--set"
     "HERMES_DISABLE_LAZY_INSTALLS"
@@ -394,7 +390,6 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
     grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
-    grep -q HERMES_MANAGED $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
     test -d $out/share/hermes/skills


### PR DESCRIPTION
HERMES_MANAGED had the unintended side effect that is prevents all config from being written.

For example switching the model via `hermes model` doesn't work and shows the following message:

```
Cannot save configuration: this Hermes installation is managed by NixOS (HERMES_MANAGED=nixos).
Edit services.hermes-agent.settings in your configuration.nix and run:
  sudo nixos-rebuild switch
```

This reverts commit d43b3140a65ba2c369f0e073cbd420ea86296bfd.

## Summary

Remove HERMES_MANAGE variable from wrapper

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
