### PR TITLE
hermes-agent: expose modules to slash workers

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -373,6 +373,12 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_PYTHON_SRC_ROOT"
     "${placeholder "out"}/${python3.sitePackages}"
+    # Dashboard slash workers re-exec the bare sys.executable, bypassing both
+    # the application wrapper and the dependency environment.
+    "--prefix"
+    "PYTHONPATH"
+    ":"
+    "${placeholder "out"}/${python3.sitePackages}:${pythonEnv}/${python3.sitePackages}"
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
@@ -452,11 +458,14 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
     grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
+    grep -q PYTHONPATH $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
     test -d $out/share/hermes/skills
     test -d $out/share/hermes/optional-skills
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
+    PYTHONPATH="$out/${python3.sitePackages}:${pythonEnv}/${python3.sitePackages}" \
+      ${python3}/bin/python3 -c 'import tui_gateway.slash_worker, yaml'
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Matrix E2EE: mautrix.crypto must import and the disable switch wired in.

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -344,6 +344,12 @@ python3.pkgs.buildPythonApplication {
   # into the read-only store on any drift, silently disabling the feature
   # (e.g. nixpkgs aiosqlite 0.21.0 vs hermes pin 0.22.1 disabled matrix).
   # The closure already provides every dep, so presence is sufficient.
+  # Dashboard slash workers re-exec the bare sys.executable, which cannot
+  # import Hermes modules or its dependencies under Nix; run them with the
+  # wrapper-provided interpreter and source root instead of leaking a global
+  # PYTHONPATH into every subprocess Hermes spawns.
+  patches = [ ./slash-worker-hermes-python.patch ];
+
   postPatch = ''
     substituteInPlace tools/lazy_deps.py \
       --replace-fail 'Version(installed) in SpecifierSet(spec_tail)' 'True'
@@ -373,12 +379,6 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_PYTHON_SRC_ROOT"
     "${placeholder "out"}/${python3.sitePackages}"
-    # Dashboard slash workers re-exec the bare sys.executable, bypassing both
-    # the application wrapper and the dependency environment.
-    "--prefix"
-    "PYTHONPATH"
-    ":"
-    "${placeholder "out"}/${python3.sitePackages}:${pythonEnv}/${python3.sitePackages}"
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
@@ -458,14 +458,14 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
     grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
-    grep -q PYTHONPATH $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
     test -d $out/share/hermes/skills
     test -d $out/share/hermes/optional-skills
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
-    PYTHONPATH="$out/${python3.sitePackages}:${pythonEnv}/${python3.sitePackages}" \
-      ${python3}/bin/python3 -c 'import tui_gateway.slash_worker, yaml'
+    # Slash workers run HERMES_PYTHON with PYTHONPATH=HERMES_PYTHON_SRC_ROOT.
+    PYTHONPATH="$out/${python3.sitePackages}" \
+      ${pythonEnv}/bin/python3 -c 'import tui_gateway.slash_worker, yaml'
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Matrix E2EE: mautrix.crypto must import and the disable switch wired in.

--- a/packages/hermes-agent/slash-worker-hermes-python.patch
+++ b/packages/hermes-agent/slash-worker-hermes-python.patch
@@ -1,0 +1,43 @@
+From 3b1d01a2a0cb3e06295cb7c507af8cfb5278949c Mon Sep 17 00:00:00 2001
+From: mulatta <67085791+mulatta@users.noreply.github.com>
+Date: Sun, 2 Aug 2026 21:15:31 +0900
+Subject: [PATCH] fix slash worker Python environment
+
+Dashboard slash workers re-exec the bare sys.executable, which can neither
+import Hermes modules nor its dependencies under Nix. Use wrapper-provided
+interpreter and source root instead.
+
+Upstream: https://github.com/NousResearch/hermes-agent/pull/51277
+---
+ tui_gateway/server.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/tui_gateway/server.py b/tui_gateway/server.py
+index ca5876a..36e672a 100644
+--- a/tui_gateway/server.py
++++ b/tui_gateway/server.py
+@@ -328,7 +328,7 @@ class _SlashWorker:
+         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
+ 
+         argv = [
+-            sys.executable,
++            os.environ.get("HERMES_PYTHON", sys.executable),
+             "-m",
+             "tui_gateway.slash_worker",
+             "--session-key",
+@@ -354,6 +354,15 @@ class _SlashWorker:
+             inherit_profile_home=False,  # base already carries the HOME contract
+             extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
+         )
++        if os.environ.get("HERMES_PYTHON_SRC_ROOT"):
++            env["PYTHONPATH"] = os.pathsep.join(
++                p
++                for p in (
++                    os.environ["HERMES_PYTHON_SRC_ROOT"],
++                    env.get("PYTHONPATH"),
++                )
++                if p
++            )
+ 
+         # start_new_session=True detaches the slash worker into its own
+         # process group / session. Without this, the worker inherits the


### PR DESCRIPTION
## Summary

Dashboard slash commands fail under Nix because slash workers re-exec the bare Python interpreter, which cannot import either Hermes application modules or packaged dependencies. Prefix the Hermes wrapper's `PYTHONPATH` with both site-packages roots so inherited slash-worker environments can import `tui_gateway` and dependencies such as `yaml`, and add an install check covering that bare-interpreter path.

This is a packaging workaround until the upstream slash-worker callsite honors `HERMES_PYTHON` and `HERMES_PYTHON_SRC_ROOT`; related upstream work is tracked in NousResearch/hermes-agent#51277.

## Test plan

Verified `nix build .#hermes-agent` succeeds. Deployed the resulting package and confirmed the Dashboard's `/tools list` command returns the built-in toolsets instead of `error: slash worker exited`.

- [x] `nix build .#hermes-agent` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
