### PR TITLE
cline: init at 3.0.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>cline</strong> - Autonomous coding agent CLI</summary>
+
+- **Source**: binary
+- **License**: Apache-2.0
+- **Homepage**: https://cline.bot
+- **Usage**: `nix run github:numtide/llm-agents.nix#cline -- --help`
+- **Nix**: [packages/cline/package.nix](packages/cline/package.nix)
+
+</details>
+<details>
 <summary><strong>code</strong> - Fork of codex. Orchestrate agents from OpenAI, Claude, Gemini or any provider.</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -179,6 +179,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 1678968;
         name = "Ara Hacopian";
       };
+      poelzi = {
+        github = "poelzi";
+        githubId = 66107;
+        name = "Daniel Poelzleithner";
+      };
     };
   }
 )

--- a/packages/cline/hashes.json
+++ b/packages/cline/hashes.json
@@ -1,8 +1,9 @@
 {
-  "version": "3.0.46",
+  "version": "3.0.47",
+  "launcherHash": "sha256-B4CC/64pooZ6/9DqxVYmRUhDGL8P8vhh1ImhDj8fO3E=",
   "hashes": {
-    "aarch64-darwin": "sha256-34KWp1bfHjg0qE6vKkhD4Q3NWhTBW4l6+eGIGhaUfE4=",
-    "aarch64-linux": "sha256-evzAH6yMdvVHI91rBwNlxSKyBWx4cHTAf357jd9KwRA=",
-    "x86_64-linux": "sha256-AB+iBN7N5mz7xr66wjqZU+S0X22n338+lUMEFs2onDs="
+    "aarch64-darwin": "sha256-xKhTFXR/h7dYjEJfn/VYL6om748q3cJ6MnwJ9xS5+3w=",
+    "aarch64-linux": "sha256-CWKnLJQ2Fh5l19U+Yj4egoJXmU7bgceyhLlFOHusHiw=",
+    "x86_64-linux": "sha256-qxsW35L+U5VeE5LLwcDgcno638Wxer/Utz/gAN+LUm4="
   }
 }

--- a/packages/cline/hashes.json
+++ b/packages/cline/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "3.0.46",
+  "hashes": {
+    "aarch64-darwin": "sha256-34KWp1bfHjg0qE6vKkhD4Q3NWhTBW4l6+eGIGhaUfE4=",
+    "aarch64-linux": "sha256-evzAH6yMdvVHI91rBwNlxSKyBWx4cHTAf357jd9KwRA=",
+    "x86_64-linux": "sha256-AB+iBN7N5mz7xr66wjqZU+S0X22n338+lUMEFs2onDs="
+  }
+}

--- a/packages/cline/package.nix
+++ b/packages/cline/package.nix
@@ -1,13 +1,19 @@
 {
   lib,
+  flake,
   stdenv,
+  fetchurl,
   platformSource,
+  cacert,
+  makeWrapper,
+  nodejs,
   wrapBuddy,
   versionCheckHook,
   versionCheckHomeHook,
 }:
 
 let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   source = platformSource {
     hashesFile = ./hashes.json;
     platforms = {
@@ -19,6 +25,10 @@ let
       { version, platform }:
       "https://registry.npmjs.org/@cline/cli-${platform}/-/cli-${platform}-${version}.tgz";
   };
+  launcher = fetchurl {
+    url = "https://registry.npmjs.org/cline/-/cline-${source.version}.tgz";
+    hash = versionData.launcherHash;
+  };
 in
 stdenv.mkDerivation {
   pname = "cline";
@@ -26,7 +36,11 @@ stdenv.mkDerivation {
 
   sourceRoot = "package";
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
 
   dontBuild = true;
   dontStrip = true;
@@ -34,10 +48,19 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib
-    cp -r . $out/lib/cline
-    mkdir -p $out/bin
-    ln -s $out/lib/cline/bin/cline $out/bin/cline
+    mkdir -p $out/lib/cline-platform $out/lib/cline-launcher
+    cp -r . $out/lib/cline-platform
+    tar -xzf ${launcher} --strip-components=1 -C $out/lib/cline-launcher package/bin
+
+    # Use the official npm launcher so Cline retains its OS trust-store
+    # handling. The npm postinstall normally caches this platform binary as
+    # bin/.cline; a symlink provides the same immutable Nix-store layout.
+    ln -s $out/lib/cline-platform/bin/cline $out/lib/cline-launcher/bin/.cline
+    patchShebangs $out/lib/cline-launcher/bin/cline
+
+    makeWrapper $out/lib/cline-launcher/bin/cline $out/bin/cline \
+      --set-default SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt \
+      --set-default SSL_CERT_DIR ${cacert}/etc/ssl/certs
 
     runHook postInstall
   '';
@@ -57,7 +80,7 @@ stdenv.mkDerivation {
     downloadPage = "https://www.npmjs.com/package/cline";
     license = lib.licenses.asl20;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = [ ];
+    maintainers = with flake.lib.maintainers; [ poelzi ];
     mainProgram = "cline";
     platforms = source.platforms;
   };

--- a/packages/cline/package.nix
+++ b/packages/cline/package.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  versionData = lib.importJSON ./hashes.json;
   source = platformSource {
     hashesFile = ./hashes.json;
     platforms = {

--- a/packages/cline/package.nix
+++ b/packages/cline/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  platformSource,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    };
+    url =
+      { version, platform }:
+      "https://registry.npmjs.org/@cline/cli-${platform}/-/cli-${platform}-${version}.tgz";
+  };
+in
+stdenv.mkDerivation {
+  pname = "cline";
+  inherit (source) version src;
+
+  sourceRoot = "package";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r . $out/lib/cline
+    mkdir -p $out/bin
+    ln -s $out/lib/cline/bin/cline $out/bin/cline
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Autonomous coding agent CLI";
+    homepage = "https://cline.bot";
+    changelog = "https://github.com/cline/cline/releases/tag/cli-v${source.version}";
+    downloadPage = "https://www.npmjs.com/package/cline";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = [ ];
+    mainProgram = "cline";
+    platforms = source.platforms;
+  };
+}

--- a/packages/cline/update.py
+++ b/packages/cline/update.py
@@ -8,15 +8,47 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import fetch_npm_version, update_platform_binaries
+from updater import (
+    calculate_platform_hashes,
+    calculate_url_hash,
+    fetch_npm_version,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
 
-update_platform_binaries(
-    Path(__file__).parent,
-    fetch_latest=lambda: fetch_npm_version("cline"),
-    url_template="https://registry.npmjs.org/@cline/cli-{platform}/-/cli-{platform}-{version}.tgz",
-    platforms={
-        "x86_64-linux": "linux-x64",
-        "aarch64-linux": "linux-arm64",
-        "aarch64-darwin": "darwin-arm64",
+pkg_dir = Path(__file__).parent
+hashes_file = pkg_dir / "hashes.json"
+data = load_hashes(hashes_file)
+current = data["version"]
+latest = fetch_npm_version("cline")
+
+print(f"Current: {current}, Latest: {latest}")
+
+if not should_update(current, latest) and "launcherHash" in data:
+    print("Already up to date")
+    raise SystemExit
+
+platforms = {
+    "x86_64-linux": "linux-x64",
+    "aarch64-linux": "linux-arm64",
+    "aarch64-darwin": "darwin-arm64",
+}
+hashes = calculate_platform_hashes(
+    "https://registry.npmjs.org/@cline/cli-{platform}/-/cli-{platform}-{version}.tgz",
+    platforms,
+    version=latest,
+)
+launcher_hash = calculate_url_hash(
+    f"https://registry.npmjs.org/cline/-/cline-{latest}.tgz"
+)
+
+save_hashes(
+    hashes_file,
+    {
+        "version": latest,
+        "launcherHash": launcher_hash,
+        "hashes": hashes,
     },
 )
+print(f"Updated to {latest}")

--- a/packages/cline/update.py
+++ b/packages/cline/update.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for the Cline CLI package."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import fetch_npm_version, update_platform_binaries
+
+update_platform_binaries(
+    Path(__file__).parent,
+    fetch_latest=lambda: fetch_npm_version("cline"),
+    url_template="https://registry.npmjs.org/@cline/cli-{platform}/-/cli-{platform}-{version}.tgz",
+    platforms={
+        "x86_64-linux": "linux-x64",
+        "aarch64-linux": "linux-arm64",
+        "aarch64-darwin": "darwin-arm64",
+    },
+)

--- a/packages/cline/update.py
+++ b/packages/cline/update.py
@@ -25,7 +25,7 @@ latest = fetch_npm_version("cline")
 
 print(f"Current: {current}, Latest: {latest}")
 
-if not should_update(current, latest) and "launcherHash" in data:
+if not should_update(current, latest):
     print("Already up to date")
     raise SystemExit
 


### PR DESCRIPTION
## Summary

- package Cline CLI 3.0.47 from its official platform-specific npm binaries
- preserve the official Node launcher and OS trust-store handling
- support x86_64 Linux, ARM64 Linux, and ARM64 macOS
- add a custom updater for the launcher and all platform hashes
- add `poelzi` as maintainer and regenerate the package catalog

## Test plan

- [x] `nix build --accept-flake-config path:.#checks.x86_64-linux.pkgs-cline`
- [x] `cline --version` and `cline --help`
- [x] official launcher delegation and CA-store handling
- [x] updater downgrade/regeneration test
- [x] `python3 .github/ci/check_maintainers.py --base-ref origin/main`
- [x] `./scripts/generate-package-docs.py`
- [x] `nix flake check --accept-flake-config --no-build path:.`
