### PR TITLE
fix(grok): avoid bubblewrap in versionCheckHook

### DIFF
--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -97,6 +97,7 @@ stdenv.mkDerivation {
   '';
 
   doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/libexec/grok/grok-launcher";
   nativeInstallCheckInputs = [
     versionCheckHook
     versionCheckHomeHook


### PR DESCRIPTION
## Summary
- `grok`'s Linux entry point (`bin/grok`) re-execs itself through `bubblewrap` to work around it hardcoding `/bin/bash`/`/bin/zsh` paths for shell tool calls
- That wrapping needs unprivileged user namespaces, which some sandboxes disallow (e.g. Ubuntu 24.04 GitHub Actions runners restrict them via AppArmor by default, and some Nix builders lack `CAP_SYS_ADMIN`), causing `installCheckPhase` to fail with `bwrap: setting up uid map: Permission denied`
- Points `versionCheckProgram` at the unwrapped `grok-launcher` instead — printing `--version`/`--help` doesn't need the `/bin` shell-path shim, so it doesn't need `bwrap` either

## Test plan
- [x] `nix build .#packages.aarch64-darwin.grok` builds and passes `versionCheckPhase` via `grok-launcher`
- [x] `nix fmt` reports no changes needed