### PR TITLE
codex: 0.144.6 -> 0.145.0

### DIFF
--- a/packages/codex/hashes.json
+++ b/packages/codex/hashes.json
@@ -1,19 +1,13 @@
 {
-  "version": "0.144.6",
-  "hash": "sha256-S25nhnF4lEJQdiyKDV38ORbjm+BNsswLoE5ivF0SE2U=",
-  "cargoHash": "sha256-S4dsZXfmKvJItL2XYKyxfhqdCMATEG6oPjrtVRwkuYc=",
+  "version": "0.145.0",
+  "hash": "sha256-/r4mBoJhHB1v5NTA4Hk565/D5B0deYJf9xJW330hyf0=",
+  "cargoHash": "sha256-t9IMRK9R+Z67ThEcgBI0HQU0E4aJHcOjKp22RFclh9U=",
   "librusty_v8": {
     "version": "149.2.0",
     "hashes": {
       "x86_64-linux": "sha256-iu2YY323533Iv7i7R1nsW95HLQv3lD9Y4OYqNQlFxVk=",
       "aarch64-linux": "sha256-+XdRJ8pk3MSjZi0BpSGizvuluY+DOUOog9hHc7Kv88U=",
       "aarch64-darwin": "sha256-+rsuyNO6Wm3qY9uaNalg3FypheujLzQrm6Sqocc0sv4="
-    }
-  },
-  "livekit_webrtc": {
-    "tag": "webrtc-24f6822-2",
-    "hashes": {
-      "aarch64-darwin": "sha256-4IwJM6EzTFgQd2AdX+Hj9NWzmyqXrSioRax2L6GKL1U="
     }
   }
 }

--- a/packages/codex/package.nix
+++ b/packages/codex/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchzip,
   installShellFiles,
   makeWrapper,
   rustPlatform,
@@ -48,25 +47,6 @@ let
         inherit hash;
       };
 
-  # codex-realtime-webrtc pulls in livekit's webrtc-sys on macOS, whose
-  # build.rs would download a ~300MB prebuilt libwebrtc archive at build
-  # time. Prefetch it as a fixed-output derivation and point the crate at
-  # it via LK_CUSTOM_WEBRTC so the build stays sandboxed.
-  livekitWebrtcTriple =
-    {
-      aarch64-darwin = "mac-arm64";
-    }
-    .${stdenv.hostPlatform.system} or null;
-  livekitWebrtc =
-    if livekitWebrtcTriple == null then
-      null
-    else
-      fetchzip {
-        name = "livekit-webrtc-${versionData.livekit_webrtc.tag}-${livekitWebrtcTriple}";
-        url = "https://github.com/livekit/rust-sdks/releases/download/${versionData.livekit_webrtc.tag}/webrtc-${livekitWebrtcTriple}-release.zip";
-        hash = versionData.livekit_webrtc.hashes.${stdenv.hostPlatform.system};
-        meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-      };
 in
 rustPlatform.buildRustPackage (
   {
@@ -103,9 +83,6 @@ rustPlatform.buildRustPackage (
       # limit on aarch64-darwin.
       CARGO_PROFILE_RELEASE_DEBUG = "false";
       CARGO_PROFILE_RELEASE_STRIP = "symbols";
-    }
-    // lib.optionalAttrs (livekitWebrtc != null) {
-      LK_CUSTOM_WEBRTC = livekitWebrtc;
     };
 
     inherit preBuild;

--- a/packages/codex/update.py
+++ b/packages/codex/update.py
@@ -34,12 +34,6 @@ RUSTY_V8_PLATFORMS = {
     "aarch64-darwin": "aarch64-apple-darwin",
 }
 
-# codex-realtime-webrtc only enables livekit/webrtc-sys on macOS, so we
-# only need to prefetch the darwin prebuilt archives.
-LIVEKIT_WEBRTC_PLATFORMS = {
-    "aarch64-darwin": "mac-arm64",
-}
-
 
 def fetch_version() -> str:
     """Fetch latest codex version from GitHub releases."""
@@ -78,42 +72,6 @@ def librusty_v8_pins(
     return {"version": v8_version, "hashes": {k: hashes[k] for k in RUSTY_V8_PLATFORMS}}
 
 
-def livekit_webrtc_pins(
-    codex_version: str, previous: dict[str, Any] | None
-) -> dict[str, Any]:
-    """Return the prebuilt livekit webrtc pin for the given codex version.
-
-    codex pins a fork of livekit/rust-sdks via a git revision; that crate's
-    ``webrtc-sys-build`` hard-codes the upstream release tag to download.
-    Re-uses existing hashes when the tag is unchanged to avoid re-downloading
-    two ~300MB archives on every bump.
-    """
-    rust_sdks_rev = fetch_version_from_text(
-        f"https://raw.githubusercontent.com/openai/codex/rust-v{codex_version}/codex-rs/Cargo.lock",
-        r'name = "webrtc-sys-build"\nversion = "[^"]+"\n'
-        r'source = "git\+https://github\.com/[^?]+\?rev=([0-9a-f]+)',
-    )
-    webrtc_tag = fetch_version_from_text(
-        f"https://raw.githubusercontent.com/juberti-oai/rust-sdks/{rust_sdks_rev}/webrtc-sys/build/src/lib.rs",
-        r'WEBRTC_TAG: &str = "([^"]+)"',
-    )
-    print(f"livekit webrtc tag: {webrtc_tag} (rust-sdks rev {rust_sdks_rev[:10]})")
-
-    if previous and previous.get("tag") == webrtc_tag:
-        print("livekit webrtc unchanged, reusing hashes")
-        return previous
-
-    hashes = {
-        nix_platform: calculate_url_hash(
-            "https://github.com/livekit/rust-sdks/releases/download/"
-            f"{webrtc_tag}/webrtc-{triple}-release.zip",
-            unpack=True,
-        )
-        for nix_platform, triple in LIVEKIT_WEBRTC_PLATFORMS.items()
-    }
-    return {"tag": webrtc_tag, "hashes": hashes}
-
-
 def main() -> None:
     """Update the codex package."""
     data = load_hashes(HASHES_FILE)
@@ -137,7 +95,6 @@ def main() -> None:
         "hash": source_hash,
         "cargoHash": DUMMY_SHA256_HASH,
         "librusty_v8": librusty_v8_pins(latest, data.get("librusty_v8")),
-        "livekit_webrtc": livekit_webrtc_pins(latest, data.get("livekit_webrtc")),
     }
     save_hashes(HASHES_FILE, data)
 


### PR DESCRIPTION
## Summary

Codex 0.145.0 removed the webrtc dep, so remove it & bump codex version

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
