### PR TITLE
paseo-desktop: fix TTS and STT capabilities

### DIFF
--- a/packages/paseo-desktop/package.nix
+++ b/packages/paseo-desktop/package.nix
@@ -31,6 +31,8 @@
   makeDesktopItem,
   electron_41,
   libuv,
+  formatelf,
+  gcc-unwrapped,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -57,9 +59,13 @@ buildNpmPackage (finalAttrs: {
     python3 # for node-gyp (node-pty)
     makeWrapper
     copyDesktopItems
+    formatelf
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libuv ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libuv
+    gcc-unwrapped.lib
+  ];
 
   dontNpmBuild = true;
 


### PR DESCRIPTION
Sherpa ONNX is loaded dynamically and its prebuilt native module cannot find libstdc++.so.6 in the Nix runtime environment. Run formatelf during fixup and provide GCC's library output so the addon receives a store-backed RUNPATH for its C++ runtime dependencies.

## Summary

<!-- Briefly describe what this PR does -->

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
