### PR TITLE
swamp: init at 20260730.185412.0-sha.ff15e73d

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>swamp</strong> - Deterministic automation for AI agents</summary>
+
+- **Source**: binary
+- **License**: AGPL-3.0-only
+- **Homepage**: https://swamp-club.com/
+- **Usage**: `nix run github:numtide/llm-agents.nix#swamp -- --help`
+- **Nix**: [packages/swamp/package.nix](packages/swamp/package.nix)
+
+</details>
+<details>
 <summary><strong>td</strong> - A minimalist CLI for tracking tasks across AI coding sessions.</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -184,6 +184,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 66107;
         name = "Daniel Poelzleithner";
       };
+      selmison = {
+        github = "selmison";
+        githubId = 24687232;
+        name = "Selmison Miranda";
+      };
     };
   }
 )

--- a/packages/swamp/hashes.json
+++ b/packages/swamp/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "20260730.185412.0-sha.ff15e73d",
+  "hashes": {
+    "x86_64-linux": "sha256-fJg12cPiiZ2Fqo/kM40v6WVqYpUY8OvVdj0UbLhDByI=",
+    "aarch64-linux": "sha256-XLn245vmP1VpiheYmX53M9wbs5KioX/HywMcDNn3skc=",
+    "aarch64-darwin": "sha256-LnKAgpkgUHSP5ekRyQC3Gd1+dJdamBE7EDwgsb9vMrQ="
+  }
+}

--- a/packages/swamp/package.nix
+++ b/packages/swamp/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = {
+      os = "linux";
+      cpu = "x86_64";
+      artifact = "linux-x86_64";
+    };
+    aarch64-linux = {
+      os = "linux";
+      cpu = "aarch64";
+      artifact = "linux-aarch64";
+    };
+    aarch64-darwin = {
+      os = "darwin";
+      cpu = "aarch64";
+      artifact = "darwin-aarch64";
+    };
+  };
+
+  system = stdenv.hostPlatform.system;
+  platform = platformMap.${system} or (throw "Unsupported system: ${system}");
+in
+stdenv.mkDerivation {
+  pname = "swamp";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://artifacts.swamp-club.com/swamp/${version}/binary/${platform.os}/${platform.cpu}/swamp-${version}-binary-${platform.artifact}.tar.gz";
+    hash = hashes.${system};
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  dontStrip = true;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 swamp $out/bin/swamp
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = with lib; {
+    description = "Deterministic automation for AI agents";
+    homepage = "https://swamp-club.com/";
+    changelog = "https://git.swamp-club.com/swamp-club/swamp/src/tag/v${version}";
+    license = licenses.agpl3Only;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ selmison ];
+    platforms = builtins.attrNames platformMap;
+    mainProgram = "swamp";
+  };
+}

--- a/packages/swamp/package.nix
+++ b/packages/swamp/package.nix
@@ -16,17 +16,14 @@ let
     x86_64-linux = {
       os = "linux";
       cpu = "x86_64";
-      artifact = "linux-x86_64";
     };
     aarch64-linux = {
       os = "linux";
       cpu = "aarch64";
-      artifact = "linux-aarch64";
     };
     aarch64-darwin = {
       os = "darwin";
       cpu = "aarch64";
-      artifact = "darwin-aarch64";
     };
   };
 
@@ -38,7 +35,7 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://artifacts.swamp-club.com/swamp/${version}/binary/${platform.os}/${platform.cpu}/swamp-${version}-binary-${platform.artifact}.tar.gz";
+    url = "https://artifacts.swamp-club.com/swamp/${version}/binary/${platform.os}/${platform.cpu}/swamp-${version}-binary-${platform.os}-${platform.cpu}.tar.gz";
     hash = hashes.${system};
   };
 

--- a/packages/swamp/update.py
+++ b/packages/swamp/update.py
@@ -9,7 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from updater import (
-    calculate_url_hash,
+    calculate_platform_hashes,
     fetch_json,
     load_hashes,
     save_hashes,
@@ -18,58 +18,35 @@ from updater import (
 
 HASHES_FILE = Path(__file__).parent / "hashes.json"
 TAGS_API = "https://git.swamp-club.com/api/v1/repos/swamp-club/swamp/tags?limit=50"
-ARTIFACT_BASE = "https://artifacts.swamp-club.com/swamp"
 PLATFORMS = {
-    "x86_64-linux": ("linux", "x86_64", "linux-x86_64"),
-    "aarch64-linux": ("linux", "aarch64", "linux-aarch64"),
-    "aarch64-darwin": ("darwin", "aarch64", "darwin-aarch64"),
+    "x86_64-linux": ("linux", "x86_64"),
+    "aarch64-linux": ("linux", "aarch64"),
+    "aarch64-darwin": ("darwin", "aarch64"),
 }
-
-
-def latest_version() -> str:
-    """Return the newest version from the official repository's tags."""
-    tags = fetch_json(TAGS_API)
-    if not isinstance(tags, list):
-        msg = f"Expected a list of tags, got {type(tags)}"
-        raise TypeError(msg)
-
-    versions: list[str] = []
-    for tag in tags:
-        if not isinstance(tag, dict):
-            continue
-        name = tag.get("name")
-        if isinstance(name, str):
-            versions.append(name.removeprefix("v"))
-    if not versions:
-        msg = "No version tags returned by the official Swamp repository"
-        raise ValueError(msg)
-
-    return max(versions)
-
-
-def artifact_url(version: str, platform: tuple[str, str, str]) -> str:
-    """Build an artifact URL using the layout from the official installer."""
-    os_name, cpu, artifact = platform
-    filename = f"swamp-{version}-binary-{artifact}.tar.gz"
-    return f"{ARTIFACT_BASE}/{version}/binary/{os_name}/{cpu}/{filename}"
 
 
 def main() -> None:
     """Update the version and hashes for all supported platforms."""
     current = load_hashes(HASHES_FILE)["version"]
-    latest = latest_version()
+    tags = fetch_json(TAGS_API)
+    if not isinstance(tags, list):
+        msg = f"Expected a list of tags, got {type(tags)}"
+        raise TypeError(msg)
+    latest = max(tag["name"].removeprefix("v") for tag in tags)
 
     print(f"Current: {current}, Latest: {latest}")
     if not should_update(current, latest):
         print("Already up to date")
         return
 
-    hashes = {}
-    for nix_platform, artifact_platform in PLATFORMS.items():
-        hashes[nix_platform] = calculate_url_hash(
-            artifact_url(latest, artifact_platform)
-        )
-        print(f"Fetched hash for {nix_platform}")
+    hashes = calculate_platform_hashes(
+        "https://artifacts.swamp-club.com/swamp/{version}/binary/{platform}.tar.gz",
+        {
+            system: f"{os}/{cpu}/swamp-{latest}-binary-{os}-{cpu}"
+            for system, (os, cpu) in PLATFORMS.items()
+        },
+        version=latest,
+    )
 
     save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
     print(f"Updated to {latest}")

--- a/packages/swamp/update.py
+++ b/packages/swamp/update.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update the Swamp package from the project's official artifact service."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_url_hash,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+TAGS_API = "https://git.swamp-club.com/api/v1/repos/swamp-club/swamp/tags?limit=50"
+ARTIFACT_BASE = "https://artifacts.swamp-club.com/swamp"
+PLATFORMS = {
+    "x86_64-linux": ("linux", "x86_64", "linux-x86_64"),
+    "aarch64-linux": ("linux", "aarch64", "linux-aarch64"),
+    "aarch64-darwin": ("darwin", "aarch64", "darwin-aarch64"),
+}
+
+
+def latest_version() -> str:
+    """Return the newest version from the official repository's tags."""
+    tags = fetch_json(TAGS_API)
+    if not isinstance(tags, list):
+        msg = f"Expected a list of tags, got {type(tags)}"
+        raise TypeError(msg)
+
+    versions: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, dict):
+            continue
+        name = tag.get("name")
+        if isinstance(name, str):
+            versions.append(name.removeprefix("v"))
+    if not versions:
+        msg = "No version tags returned by the official Swamp repository"
+        raise ValueError(msg)
+
+    return max(versions)
+
+
+def artifact_url(version: str, platform: tuple[str, str, str]) -> str:
+    """Build an artifact URL using the layout from the official installer."""
+    os_name, cpu, artifact = platform
+    filename = f"swamp-{version}-binary-{artifact}.tar.gz"
+    return f"{ARTIFACT_BASE}/{version}/binary/{os_name}/{cpu}/{filename}"
+
+
+def main() -> None:
+    """Update the version and hashes for all supported platforms."""
+    current = load_hashes(HASHES_FILE)["version"]
+    latest = latest_version()
+
+    print(f"Current: {current}, Latest: {latest}")
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    hashes = {}
+    for nix_platform, artifact_platform in PLATFORMS.items():
+        hashes[nix_platform] = calculate_url_hash(
+            artifact_url(latest, artifact_platform)
+        )
+        print(f"Fetched hash for {nix_platform}")
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- package Swamp 20260730.185412.0-sha.ff15e73d from its official artifacts
- support x86_64-linux, aarch64-linux, and aarch64-darwin
- add a custom updater backed by the official tag API and artifact service
- add package documentation and maintainer metadata

## Test plan

- [x] `nix build --accept-flake-config .#swamp`
- [x] `nix flake check --accept-flake-config`
- [x] `python3 packages/swamp/update.py` reports the package is current
- [x] `./result/bin/swamp --version` reports the packaged version
