### PR TITLE
hermes-agent: relax croniter pin

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -374,6 +374,7 @@ python3.pkgs.buildPythonApplication {
     # nixpkgs moved past upstream's == pins
     "rich"
     "pillow"
+    "croniter"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
nixpkgs bumped croniter to 6.2.4 while upstream pins `croniter==6.0.0`, which fails `pythonRuntimeDepsCheck`. Add croniter to `pythonRelaxDeps`.