### PR TITLE
beads-rust: 0.2.16 -> 0.2.19

### DIFF
--- a/packages/beads-rust/hashes.json
+++ b/packages/beads-rust/hashes.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.2.16",
-  "hash": "sha256-3v0Le2g7jcU+FirFVmLY53jc0Q77G9oPjPYFMrpU/zI=",
-  "cargoHash": "sha256-I8R0UWt+dlG05RGdASDCBo56m2vx4wSTg/pzP9eHYGg=",
+  "version": "0.2.19",
+  "hash": "sha256-DsXAjFac20UpKuA8kp7Zj90rx6leM5tr6ZeMb+RvsWM=",
+  "cargoHash": "sha256-9lZgWwSi0v855ihjX9M4RgjSd9jEU8wsjo6jDXnxhUY=",
   "frankensqlite": {
-    "rev": "ca4c277b69dda5c55b140516a5b7ab0031755592",
-    "hash": "sha256-Tj7naCivL4Yt3702bnasausn1kde0pVxn47nC0c2RDs="
+    "rev": "5b49d27add667f46a6a048c8f28758ef27a3746c",
+    "hash": "sha256-prwg1yLAclw+9to66s8cYk3aqLKVJ5GXTRC+QL4Kw94="
   }
 }

--- a/packages/beads-rust/package.nix
+++ b/packages/beads-rust/package.nix
@@ -35,14 +35,6 @@ rustPlatform.buildRustPackage {
   postUnpack = ''
     cp -r ${frankensqlite} frankensqlite
     chmod -R u+w frankensqlite
-
-    # frankensqlite's workspace manifest pins asupersync to the maintainer's
-    # absolute dev path (/dp/asupersync), which does not exist here. The crate
-    # is published on crates.io at the same version and is already locked in
-    # beads_rust's Cargo.lock, so drop the path override to resolve from the
-    # registry.
-    substituteInPlace frankensqlite/Cargo.toml \
-      --replace-fail ', path = "/dp/asupersync", default-features = false' ', default-features = false'
   '';
 
   postPatch = ''


### PR DESCRIPTION
The scheduled update job failed (https://github.com/numtide/llm-agents.nix/actions/runs/30793629415) because the newer frankensqlite pin no longer contains the `/dp/asupersync` path override that our `substituteInPlace` in `postUnpack` patched out. Upstream removed the override, so the workaround is dropped together with the version bump.

Verified `checks.x86_64-linux.pkgs-beads-rust` builds and the version check passes.