### PR TITLE
omp: fix Bun.Image support by compiling against a pinned bun

### DIFF
--- a/packages/bun-bin/hashes.json
+++ b/packages/bun-bin/hashes.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.4.0-canary.1",
+  "tag": "canary",
+  "hashes": {
+    "aarch64-darwin": "sha256-upcAnx7TF7mc259T1Pxzzj4qSbKW0SaN2P88xkvUuF0=",
+    "aarch64-linux": "sha256-UOtT/yQErqa24OngNRjZntsBuE+j7ZLJtRwi6mHaLVw=",
+    "x86_64-darwin": "sha256-LSphq+gJwM37LNeUwosi0070r3O4wLFCO0+oDUK4hno=",
+    "x86_64-linux": "sha256-FQN47aaKp4qrfVNMA4wpwIoNIXHxfzWgbne5Jo3fMmc="
+  }
+}

--- a/packages/bun-bin/package.nix
+++ b/packages/bun-bin/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  unzip,
+  installShellFiles,
+  openssl,
+  cctools,
+  darwin,
+  rcodesign,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  # Release tag holding the artifacts. Normally "bun-v<version>"; the rolling
+  # "canary" tag is used while a needed fix is merged upstream but unreleased.
+  #
+  # Currently pinned to canary for oven-sh/bun#31024 (merged 2026-07-29), the
+  # ELF fix without which `bun build --compile` emits segfaulting binaries on
+  # NixOS. The newest stable, 1.3.14, predates it. update.py drops `tag` and
+  # returns to a stable tag as soon as bun 1.4.0 is released; note that the
+  # canary artifacts are mutable, so the pinned hashes go stale on rotation.
+  releaseTag = versionData.tag or "bun-v${version}";
+
+  archName =
+    {
+      "aarch64-darwin" = "bun-darwin-aarch64";
+      "aarch64-linux" = "bun-linux-aarch64";
+      "x86_64-darwin" = "bun-darwin-x64-baseline";
+      "x86_64-linux" = "bun-linux-x64";
+    }
+    .${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform for bun-bin: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "bun-bin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/oven-sh/bun/releases/download/${releaseTag}/${archName}.zip";
+    hash =
+      hashes.${stdenvNoCC.hostPlatform.system}
+        or (throw "Missing bun hash for ${stdenvNoCC.hostPlatform.system}");
+  };
+
+  # Darwin zips contain a subdirectory; Linux ones extract flat.
+  sourceRoot =
+    {
+      "aarch64-darwin" = archName;
+      "x86_64-darwin" = archName;
+    }
+    .${stdenvNoCC.hostPlatform.system} or null;
+
+  strictDeps = true;
+
+  # Deliberate exception to the repo-wide use-formatelf rule (see the ignore
+  # entry in rules/use-formatelf.yml).
+  #
+  # `bun build --compile` copies the running bun binary as the template for
+  # its output and appends a .bun section, so the template's segment layout
+  # has to be one bun's own ELF writer understands. Measured on x86_64-linux:
+  #
+  #   bun         patcher      bun runs   compiled output runs
+  #   1.3.13      patchelf     yes        yes    (status quo)
+  #   1.3.14      patchelf     NO         -      (oven-sh/bun#31023)
+  #   1.3.14      formatelf    yes        NO
+  #   canary      patchelf     yes        yes
+  #   canary      formatelf    yes        NO
+  #
+  # formatelf appends its extra writable PT_LOAD after the image instead of
+  # prepending it; write_bun_section then lands .bun in a segment bun cannot
+  # replay, and the output faults at execve even with the #31024 fix. Only
+  # patchelf's layout produces a working binary here.
+  nativeBuildInputs = [
+    unzip
+    installShellFiles
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ openssl ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 ./bun $out/bin/bun
+    ln -s $out/bin/bun $out/bin/bunx
+    runHook postInstall
+  '';
+
+  postPhases = [ "postPatchelf" ];
+  postPatchelf =
+    lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      '${lib.getExe' cctools "${cctools.targetPrefix}install_name_tool"}' $out/bin/bun \
+        -change /usr/lib/libicucore.A.dylib '${lib.getLib darwin.ICU}/lib/libicucore.A.dylib'
+      '${lib.getExe rcodesign}' sign --code-signature-flags linker-signed $out/bin/bun
+    ''
+    +
+      lib.optionalString
+        (
+          stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform
+          && !(stdenvNoCC.hostPlatform.isDarwin && stdenvNoCC.hostPlatform.isx86_64)
+        )
+        ''
+          installShellCompletion --cmd bun \
+            --bash <(SHELL="bash" $out/bin/bun completions) \
+            --zsh <(SHELL="zsh" $out/bin/bun completions) \
+            --fish <(SHELL="fish" $out/bin/bun completions)
+        '';
+
+  passthru.hideFromDocs = true;
+
+  meta = {
+    description = "Latest Bun runtime (prebuilt binary) for packages that need a newer version than nixpkgs ships";
+    homepage = "https://bun.sh";
+    changelog = "https://bun.sh/blog/bun-v${version}";
+    license = with lib.licenses; [
+      mit
+      lgpl21Only
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "bun";
+    platforms = builtins.attrNames hashes;
+    broken = stdenvNoCC.hostPlatform.isMusl;
+  };
+}

--- a/packages/bun-bin/update.py
+++ b/packages/bun-bin/update.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for bun-bin package.
+
+Fetches the latest stable Bun release from GitHub and updates hashes.json.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_platform_hashes,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+
+# Maps nix platform to bun archive name component
+PLATFORMS = {
+    "aarch64-darwin": "darwin-aarch64",
+    "aarch64-linux": "linux-aarch64",
+    "x86_64-darwin": "darwin-x64-baseline",
+    "x86_64-linux": "linux-x64",
+}
+
+URL_TEMPLATE = (
+    "https://github.com/oven-sh/bun/releases/download/bun-v{version}/bun-{platform}.zip"
+)
+
+
+def main() -> None:
+    """Update the bun-bin package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+
+    print(f"Current: {current}")
+
+    latest = fetch_github_latest_release("oven-sh", "bun")
+    # Bun tags are "bun-v1.2.3"
+    latest = latest.removeprefix("bun-v")
+    print(f"Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    hashes = calculate_platform_hashes(URL_TEMPLATE, PLATFORMS, version=latest)
+    for plat, h in sorted(hashes.items()):
+        print(f"  {plat}: {h}")
+
+    save_hashes(HASHES_FILE, {"version": latest, "hashes": hashes})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   bun2nixLib,
-  bun,
+  bun-bin,
   rustc,
   cargo,
   rustPlatform,
@@ -19,6 +19,23 @@
 }:
 
 let
+  # omp requires bun >= 1.3.14: its whole image pipeline (provider-side
+  # many-image downscaling, attachment/paste resizing, terminal rendering)
+  # goes through `Bun.Image`, which nixpkgs' 1.3.13 does not have. Compiling
+  # against 1.3.13 yields a binary that starts fine and then throws
+  # "undefined is not a constructor" on every image, which the Anthropic
+  # provider turns into an unrecoverable HTTP 400.
+  bun = bun-bin;
+
+  # bun2nix's hook propagates nixpkgs' bun, which lands earlier on PATH than
+  # anything in nativeBuildInputs; `bun build --compile` would then embed that
+  # runtime no matter what we pass here. Substitute the pinned bun so the
+  # compiler, the embedded runtime and engines.bun all agree.
+  bunHook = bun2nixLib.hook.overrideAttrs (old: {
+    propagatedBuildInputs = map (p: if (p.pname or null) == "bun" then bun else p) (
+      old.propagatedBuildInputs or [ ]
+    );
+  });
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version hash cargoHash;
   platformsBySystem = {
@@ -61,7 +78,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    bun2nixLib.hook
+    bunHook
     bun
     rustc
     cargo
@@ -151,12 +168,6 @@ stdenv.mkDerivation {
       fi
     done
     sed -i 's/: "\^/: "/g; s/: "~/: "/g' bun.lock
-
-    # Relax engines.bun to the bun doing the compile, otherwise omp refuses
-    # to start when the embedded runtime is older than upstream's minimum
-    # (issue #4996).
-    sed -i 's/"bun": ">=[0-9.]*"/"bun": ">='"$(bun --version)"'"/' \
-      packages/utils/package.json
 
     # swarm-extension pins @oh-my-pi/pi-coding-agent to a stale major, which
     # bun can't satisfy locally and would fetch from npm. Use the workspace

--- a/rules/use-formatelf.yml
+++ b/rules/use-formatelf.yml
@@ -7,6 +7,11 @@ files:
   - 'packages/**'
 ignores:
   - 'packages/formatelf/**'
+  # bun is the one binary that must keep patchelf's segment layout: `bun build
+  # --compile` reuses the running bun as its output template, and formatelf's
+  # appended PT_LOAD makes every compiled binary fault at execve. See the
+  # measurement table in packages/bun-bin/package.nix.
+  - 'packages/bun-bin/**'
 rule:
   pattern: autoPatchelfHook
   kind: identifier


### PR DESCRIPTION
Fixes #7598.

`e22339d7` patched omp's `engines.bun` down to whatever bun performs the compile, so the startup check always passes. The requirement it silenced is real: `Bun.Image` arrived in bun 1.3.14, and omp routes its whole image pipeline through it — provider-side many-image downscaling, attachment/paste resizing, `read`/`inspect_image`, `eval` display images, terminal rendering. Compiled against nixpkgs' 1.3.13 the binary starts fine and then throws `undefined is not a constructor` on every image, which the Anthropic provider turns into an unrecoverable HTTP 400 (11 of them in one session here, see the issue).

Two commits:

- **`bun-bin: init at 1.4.0-canary.1`** — reinstates the package removed in `e22339d7`.
- **`omp: compile against bun-bin instead of relaxing engines.bun`** — substitutes the pinned bun into `bun2nixLib.hook`'s propagated inputs and drops the `sed`.

### The PATH problem from e22339d7 is addressed directly

> `bun2nix.hook` propagates nixpkgs' bun (currently 1.3.13), which lands earlier on PATH than any bun we pass in `nativeBuildInputs`.

Rather than racing it on PATH, the hook's propagated `bun` is swapped for the pinned one:

```nix
bunHook = bun2nixLib.hook.overrideAttrs (old: {
  propagatedBuildInputs = map (p: if (p.pname or null) == "bun" then bun else p) (
    old.propagatedBuildInputs or [ ]
  );
});
```

No version-check patch is needed afterwards. `Bun.version` reports `1.4.0` for the canary and `cli.ts` gates on `Bun.semver.order(Bun.version, MIN_BUN_VERSION)`, so `engines.bun` passes because the requirement is met rather than because it was rewritten.

### Why canary, and why patchelf

The newest stable bun is 1.3.14 (2026-05-13, 84 days ago). It cannot be used: `bun build --compile` only emits working binaries once oven-sh/bun#31024 is present, which is merged (2026-07-29) but unreleased. Measured on x86_64-linux, compiling and running a hello-world with each combination:

| bun | patcher | bun runs | compiled output runs |
|---|---|---|---|
| 1.3.13 | patchelf | yes | yes (status quo) |
| 1.3.14 | patchelf | **no** | – |
| 1.3.14 | formatelf | yes | **no** |
| canary (1.4.0-canary.1) | patchelf | yes | **yes** |
| canary | formatelf | yes | **no** |

Hence the `use-formatelf` ignore entry, which I would rather not add and am happy to drop if you see another way. `bun build --compile` reuses the running bun as the template for its output, so the template's segment layout has to be one bun's own ELF writer understands. formatelf appends its extra writable `PT_LOAD` after the image instead of prepending it, `write_bun_section` then lands `.bun` in a segment bun cannot replay, and the output faults at execve *even with #31024 applied*. Program headers:

```
raw 1.3.14 (unpatched)      PT_LOAD=3   PHDR off=0x40
bun-bin canary (formatelf)  PT_LOAD=4   extra RW LOAD vaddr=0x5e88000 (appended)
nixpkgs bun 1.3.13          PT_LOAD=4   extra RW LOAD vaddr=0x1ff000  (prepended)
```

The table and this reasoning are in `packages/bun-bin/package.nix` so the exception is not mysterious later.

### Exit path

`hashes.json` gains an optional `tag` field so the URL can point at a rolling tag; without it the URL is the usual `bun-v${version}`. `update.py` writes a fresh dict, so the field disappears by itself on the next stable release, and the version comparison already does the right thing:

```
should_update("1.4.0-canary.1", "1.4.0")  -> True    # migrates on release
should_update("1.4.0-canary.1", "1.3.14") -> False   # no downgrade
```

All four platform hashes are included, so `meta.platforms` is unchanged from the original package.

### Verification

x86_64-linux, replaying the 1080x2400 screenshot that produced the 400, through the exact logic of `resizeAnthropicManyImageBlock`:

```
old binary (nixpkgs bun 1.3.13):
  TypeError: undefined is not a constructor (evaluating 'new Bun.Image(inputBuffer)')

new binary (bun-bin 1.4.0-canary.1):
  source:  1080x2400 (107521 bytes)
  resized: 900x2000 image/jpeg (64841 bytes)
  PASS: within Anthropic many-image cap
```

```
$ omp --version
omp/17.2.8
$ BUN_BE_BUN=1 omp -e 'console.log(Bun.version, typeof Bun.Image)'
1.4.0 function
$ omp -p 'read /tmp/shot.png and describe in at most 8 words'
Mobile emulator touch gamepad overlay, blank white screen.
```

That last one is a real end-to-end turn: the 2400px screenshot read, downscaled, sent, described. No resize warnings in the session log.

`nix fmt` is clean on the touched files. Note that `packages/pi/package.nix` is unformatted at `9c0f302` independently of this change; I left it alone.

### The obvious objection

Canary artifacts are mutable, so the pinned hashes go stale whenever the asset rotates, and a fresh build then fails on hash mismatch. I do not love it either, and I checked the alternatives before proposing it:

- npm's `@oven/bun-linux-x64` canary channel stopped publishing on 2026-05-19, before the fix — no immutable artifact carries #31024.
- Bun's R2 bucket only serves rolling `canary`/`latest`/stable tags; per-commit paths 404.
- Building bun from source works and is not slow (~12 min on 12 cores, WebKit comes prebuilt), but needs fenix for the pinned `nightly-2026-07-20` plus FODs for the WebKit/Node/npm fetches. Worth noting nixpkgs has never built bun from source: the one attempt, NixOS/nixpkgs#422563, went stale after a year having finished only `bun-webkit`, blocked on NixOS/nixpkgs#376299 which has been a draft for 19 months.

So the choices are a mutable canary pin, a source build, or shipping omp with a knowingly broken image stack until bun 1.4.0. If you would rather wait for the release, that is defensible — but then the `engines.bun` patch should still go, so the failure surfaces as a startup error instead of a provider-side 400. Happy to cut this PR down to that, or to gate the canary behind an option, whichever you prefer.
