### PR TITLE
packages: build with our own bun, not the consumer's

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,18 @@
               platformSource = import ./lib/platform-source.nix {
                 inherit (pkgs) stdenv fetchurl;
               };
+              # `bun build --compile` copies the running bun binary into the
+              # executable it produces, so bun ends up inside our outputs
+              # rather than being a build tool we can leave to the consumer.
+              # bun 1.3.14 miscomputes where its own runtime image ends once
+              # patchelf has rewritten the ELF, and emits a standalone binary
+              # that embeds the runtime twice and segfaults on startup. Via
+              # overlays.shared-nixpkgs we get whatever bun the consumer's
+              # overlays provide, so take bun from our own nixpkgs instead.
+              # Pinning it also keeps the bun packages substitutable for
+              # shared-nixpkgs consumers, whose bun would otherwise change
+              # every store path in the set.
+              bun = pkgsFor.${system}.bun or pkgs.bun;
               # bun2nix builder set (hook, fetchBunDeps, ...); the `bun2nix`
               # scope attribute is the CLI package.
               bun2nixLib = (pkgs.extend inputs.bun2nix.overlays.default).bun2nix;


### PR DESCRIPTION
## Problem

`bun build --compile` copies the running bun binary into the executable it produces, so bun ends up *inside* our outputs rather than being a build tool we can leave to the consumer.

bun 1.3.14 miscomputes where its own runtime image ends once patchelf has rewritten the ELF. The standalone executable it emits embeds the runtime twice and segfaults on startup, which surfaces as an empty `versionCheckHook` failure:

```
hunk> Did not find version 0.17.6 in the output of the command /nix/store/...-hunk-0.17.6/bin/hunk --version
hunk>
error: Cannot build '/nix/store/...-hunk-0.17.6.drv'
```

Every Nix packaging of bun runs `autoPatchelfHook`, so a consumer whose overlays pin bun 1.3.14 hands us a bun that cannot produce a working standalone binary — and `overlays.shared-nixpkgs` passes it straight through to `pi`, `ralph-tui`, `plannotator`, `omp` and `hunk`.

nixpkgs is still on bun 1.3.13, so this repo's own builds are fine today; it breaks for shared-nixpkgs consumers now, and for us as soon as nixpkgs bumps.

## Measurements

Compiling `console.log("ok")` on aarch64-linux:

| bun | `--compile` output | runs? |
| --- | --- | --- |
| stock 1.3.14 tarball | 94 MB | yes |
| same binary after `patchelf --set-interpreter` | 188 MB | SIGSEGV |
| 1.3.13, stock or patchelf'd | 101 MB | yes |

`patchelf --set-rpath` on bun 1.3.14 is worse still — `--compile` fails outright.

## Change

Take `bun` from our own nixpkgs in the package scope. As a side effect the bun packages stay substitutable for shared-nixpkgs consumers, whose bun would otherwise change every store path in the set.

## Testing

- `nix fmt`
- Store paths compared before/after for `hunk`, `omp`, `pi`, `ralph-tui` and `plannotator` on all three systems — **all unchanged**, so this is a no-op for our own builds.
- Reproduced the failure and confirmed the fix in an aarch64-linux container, building `pkgs.llm-agents.hunk` through `overlays.shared-nixpkgs` against a nixpkgs whose overlays pin bun 1.3.14:
  - before: `versionCheckHook` fails, binary is 233 MB and exits 139
  - after: builds with `versionCheckHook` enabled; `hunk --version` → `0.17.6`, binary 146 MB

The underlying `--compile` regression is a bun bug and worth reporting upstream; this makes the package set independent of it either way.