### PR TITLE
ci: create update PR even if bump was pushed by an earlier failed run

### DIFF
--- a/.github/ci/create_pr.py
+++ b/.github/ci/create_pr.py
@@ -89,7 +89,10 @@ def create_or_update_pr(config: PrConfig, *, labels: str, auto_merge: bool) -> N
     commit the updater's changes on top and force-push.
     """
     run(["git", "add", "."])
-    run(["git", "commit", "-m", config.commit_message, "--signoff"])
+    # The commit may already exist on the reused branch if a previous run
+    # pushed it but failed before creating the PR.
+    if run(["git", "diff", "--quiet", "--cached"], check=False).returncode != 0:
+        run(["git", "commit", "-m", config.commit_message, "--signoff"])
     run(["git", "push", "--force", "origin", f"HEAD:{config.branch}"])
 
     pr_number = gh_get_pr_number(config.branch)

--- a/.github/ci/update.py
+++ b/.github/ci/update.py
@@ -21,8 +21,12 @@ log = logging.getLogger(__name__)
 
 
 def git_has_changes() -> bool:
-    """Check if the working tree has uncommitted changes."""
-    return run(["git", "diff", "--quiet"], check=False).returncode != 0
+    """Check if the branch differs from origin/main.
+
+    Diffing against origin/main also catches commits already on a reused
+    update/* branch that never made it into a pull request.
+    """
+    return run(["git", "diff", "--quiet", "origin/main"], check=False).returncode != 0
 
 
 def run_update_command(cmd: list[str], error_label: str) -> None:


### PR DESCRIPTION
If a previous run pushed the version bump to the update/* branch but
failed before opening the pull request, the next run saw no working-tree
changes and skipped the PR step, leaving the update stranded on the
branch. Detect changes by diffing against origin/main and only create a
new commit when there is actually something staged.
