### PR TITLE
fix(omp): re-sign Bun binary on Darwin

### DIFF
--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -9,6 +9,7 @@
   rustPlatform,
   pkg-config,
   makeWrapper,
+  rcodesign,
   formatelf,
   zlib,
   libopus,
@@ -75,7 +76,8 @@ stdenv.mkDerivation {
     # audiopus_sys (new dependency in 17.1.3) builds bundled libopus via cmake
     cmake
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ formatelf ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ formatelf ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ rcodesign ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
@@ -261,6 +263,12 @@ stdenv.mkDerivation {
     }"}
 
     runHook postInstall
+  '';
+
+  # Re-sign the bun-compiled binary after fixup. fixDarwinDylibNames may run
+  # install_name_tool, and Bun can produce invalid signatures on newer macOS.
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed $out/lib/omp/omp
   '';
 
   # Workers and the stats dashboard only fail at runtime when their bunfs


### PR DESCRIPTION
## Summary

Fixes `omp` failing to start on newer macOS releases because its Bun-compiled executable has an invalid code signature. I followed the same flow in `pi`.

- Adds `rcodesign` as a Darwin-only native build input.
- Re-signs the OMP executable after Darwin fixup, since `install_name_tool` can invalidate Bun-generated signatures.
- Leaves Linux package behavior unchanged.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#omp` succeeds on `aarch64-darwin` running macOS 27
- [x] `/usr/bin/codesign --verify --deep --strict --verbose=4` succeeds
- [x] `omp --version` reports `omp/17.2.8`
- [x] `omp --smoke-test` reports `smoke-test: ok`
- [x] The `x86_64-linux` package still evaluates successfully
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work — N/A; this PR does not update the package

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
