### PR TITLE
ironclaw: init at 1.0.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>ironclaw</strong> - Secure personal AI assistant that protects your data and expands its capabilities on the fly</summary>
+
+- **Source**: source
+- **License**: MIT / Apache-2.0
+- **Homepage**: https://github.com/nearai/ironclaw
+- **Usage**: `nix run github:numtide/llm-agents.nix#ironclaw -- --help`
+- **Nix**: [packages/ironclaw/package.nix](packages/ironclaw/package.nix)
+
+</details>
+<details>
 <summary><strong>localgpt</strong> - Local AI assistant with persistent markdown memory, autonomous tasks, and semantic search</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,11 +14,6 @@ inputs.nixpkgs.lib.extend (
     };
 
     maintainers = prev.maintainers // {
-      kmjayadeep = {
-        github = "kmjayadeep";
-        githubId = 6793260;
-        name = "Jayadeep KM";
-      };
       ak2k = {
         github = "ak2k";
         githubId = 19240940;
@@ -178,6 +173,11 @@ inputs.nixpkgs.lib.extend (
         github = "iainlane";
         githubId = 321014;
         name = "Iain Lane";
+      };
+      kmjayadeep = {
+        github = "kmjayadeep";
+        githubId = 6793260;
+        name = "Jayadeep KM";
       };
       ahacop = {
         github = "ahacop";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,11 @@ inputs.nixpkgs.lib.extend (
     };
 
     maintainers = prev.maintainers // {
+      kmjayadeep = {
+        github = "kmjayadeep";
+        githubId = 6793260;
+        name = "Jayadeep KM";
+      };
       ak2k = {
         github = "ak2k";
         githubId = 19240940;

--- a/packages/ironclaw/package.nix
+++ b/packages/ironclaw/package.nix
@@ -15,7 +15,10 @@
 }:
 
 let
+  # frontend/package.json pins node 22 and pnpm 11 via `engines`.
   pnpm = pnpm_11.override { nodejs-slim = nodejs_22; };
+  # The webui build.rs runs `corepack pnpm ...`.
+  # Forward that to our pnpm instead of letting corepack download its own.
   corepack = writeShellScriptBin "corepack" ''
     shift
     exec ${pnpm}/bin/pnpm "$@"
@@ -61,7 +64,6 @@ rustPlatform.buildRustPackage rec {
     "--package"
     "ironclaw"
   ];
-  cargoTestFlags = cargoBuildFlags;
 
   # Upstream's smoke tests require host CA certificates and GNU awk, but do
   # not arrange either in Cargo's test environment.
@@ -72,7 +74,6 @@ rustPlatform.buildRustPackage rec {
     versionCheckHook
     versionCheckHomeHook
   ];
-  versionCheckProgramArg = "--version";
 
   passthru.category = "AI Assistants";
 

--- a/packages/ironclaw/package.nix
+++ b/packages/ironclaw/package.nix
@@ -1,0 +1,92 @@
+{
+  flake,
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  rustPlatform,
+  nodejs_22,
+  openssl,
+  pkg-config,
+  pnpm_11,
+  pnpmConfigHook,
+  writeShellScriptBin,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  pnpm = pnpm_11.override { nodejs-slim = nodejs_22; };
+  corepack = writeShellScriptBin "corepack" ''
+    shift
+    exec ${pnpm}/bin/pnpm "$@"
+  '';
+in
+rustPlatform.buildRustPackage rec {
+  pname = "ironclaw";
+  version = "1.0.0-rc.1";
+
+  src = fetchFromGitHub {
+    owner = "nearai";
+    repo = "ironclaw";
+    tag = "ironclaw-v${version}";
+    hash = "sha256-1Err4VlwZgRL3Wyn3lFw2diSKa+Jr+GQXk7OpCYFu8M=";
+  };
+
+  cargoHash = "sha256-wnnkl0DZTXhanUtul0EmW8+jp/ZTRmfd/1LCXF137dU=";
+
+  pnpmDeps = fetchPnpmDeps {
+    pname = "${pname}-webui";
+    inherit version src;
+    inherit pnpm;
+    sourceRoot = "source/crates/ironclaw_webui/frontend";
+    hash = "sha256-+dEMbruwOengINcmRTBq4Xb3tgQmEQmnqEghl6EDnAU=";
+    fetcherVersion = 4;
+  };
+  pnpmRoot = "crates/ironclaw_webui/frontend";
+
+  nativeBuildInputs = [
+    corepack
+    nodejs_22
+    pkg-config
+    pnpm
+    pnpmConfigHook
+  ];
+  buildInputs = [ openssl ];
+
+  # cargo-auditable's metadata collection cannot resolve the upstream
+  # workspace's private libsql feature aliases.
+  auditable = false;
+
+  cargoBuildFlags = [
+    "--package"
+    "ironclaw"
+  ];
+  cargoTestFlags = cargoBuildFlags;
+
+  # Upstream's smoke tests require host CA certificates and GNU awk, but do
+  # not arrange either in Cargo's test environment.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.category = "AI Assistants";
+
+  meta = {
+    description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly";
+    homepage = "https://github.com/nearai/ironclaw";
+    changelog = "https://github.com/nearai/ironclaw/releases/tag/ironclaw-v${version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ kmjayadeep ];
+    mainProgram = "ironclaw";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package Ironclaw 1.0.0-rc.1, including its embedded WebUI frontend
- add package metadata, README entry, and maintainer record

## Test Strategy
- `nix fmt`
- `nix build --accept-flake-config .#ironclaw`
- Not applicable: upstream smoke tests require host CA certificates and GNU awk and fail in the Nix test sandbox; the derivation disables them while retaining the install version check.