### PR TITLE
gitbutler, workmux, vibe-kanban: drop darwin workarounds

### DIFF
--- a/packages/gitbutler/package.nix
+++ b/packages/gitbutler/package.nix
@@ -156,8 +156,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with flake.lib.maintainers; [ mic92 ];
     mainProgram = "gitbutler-tauri";
     platforms = platforms.linux ++ platforms.darwin;
-    # gtk4 4.22.4 currently fails to build on darwin in nixpkgs; unmark once
-    # nixpkgs ships a fixed gtk4.
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -113,8 +113,7 @@ rustPlatform.buildRustPackage {
     # cross-compile builds, which forces a from-source openssl build that
     # needs perl regardless of the host openssl present in buildInputs.
     perl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.lld ];
+  ];
   buildInputs = [
     openssl
     libgit2
@@ -131,12 +130,6 @@ rustPlatform.buildRustPackage {
   env = {
     SQLX_OFFLINE = "true";
     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # nixpkgs' classic ld64 crashes in its stubs pass when linking the
-    # mac-notification-sys Objective-C object (NixOS/nixpkgs#540450); use lld
-    # on darwin until the ld64 fix (NixOS/nixpkgs#536365) lands.
-    NIX_CFLAGS_LINK = "-fuse-ld=lld";
   };
 
   doCheck = false;

--- a/packages/workmux/package.nix
+++ b/packages/workmux/package.nix
@@ -4,7 +4,6 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
-  llvmPackages,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -24,15 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     installShellFiles
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.lld ];
-
-  # nixpkgs' classic ld64 crashes in its stubs pass when linking the
-  # mac-notification-sys Objective-C object (NixOS/nixpkgs#540450); use lld
-  # on darwin until the ld64 fix (NixOS/nixpkgs#536365) lands.
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_CFLAGS_LINK = "-fuse-ld=lld";
-  };
+  ];
 
   # Some tests require filesystem access outside the sandbox
   doCheck = false;


### PR DESCRIPTION
nixpkgs-unstable now ships a gtk4 4.22.4 that builds on darwin and an
ld64 with hardening disabled again (NixOS/nixpkgs#536365), so the
gitbutler broken marker and the lld linker workaround for
mac-notification-sys (NixOS/nixpkgs#540450) are no longer needed.
Verified aarch64-darwin builds of all three packages.

Fixes #6713
Partially addresses #6712 (bernstein otel test workaround still needed
with opentelemetry-exporter-otlp-proto-grpc 1.43.0).
