### PR TITLE
aven: init at 0.1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>aven</strong> - Local-first task manager for power users and agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/raine/aven
+- **Usage**: `nix run github:numtide/llm-agents.nix#aven -- --help`
+- **Nix**: [packages/aven/package.nix](packages/aven/package.nix)
+
+</details>
+<details>
 <summary><strong>backlog-md</strong> - Backlog.md - A tool for managing project collaboration between humans and AI Agents in a git ecosystem</summary>
 
 - **Source**: source

--- a/packages/aven/package.nix
+++ b/packages/aven/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cacert,
+  git,
+  sqlite,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "aven";
+  version = "0.1.19";
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "aven";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O061QVxle2f9UdGBNdgovBskpT1tpUiEqAVHbyChDtI=";
+  };
+
+  cargoHash = "sha256-fDM1ymMOmCUc7q7onb5Fn49frzXtmZO4hk9ESgbCBww=";
+
+  # A handful of store tests assert display refs whose project key is inferred
+  # from the checkout directory's name (e.g. "aven" -> "AVN"). Nix unpacks the
+  # source into a directory called "source" (-> "SRC"), so rename it to "aven"
+  # to match upstream's expectations. Paired with the git init in preCheck.
+  postUnpack = ''
+    mv source aven
+    export sourceRoot=aven
+  '';
+
+  # Only build the CLI crate, not the aven-uniffi mobile bindings.
+  cargoBuildFlags = [
+    "--package"
+    "aven"
+  ];
+
+  postInstall = ''
+    install -d $out/share/aven
+    cp -r skills $out/share/aven/skills
+  '';
+
+  # git: TUI tests infer the project from the checkout's git repo (see preCheck).
+  # sqlite: cli_attachment_lifecycle integration tests shell out to `sqlite3`.
+  # cacert: the sync client (reqwest + rustls-native-certs) loads system CA
+  # certs when it is built, even for plain http://127.0.0.1 test servers, and
+  # errors with "No CA certificates were loaded from the system" in the Linux
+  # sandbox, which has none. Paired with SSL_CERT_FILE in preCheck.
+  nativeCheckInputs = [
+    cacert
+    git
+    sqlite
+  ];
+
+  checkFlags = [
+    # chrono resolves a named TZ (e.g. TZ=America/New_York) only from a hardcoded
+    # set of system paths (/usr/share/zoneinfo, ...) and ignores $TZDIR
+    # (https://github.com/chronotope/chrono/issues/1265), so the DST offset test
+    # cannot see a zoneinfo database in the hermetic sandbox and falls back to
+    # UTC. Skip just that test; the rest of cli_local runs.
+    "--skip=local_calendar_dates_use_offsets_across_daylight_saving_boundaries"
+    # `aven backup` shells out to a `sqlite3 .backup` subprocess (busy_timeout=0)
+    # while its own WAL connection to the same file is still open, so a WAL
+    # checkpoint racing that lock surfaces as "database is locked". The window is
+    # load-sensitive: it passes under light load but flakes on heavily parallel,
+    # slower runners (seen on aarch64). Run the suite single-threaded to remove
+    # the cross-test CPU contention that widens the race.
+    "--test-threads=1"
+  ];
+
+  # A large share of the TUI tests create tasks without an explicit project and
+  # rely on aven inferring one from the current directory's git repository
+  # (src/projects.rs: git_root walks up for a `.git`). The Nix sandbox is not a
+  # git repo, so inference yields nothing and the tasks fail with
+  # "project-required". Initialise a repo at the check cwd so inference resolves.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+    git init -q .
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = {
+    description = "Local-first task manager for power users and agents";
+    longDescription = ''
+      Aven is a local-first task manager built for both humans and AI agents.
+      It stores tasks offline in SQLite with optional self-hosted sync, exposes
+      an agent-first CLI, ships a polished terminal UI, and keeps tasks
+      markdown-native with unique IDs and workspace isolation.
+    '';
+    homepage = "https://github.com/raine/aven";
+    changelog = "https://github.com/raine/aven/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "aven";
+    maintainers = with lib.maintainers; [ sei40kr ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/packages/aven/package.nix
+++ b/packages/aven/package.nix
@@ -21,10 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-fDM1ymMOmCUc7q7onb5Fn49frzXtmZO4hk9ESgbCBww=";
 
-  # A handful of store tests assert display refs whose project key is inferred
-  # from the checkout directory's name (e.g. "aven" -> "AVN"). Nix unpacks the
-  # source into a directory called "source" (-> "SRC"), so rename it to "aven"
-  # to match upstream's expectations. Paired with the git init in preCheck.
+  # Some tests infer the project key from the checkout directory name
+  # ("aven" -> "AVN"), but Nix unpacks into "source".
   postUnpack = ''
     mv source aven
     export sourceRoot=aven
@@ -41,12 +39,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cp -r skills $out/share/aven/skills
   '';
 
-  # git: TUI tests infer the project from the checkout's git repo (see preCheck).
-  # sqlite: cli_attachment_lifecycle integration tests shell out to `sqlite3`.
-  # cacert: the sync client (reqwest + rustls-native-certs) loads system CA
-  # certs when it is built, even for plain http://127.0.0.1 test servers, and
-  # errors with "No CA certificates were loaded from the system" in the Linux
-  # sandbox, which has none. Paired with SSL_CERT_FILE in preCheck.
+  # git: tests infer the project from the checkout's git repo (see preCheck).
+  # sqlite: attachment tests shell out to `sqlite3`.
+  # cacert: rustls-native-certs fails without system CA certs in the sandbox.
   nativeCheckInputs = [
     cacert
     git
@@ -54,26 +49,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   checkFlags = [
-    # chrono resolves a named TZ (e.g. TZ=America/New_York) only from a hardcoded
-    # set of system paths (/usr/share/zoneinfo, ...) and ignores $TZDIR
-    # (https://github.com/chronotope/chrono/issues/1265), so the DST offset test
-    # cannot see a zoneinfo database in the hermetic sandbox and falls back to
-    # UTC. Skip just that test; the rest of cli_local runs.
+    # Needs a system zoneinfo database, which the sandbox lacks
+    # (chrono ignores $TZDIR: https://github.com/chronotope/chrono/issues/1265).
     "--skip=local_calendar_dates_use_offsets_across_daylight_saving_boundaries"
-    # `aven backup` shells out to a `sqlite3 .backup` subprocess (busy_timeout=0)
-    # while its own WAL connection to the same file is still open, so a WAL
-    # checkpoint racing that lock surfaces as "database is locked". The window is
-    # load-sensitive: it passes under light load but flakes on heavily parallel,
-    # slower runners (seen on aarch64). Run the suite single-threaded to remove
-    # the cross-test CPU contention that widens the race.
+    # `aven backup` races its own WAL connection against a `sqlite3 .backup`
+    # subprocess and flakes as "database is locked" on loaded runners.
     "--test-threads=1"
   ];
 
-  # A large share of the TUI tests create tasks without an explicit project and
-  # rely on aven inferring one from the current directory's git repository
-  # (src/projects.rs: git_root walks up for a `.git`). The Nix sandbox is not a
-  # git repo, so inference yields nothing and the tasks fail with
-  # "project-required". Initialise a repo at the check cwd so inference resolves.
+  # Many tests rely on inferring the project from the surrounding git repo;
+  # the sandbox is not a git repo, so create one.
   preCheck = ''
     export HOME=$(mktemp -d)
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
@@ -87,12 +72,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Local-first task manager for power users and agents";
-    longDescription = ''
-      Aven is a local-first task manager built for both humans and AI agents.
-      It stores tasks offline in SQLite with optional self-hosted sync, exposes
-      an agent-first CLI, ships a polished terminal UI, and keeps tasks
-      markdown-native with unique IDs and workspace isolation.
-    '';
     homepage = "https://github.com/raine/aven";
     changelog = "https://github.com/raine/aven/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;


### PR DESCRIPTION
## Summary

Add [`aven`](https://github.com/raine/aven) — a local-first task manager for power users and AI agents (Rust). Offline SQLite storage with optional self-hosted sync, an agent-first CLI, and a terminal UI.

- `rustPlatform.buildRustPackage`, pinned to `v0.1.19` via `tag`
- Only builds the `aven` CLI crate (skips the `aven-uniffi` mobile bindings)
- Installs the bundled agent skill to `$out/share/aven/skills`
- Category: `Workflow & Project Management`

The upstream test suite assumes a rich host environment that the hermetic Nix sandbox does not provide. Rather than disabling `doCheck`, the check environment is adjusted so the suite passes (all but one env-dependent test are kept):

- `preCheck` runs `git init` — TUI tests infer the active project from the checkout's git repo, else fail with `project-required`
- `postUnpack` renames the source dir `source` → `aven` — store tests assert display refs whose project key derives from the checkout dir name (`aven` → `AVN`, not `source`/`SRC`)
- `sqlite` in `nativeCheckInputs` — `cli_attachment_lifecycle` shells out to `sqlite3`
- `cacert` + `SSL_CERT_FILE` — the sync client (`reqwest` + `rustls-native-certs`) loads system CA certs when it is built, even for plain `http://127.0.0.1` test servers, and errors with `No CA certificates were loaded from the system` on the Linux sandbox, which has none (`cli_conflicts`, 9 tests)
- `checkFlags` skips `local_calendar_dates_use_offsets_across_daylight_saving_boundaries` — `chrono` resolves a named `TZ` (e.g. `America/New_York`) only from hardcoded paths (`/usr/share/zoneinfo`, …) and ignores `$TZDIR` ([chronotope/chrono#1265](https://github.com/chronotope/chrono/issues/1265)), so the sandbox lacks a zoneinfo database and the DST offset falls back to UTC. The one offset test is skipped; the rest of `cli_local` runs.
- `checkFlags` adds `--test-threads=1` — `aven backup` shells out to a `sqlite3 .backup` subprocess (`busy_timeout=0`) while its own WAL connection to the same file is still open, so a WAL checkpoint racing that lock surfaces as `database is locked`. The window is load-sensitive (passes under light load, flaked on the slower, heavily parallel aarch64 runner), so the suite runs single-threaded to remove the cross-test CPU contention that widens the race.

Only `darwin` differed enough to pass unpatched: it ships system CA certs and a zoneinfo database, and its runner load didn't hit the backup race — which is why the CA/tz/lock issues only surfaced on the Linux builders.

## Test plan

- [x] `nix build .#aven` succeeds on `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`
- [x] Package updates via `nix-update`

Additional verification:

- Full test suite passes in the sandbox (lib + integration, 0 failed aside from the one skipped DST test)
- `aven --version` → `aven 0.1.19` (via `versionCheckHook`)
- `nix-update --flake aven` confirmed to bump version + hashes (0.1.18 → 0.1.19)
- `nix fmt` / `ast-grep scan` clean
