### PR TITLE
herdr: fix source provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 <details>
 <summary><strong>herdr</strong> - Terminal workspace manager for AI coding agents</summary>
 
-- **Source**: unknown
+- **Source**: source
 - **License**: AGPL-3.0-or-later
 - **Homepage**: https://herdr.dev
 - **Usage**: `nix run github:numtide/llm-agents.nix#herdr -- --help`

--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -93,7 +93,7 @@ let
     passthru.category = "Workflow & Project Management";
 
     meta = commonMeta // {
-      sourceProvenance = with lib.sourceTypes; [ fromSource ];
+      sourceProvenance = [ lib.sourceTypes.fromSource ];
       platforms = lib.platforms.linux;
     };
   });


### PR DESCRIPTION
## Summary

Fix `herdr`'s source provenance metadata by explicitly referencing `lib.sourceTypes.fromSource`.

## Problem

The source-built `herdr` derivation used:

```nix
sourceProvenance = with lib.sourceTypes; [ fromSource ];
```

The package also defines a local derivation named `fromSource`. Nix selected that derivation instead of `lib.sourceTypes.fromSource`.

When a NixOS configuration disallows non-source packages, nixpkgs checks each provenance entry for `isSource`. Since the entry was a derivation, the NixOS build failed during evaluation:

```text
error: attribute 'isSource' missing
at pkgs/stdenv/generic/check-meta.nix:190:17:
   189|     attrs ? meta.sourceProvenance
   190|     && any (t: !t.isSource) attrs.meta.sourceProvenance
      |                 ^
   191|     && !allowNonSourcePredicate attrs;
```

This prevented the complete NixOS system configuration from building.

A normal `nix build .#herdr` did not expose the problem because this flake allows non-source packages by default, so nixpkgs did not inspect the malformed provenance entry.

## Fix

Use the fully qualified source type:

```nix
sourceProvenance = [ lib.sourceTypes.fromSource ];
```

## Reproduction

The failure can be reproduced from the pre-fix commit with:

```bash
NIXPKGS_ALLOW_NONSOURCE=0 nix build \
  --accept-flake-config \
  --impure \
  --no-link \
  --show-trace \
  .#herdr
```

Before the fix, this fails with `attribute 'isSource' missing`.

## Testing

- `nix fmt`
- `nix build --accept-flake-config .#herdr`
- Relevant package and metadata checks
- `nix flake check --accept-flake-config --no-build`
- Confirmed the old version fails and the fixed version succeeds
- Ran ./scripts/generate-package-docs.py
