### PR TITLE
claude-agent-acp: default CLAUDE_CODE_EXECUTABLE to claude-code

### DIFF
--- a/packages/claude-agent-acp/package.nix
+++ b/packages/claude-agent-acp/package.nix
@@ -2,6 +2,8 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  makeWrapper,
+  claude-code,
 }:
 
 buildNpmPackage rec {
@@ -21,6 +23,17 @@ buildNpmPackage rec {
 
   # Disable install scripts to avoid platform-specific dependency fetching issues
   npmFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # The bundled @anthropic-ai/claude-agent-sdk platform packages ship a
+  # prebuilt dynamically linked `claude` binary that is not usable on NixOS;
+  # point the adapter at this flake's claude-code package instead, unless the
+  # user overrides CLAUDE_CODE_EXECUTABLE themselves.
+  postInstall = ''
+    wrapProgram $out/bin/claude-agent-acp \
+      --set-default CLAUDE_CODE_EXECUTABLE ${lib.getExe claude-code}
+  '';
 
   passthru.category = "ACP Ecosystem";
 


### PR DESCRIPTION
## Problem

`claude-agent-acp` is broken on NixOS out of the box. The bundled `@anthropic-ai/claude-agent-sdk` platform packages (e.g. `@anthropic-ai/claude-agent-sdk-linux-x64`) ship a prebuilt, dynamically linked `claude` binary. On NixOS that binary cannot be executed, so every prompt fails with:

```
Claude Code process exited with code 127. stderr: Could not start dynamically linked executable: .../node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
NixOS cannot run dynamically linked executables intended for generic linux environments out of the box.
```

The initialize handshake succeeds (pure JS), so the failure only shows up on the first prompt, which makes it look like a protocol error in ACP clients.

Note that patchelf is not a good option here: the binary is Bun-compiled with an embedded blob, the same reason nixpkgs uses wrapbuddy for `claude-code` itself.

## Fix

Wrap the adapter so `CLAUDE_CODE_EXECUTABLE` defaults to this flake's `claude-code` package, exactly mirroring the existing `codex-acp` wrapper that defaults `CODEX_PATH` to this flake's `codex` package. The adapter already honors `CLAUDE_CODE_EXECUTABLE`, and `--set-default` keeps it user-overridable.

## Testing

- `nix build .#claude-agent-acp` on x86_64-linux (NixOS)
- Verified the wrapped adapter completes a real ACP session end-to-end (initialize → session → prompt → file write) driven by an ACP client, where the unwrapped package fails with the exit-127 error above

🤖 Generated with [Claude Code](https://claude.com/claude-code)