### PR TITLE
Drop antigravity/auto-claude/forge rename aliases

### DIFF
--- a/packages/antigravity/package.nix
+++ b/packages/antigravity/package.nix
@@ -1,5 +1,0 @@
-{ lib, antigravity-cli }:
-lib.warnOnInstantiate "'antigravity' has been renamed to 'antigravity-cli'. Please update your references." antigravity-cli
-// {
-  passthru.hideFromDocs = true;
-}

--- a/packages/auto-claude/package.nix
+++ b/packages/auto-claude/package.nix
@@ -1,5 +1,0 @@
-{ lib, aperant }:
-lib.warnOnInstantiate "'auto-claude' has been renamed to 'aperant'. Please update your references." aperant
-// {
-  passthru.hideFromDocs = true;
-}

--- a/packages/forge/package.nix
+++ b/packages/forge/package.nix
@@ -1,5 +1,0 @@
-{ lib, forgecode }:
-lib.warnOnInstantiate "'forge' has been renamed to 'forgecode'. Please update your references." forgecode
-// {
-  passthru.hideFromDocs = true;
-}


### PR DESCRIPTION
The `warnOnInstantiate` alias stubs for the July 19 renames (antigravity → antigravity-cli, auto-claude → aperant, forge → forgecode) have served their deprecation window. Remove them.

README is unchanged since the aliases were already `hideFromDocs`.