### PR TITLE
omp: add runtime dependency on pulseaudio for /live

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -15,6 +15,7 @@
   python3,
   zig,
   cmake,
+  libpulseaudio,
 }:
 
 let
@@ -255,6 +256,7 @@ stdenv.mkDerivation {
       lib.makeLibraryPath [
         zlib
         stdenv.cc.cc.lib
+        libpulseaudio
       ]
     }"}
 


### PR DESCRIPTION
## Summary

https://github.com/numtide/llm-agents.nix/commit/770d89e1ea026779c768174f7bc7b02cce77e82d added the required opus dependency to fix the build, but in order to actually use the new `/live` mode there's still a runtime dependency on the audio backend(s) for miniaudio to function.

```rs
#[cfg(target_os = "macos")]
const AUDIO_BACKENDS: &[Backend] = &[Backend::CoreAudio];
#[cfg(target_os = "linux")]
const AUDIO_BACKENDS: &[Backend] = &[Backend::PulseAudio, Backend::Alsa, Backend::Jack];
```

These are the upstream list of audio backends for macOS and linux respectively, I unfortunately do not have access to a mac so there's no way for me to validate but at least on linux simply adding `libpulseaudio` to `LD_LIBRARY_PATH` in the wrapper seems to do the job. 

## Test plan

Simply built the package and ran `/live` to use it

- [x] `nix build .#<package>` succeeds

