### PR TITLE
mindwalk: init at 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/entire/package.nix](packages/entire/package.nix)
 
 </details>
+<details>
+<summary><strong>mindwalk</strong> - Visualization tool that replays coding-agent sessions on a 3D map of your codebase</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/cosmtrek/mindwalk
+- **Usage**: `nix run github:numtide/llm-agents.nix#mindwalk -- --help`
+- **Nix**: [packages/mindwalk/package.nix](packages/mindwalk/package.nix)
+
+</details>
 
 ### Workflow & Project Management
 

--- a/packages/mindwalk/package.nix
+++ b/packages/mindwalk/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "mindwalk";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "cosmtrek";
+    repo = "mindwalk";
+    tag = "v${version}";
+    hash = "sha256-kKqW+yeHYR1eZopxspJ8xiZszQcrW+MvMBynhbtzKpU=";
+  };
+
+  vendorHash = "sha256-qVoj03LNLbdoCUAOydK7oEHsuZ1BZ6Z2jwYB3gPOfrw=";
+
+  # The pre-built web UI is committed at the tag under
+  # internal/server/static, so no npm build is needed.
+  subPackages = [ "cmd/mindwalk" ];
+
+  env.CGO_ENABLED = "0";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.category = "Usage Analytics";
+
+  meta = with lib; {
+    description = "Visualization tool that replays coding-agent sessions on a 3D map of your codebase";
+    homepage = "https://github.com/cosmtrek/mindwalk";
+    changelog = "https://github.com/cosmtrek/mindwalk/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ zimbatm ];
+    mainProgram = "mindwalk";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description

Packages [mindwalk](https://github.com/cosmtrek/mindwalk) v0.4.0, a visualization tool by cosmtrek (author of `air`) that replays coding-agent sessions (Claude Code, Codex, pi) on a 3D map of your codebase. Fully local, single Go binary.

<img width="1873" height="1200" alt="image" src="https://github.com/user-attachments/assets/8068294c-6af2-476f-b57d-92ae5ed16903" />

## Implementation notes

- Plain `buildGoModule` — upstream commits the pre-built Vite web UI under `internal/server/static/` at each tag, so no npm build step is needed.
- `CGO_ENABLED=0` and `-s -w` ldflags, matching upstream's goreleaser config.
- No `versionCheckHook`: upstream has no `--version` flag.
- Category: Usage Analytics.

## Testing

- `nix build .#mindwalk` succeeds on x86_64-linux.
- `mindwalk build <repo>` generated a valid 407-file citymap of this repository.
- `mindwalk serve` serves the embedded web UI (verified with curl).
- nix-update round-trip verified: downgraded to 0.3.0, `nix-update --flake mindwalk` correctly restored 0.4.0 with the right hashes.

Sample run:
```
$ mindwalk
mindwalk

Usage:
  mindwalk                        serve on a random local port and open the UI
  mindwalk serve [--port N] [--no-open] [--claude-dir DIR] [--codex-dir DIR] [--pi-dir DIR]
  mindwalk open [--no-open] <session.jsonl> open a specific Claude Code, Codex, or pi session
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wpNGHFLiGZDugAgAnyatD