### PR TITLE
zeroclaw: fix nix-update subpackage handling

### DIFF
--- a/packages/zeroclaw/nix-update-args
+++ b/packages/zeroclaw/nix-update-args
@@ -1,4 +1,4 @@
 --version-regex
 ^v([0-9]+\.[0-9]+\.[0-9]+)$
 --subpackage
-frontend
+npmDeps

--- a/packages/zeroclaw/package.nix
+++ b/packages/zeroclaw/package.nix
@@ -45,6 +45,8 @@ rustPlatform.buildRustPackage {
     "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
 
   npmDeps = fetchNpmDeps {
+    # nix-update needs a version attribute to update the subpackage hash
+    inherit version;
     src = frontendSrc;
     name = "${pname}-${version}-npm-deps";
     hash = "sha256-5lj/KyxZ87LYLR8jHbIiAohpXrqrQNwqLdenDgCmk5k=";


### PR DESCRIPTION
The update workflow failed because nix-update-args referenced a
non-existent 'frontend' subpackage attribute. Point it at npmDeps
instead and give the fetchNpmDeps derivation a version attribute so
nix-update can locate its position for hash updates.
