### PR TITLE
ccusage: fix stale pricing pin, add updater, 20.0.18 -> 20.0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 - **Source**: source
 - **License**: MIT
-- **Homepage**: https://github.com/ryoppippi/ccusage
+- **Homepage**: https://ccusage.com/
 - **Usage**: `nix run github:numtide/llm-agents.nix#ccusage -- --help`
 - **Nix**: [packages/ccusage/package.nix](packages/ccusage/package.nix)
 

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -78,6 +78,6 @@ rustPlatform.buildRustPackage rec {
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ ryoppippi ];
     mainProgram = "ccusage";
-    platforms = platforms.all;
+    platforms = platforms.unix;
   };
 }

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
-  jq,
   pkg-config,
   stdenv,
   versionCheckHook,
@@ -13,8 +12,10 @@
 let
   # build.rs embeds a LiteLLM pricing snapshot. Without a local file it
   # downloads model_prices_and_context_window.json at build time, which the
-  # sandbox forbids. Pin the same litellm rev as upstream's flake.lock
-  # (nodes.litellm.locked) and pass it via CCUSAGE_PRICING_JSON_PATH.
+  # sandbox forbids, so pass a pinned copy via CCUSAGE_PRICING_JSON_PATH.
+  # build.rs resolves that URL from nodes.litellm.locked in the tagged tree's
+  # flake.lock, so the pin must match it exactly or we embed different prices
+  # than upstream ships. update.py re-reads it from the tag on every bump.
   litellmRev = "34561482ed092d78c296cab7999486022af5a938";
   litellm-pricing = fetchurl {
     url = "https://raw.githubusercontent.com/BerriAI/litellm/${litellmRev}/model_prices_and_context_window.json";
@@ -47,10 +48,7 @@ rustPlatform.buildRustPackage rec {
   # tarball builds cannot satisfy; upstream's own derivation skips them too.
   doCheck = false;
 
-  nativeBuildInputs = [
-    jq
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
   # nixpkgs' Darwin cc-wrapper injects -liconv even though ccusage references no
   # iconv symbols, leaving an unused store dependency (upstream ccusage#1251).
@@ -62,18 +60,6 @@ rustPlatform.buildRustPackage rec {
   # build.rs falls back to the tagged tree's own version, but the tag is
   # authoritative for what we claim to ship.
   env.CCUSAGE_VERSION = version;
-
-  # The pricing snapshot above is pinned by hand while build.rs resolves it from
-  # upstream's flake.lock, so the two drift apart on every version bump unless
-  # the mismatch is fatal.
-  preBuild = ''
-    lockedRev=$(jq -r .nodes.litellm.locked.rev ../flake.lock)
-    if [ "$lockedRev" != "${litellmRev}" ]; then
-      echo "error: litellm pricing pin ${litellmRev} != upstream flake.lock $lockedRev" >&2
-      echo "       update litellmRev and its hash in packages/ccusage/package.nix" >&2
-      exit 1
-    fi
-  '';
 
   doInstallCheck = true;
 

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -24,18 +24,18 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "ccusage";
-  version = "20.0.18";
+  version = "20.0.19";
 
   src = fetchFromGitHub {
     owner = "ccusage";
     repo = "ccusage";
     tag = "v${version}";
-    hash = "sha256-vtxaUrzX9389M6GIfdbgmt+Z3lwCb1XgcLtdNj1lFWo=";
+    hash = "sha256-/x/RsJ8JLrGm8UXBewF/kbFLTdE51P+tPb3LwBT+LT8=";
   };
 
   sourceRoot = "${src.name}/rust";
 
-  cargoHash = "sha256-/sJ4c7F8tuiTxo2sUqgpB6z3rEC0BZlLn1FToz1Oe+g=";
+  cargoHash = "sha256-VJBLhQrVmeZSJ0EVpZaDiQ0eMpk5fgcaipgRd2GN9gw=";
 
   cargoBuildFlags = [
     "-p"

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   version = "20.0.18";
 
   src = fetchFromGitHub {
-    owner = "ryoppippi";
+    owner = "ccusage";
     repo = "ccusage";
     tag = "v${version}";
     hash = "sha256-vtxaUrzX9389M6GIfdbgmt+Z3lwCb1XgcLtdNj1lFWo=";
@@ -43,6 +43,8 @@ rustPlatform.buildRustPackage rec {
     "ccusage"
   ];
 
+  # Workspace tests need fixture crates and insta snapshots that the tagged
+  # tarball builds cannot satisfy; upstream's own derivation skips them too.
   doCheck = false;
 
   nativeBuildInputs = [
@@ -56,6 +58,10 @@ rustPlatform.buildRustPackage rec {
   env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-Wl,-dead_strip_dylibs";
 
   env.CCUSAGE_PRICING_JSON_PATH = litellm-pricing;
+
+  # build.rs falls back to the tagged tree's own version, but the tag is
+  # authoritative for what we claim to ship.
+  env.CCUSAGE_VERSION = version;
 
   # The pricing snapshot above is pinned by hand while build.rs resolves it from
   # upstream's flake.lock, so the two drift apart on every version bump unless
@@ -80,8 +86,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Analyze coding agent CLI token usage and costs from local data";
-    homepage = "https://github.com/ryoppippi/ccusage";
-    changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${version}";
+    homepage = "https://ccusage.com/";
+    changelog = "https://github.com/ccusage/ccusage/releases/tag/v${version}";
     license = licenses.mit;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with maintainers; [ ryoppippi ];

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
+  jq,
   pkg-config,
   stdenv,
   libiconv,
@@ -15,9 +16,10 @@ let
   # downloads model_prices_and_context_window.json at build time, which the
   # sandbox forbids. Pin the same litellm rev as upstream's flake.lock
   # (nodes.litellm.locked) and pass it via CCUSAGE_PRICING_JSON_PATH.
+  litellmRev = "34561482ed092d78c296cab7999486022af5a938";
   litellm-pricing = fetchurl {
-    url = "https://raw.githubusercontent.com/BerriAI/litellm/e59e34bed3670a6894d43129c2af16af28057d03/model_prices_and_context_window.json";
-    hash = "sha256-aPue4NpPpTKAtAYCI8S8ojmVCDtYr+mxwtYkOASEg3w=";
+    url = "https://raw.githubusercontent.com/BerriAI/litellm/${litellmRev}/model_prices_and_context_window.json";
+    hash = "sha256-jV/bRDNx+DNMKMsP9kvw82rRNexvdm7sdnzGLTt/gJI=";
   };
 in
 rustPlatform.buildRustPackage rec {
@@ -44,11 +46,26 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    jq
+    pkg-config
+  ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   env.CCUSAGE_PRICING_JSON_PATH = litellm-pricing;
+
+  # The pricing snapshot above is pinned by hand while build.rs resolves it from
+  # upstream's flake.lock, so the two drift apart on every version bump unless
+  # the mismatch is fatal.
+  preBuild = ''
+    lockedRev=$(jq -r .nodes.litellm.locked.rev ../flake.lock)
+    if [ "$lockedRev" != "${litellmRev}" ]; then
+      echo "error: litellm pricing pin ${litellmRev} != upstream flake.lock $lockedRev" >&2
+      echo "       update litellmRev and its hash in packages/ccusage/package.nix" >&2
+      exit 1
+    fi
+  '';
 
   doInstallCheck = true;
 

--- a/packages/ccusage/package.nix
+++ b/packages/ccusage/package.nix
@@ -6,7 +6,6 @@
   jq,
   pkg-config,
   stdenv,
-  libiconv,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -51,7 +50,10 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  # nixpkgs' Darwin cc-wrapper injects -liconv even though ccusage references no
+  # iconv symbols, leaving an unused store dependency (upstream ccusage#1251).
+  # dead_strip_dylibs drops load commands whose symbols are never referenced.
+  env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-Wl,-dead_strip_dylibs";
 
   env.CCUSAGE_PRICING_JSON_PATH = litellm-pricing;
 

--- a/packages/ccusage/update.py
+++ b/packages/ccusage/update.py
@@ -71,6 +71,23 @@ def resolve_litellm_rev(version: str) -> str:
     return str(rev)
 
 
+def pinned_litellm_rev() -> str:
+    """Read the litellm rev currently pinned in package.nix.
+
+    Returns:
+        The pinned 40-character rev.
+
+    Raises:
+        ValueError: If package.nix has no litellmRev pin.
+
+    """
+    match = LITELLM_REV_RE.search(PACKAGE_NIX.read_text())
+    if match is None:
+        msg = "package.nix has no litellmRev pin"
+        raise ValueError(msg)
+    return match.group(0).split('"')[1]
+
+
 def pin_litellm_pricing(rev: str, pricing_hash: str) -> None:
     """Rewrite the pinned litellm rev and its snapshot hash in package.nix.
 
@@ -104,22 +121,29 @@ def main() -> None:
 
     print(f"Current: {current}, Latest: {latest}")
 
-    if not should_update(current, latest):
-        print("Already up to date")
+    bump = should_update(current, latest)
+
+    # Re-pin against the version we will actually ship, whether or not there is
+    # a new release. The pin can be stale while the version is current -- that
+    # is how it drifted two months behind upstream -- so this must not hinge on
+    # a bump. Resolve over the network before touching package.nix so an
+    # unreachable tag cannot leave a half-written file.
+    target = latest if bump else current
+    rev = resolve_litellm_rev(target)
+
+    if rev == pinned_litellm_rev():
+        print(f"litellm pin already matches v{target} ({rev})")
+    else:
+        print(f"v{target} pins litellm {rev}, re-pinning")
+        pricing_url = (
+            f"https://raw.githubusercontent.com/BerriAI/litellm/{rev}/{PRICING_FILE}"
+        )
+        pricing_hash = calculate_url_hash(pricing_url)
+        pin_litellm_pricing(rev, pricing_hash)
+
+    if not bump:
+        print("Version already up to date")
         return
-
-    # Resolve everything over the network before touching package.nix, so a
-    # missing tag or an unreachable flake.lock cannot leave a half-bumped file.
-    rev = resolve_litellm_rev(latest)
-    print(f"v{latest} pins litellm {rev}")
-
-    print("Calculating LiteLLM pricing hash...")
-    pricing_url = (
-        f"https://raw.githubusercontent.com/BerriAI/litellm/{rev}/{PRICING_FILE}"
-    )
-    pricing_hash = calculate_url_hash(pricing_url)
-
-    pin_litellm_pricing(rev, pricing_hash)
 
     subprocess.run(
         ["nix-update", "--flake", "ccusage", "--version", latest],

--- a/packages/ccusage/update.py
+++ b/packages/ccusage/update.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 nixpkgs#nix-update --command python3
+
+"""Update script for ccusage.
+
+nix-update handles version, source hash and cargoHash on its own, but it knows
+nothing about the LiteLLM pricing snapshot the build embeds. build.rs derives
+that snapshot's URL from nodes.litellm.locked in the tagged tree's flake.lock;
+we pin a copy instead so the build needs no network. Nothing ties the two
+together, so a plain nix-update bump leaves the pin behind and the binary
+embeds prices upstream never shipped -- new models silently fall out of the
+embedded table.
+
+Re-read the rev from the tag being packaged, then delegate the rest to
+nix-update.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_url_hash,
+    fetch_github_latest_release,
+    fetch_text,
+    nix_eval,
+    should_update,
+)
+
+PACKAGE_NIX = Path(__file__).parent / "package.nix"
+
+OWNER = "ccusage"
+REPO = "ccusage"
+
+PRICING_FILE = "model_prices_and_context_window.json"
+
+# `litellmRev = "<40 hex>";`
+LITELLM_REV_RE = re.compile(r'(litellmRev = ")[0-9a-f]{40}(")')
+# The first `hash = "..."` inside the litellm-pricing fetchurl block. Anchoring
+# on the block keeps this off the fetchFromGitHub hash further down the file.
+PRICING_HASH_RE = re.compile(
+    r'(litellm-pricing = fetchurl \{.*?hash = ")[^"]+(")',
+    re.DOTALL,
+)
+
+
+def resolve_litellm_rev(version: str) -> str:
+    """Read the litellm rev that the given ccusage tag builds against.
+
+    Args:
+        version: ccusage version without the leading "v".
+
+    Returns:
+        The 40-character litellm commit rev from the tag's flake.lock.
+
+    Raises:
+        ValueError: If the tag's flake.lock has no nodes.litellm.locked.rev.
+
+    """
+    url = f"https://raw.githubusercontent.com/{OWNER}/{REPO}/v{version}/flake.lock"
+    lock = json.loads(fetch_text(url))
+
+    rev = lock.get("nodes", {}).get("litellm", {}).get("locked", {}).get("rev")
+    if not rev:
+        msg = f"v{version} flake.lock is missing nodes.litellm.locked.rev"
+        raise ValueError(msg)
+    return str(rev)
+
+
+def pin_litellm_pricing(rev: str, pricing_hash: str) -> None:
+    """Rewrite the pinned litellm rev and its snapshot hash in package.nix.
+
+    Args:
+        rev: litellm commit rev to pin.
+        pricing_hash: SRI hash of the pricing JSON at that rev.
+
+    Raises:
+        ValueError: If either pin could not be located in package.nix.
+
+    """
+    text = PACKAGE_NIX.read_text()
+
+    text, rev_count = LITELLM_REV_RE.subn(rf"\g<1>{rev}\g<2>", text)
+    if rev_count != 1:
+        msg = f"expected one litellmRev pin in package.nix, found {rev_count}"
+        raise ValueError(msg)
+
+    text, hash_count = PRICING_HASH_RE.subn(rf"\g<1>{pricing_hash}\g<2>", text)
+    if hash_count != 1:
+        msg = f"expected one litellm-pricing hash in package.nix, found {hash_count}"
+        raise ValueError(msg)
+
+    PACKAGE_NIX.write_text(text)
+
+
+def main() -> None:
+    """Update ccusage, keeping the LiteLLM pricing pin in step with the tag."""
+    current = nix_eval(".#ccusage.version")
+    latest = fetch_github_latest_release(OWNER, REPO)
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    # Resolve everything over the network before touching package.nix, so a
+    # missing tag or an unreachable flake.lock cannot leave a half-bumped file.
+    rev = resolve_litellm_rev(latest)
+    print(f"v{latest} pins litellm {rev}")
+
+    print("Calculating LiteLLM pricing hash...")
+    pricing_url = (
+        f"https://raw.githubusercontent.com/BerriAI/litellm/{rev}/{PRICING_FILE}"
+    )
+    pricing_hash = calculate_url_hash(pricing_url)
+
+    pin_litellm_pricing(rev, pricing_hash)
+
+    subprocess.run(
+        ["nix-update", "--flake", "ccusage", "--version", latest],
+        check=True,
+    )
+
+    print(f"Updated ccusage to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Reviewed `packages/ccusage/package.nix` against upstream's own `package.nix` and fixed everything that turned up. The headline bug is user-visible: the embedded LiteLLM price table was two months stale and missing current Claude models. The pin that caused it is now maintained by an `update.py` rather than by hand.

## What changed

**The LiteLLM pricing pin was stale.** `build.rs` embeds a LiteLLM snapshot whose URL it derives from `nodes.litellm.locked` in the tagged tree's `flake.lock`. We pass a pinned copy so the sandbox needs no network, but the pin sat at `e59e34b` (2026-05-19) while v20.0.18 locks `3456148` (2026-07-20) — despite the comment claiming the two matched. In the built binary:

```
claude-sonnet-4-5      "claude-sonnet-4-5":{"cc":3.75e-6,...}
claude-opus-4-5        "claude-opus-4-5":{"cc":6.25e-6,...}
claude-sonnet-5        *** absent from the embedded price table ***
claude-opus-4-8        *** absent ***
claude-fable-5         *** absent ***
```

Not fatal — `pricing.rs` has a committed models.dev fallback covering all three — but online runs re-fetched those models from LiteLLM `main` at runtime, and offline runs used a different price source than upstream intends.

**`update.py` now owns the pin.** `nix-update` never touched it, so every bump widened the gap silently. The updater reads `nodes.litellm.locked.rev` from the tag it is about to package, prefetches that snapshot, rewrites both pins, and delegates version/source hash/`cargoHash` to `nix-update`. All network work happens before `package.nix` is touched, so an unreachable tag cannot leave a half-written file. CI already prefers `packages/<name>/update.py` over bare `nix-update`, so this travels with every automated bump.

Crucially the pin check does **not** depend on there being a new release — a stale pin on a current version is exactly the state this PR started from, so the updater repairs that too.

**`libiconv` was the entire Darwin runtime closure.** ccusage references no iconv symbols; the nixpkgs Darwin cc-wrapper injects `-liconv` regardless. Adding `libiconv` to `buildInputs` satisfied the flag but recorded a real store dependency. Upstream deliberately avoids this and strips the unused dylib instead (ccusage#1251); this now does the same via `-dead_strip_dylibs`.

**Repository moved to `ccusage/ccusage`.** `fetchFromGitHub` was relying on GitHub's owner redirect and `meta` pointed at the old location. Also sets `CCUSAGE_VERSION` explicitly (as upstream does) rather than letting `build.rs` read `package.json` from outside `sourceRoot`, narrows `platforms.all` to `platforms.unix`, and records why the workspace tests stay disabled.

**Bumps 20.0.18 -> 20.0.19**, produced by the new updater.

## Testing

`nix build .#ccusage` on aarch64-darwin, verified against the resulting 20.0.19 binary:

- new models are in the embedded table — `claude-sonnet-5 {"cc":2.5e-6,"cr":2e-7,"ctx":1000000,"i":2e-6,"o":0.00001}`, plus `claude-opus-4-8` and `claude-fable-5`
- `otool -L` lists only `/usr/lib/libSystem.B.dylib`; `nix-store -q --references` is empty
- `versionCheckHook` finds `20.0.19`
- `ast-grep scan packages/ccusage` and `nix fmt` clean; `meta.changelog` returns 200

The updater was tested on both paths:

- **version bump**: ran against 20.0.18, resolved v20.0.19's `flake.lock`, and produced the version, source-hash and `cargoHash` changes in this PR
- **drift only**: with the pin reverted to `e59e34b` while the version was already current, it re-pinned `3456148` and its hash, leaving `package.nix` byte-identical to a correct one

Not tested: Linux (`RUSTFLAGS` is empty there, so no behaviour change expected) and a repo-wide `nix flake check`.

## Note for reviewers

Upstream pairs `-dead_strip_dylibs` with an `install_name_tool` fallback in `postInstall`, because in their CI the cc-wrapper's `-liconv` can arrive after the linker resolves dead-stripping. If x86_64-darwin CI here shows libiconv back in the closure, that fallback is the remedy.

An earlier revision of this branch caught pin drift with a `preBuild` guard that shelled out to `jq`. Commit `65dc892e` replaces it: build-time detection could report the problem but not fix it, and the updater both detects and repairs it without adding a build dependency.
