### PR TITLE
t3code: init at 0.0.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>t3code</strong> - Control surface for coding agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://t3.codes
+- **Usage**: `nix run github:numtide/llm-agents.nix#t3code -- --help`
+- **Nix**: [packages/t3code/package.nix](packages/t3code/package.nix)
+
+</details>
+<details>
+<summary><strong>t3code-desktop</strong> - Desktop control surface for coding agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://t3.codes
+- **Usage**: `nix run github:numtide/llm-agents.nix#t3code-desktop -- --help`
+- **Nix**: [packages/t3code-desktop/package.nix](packages/t3code-desktop/package.nix)
+
+</details>
+<details>
 <summary><strong>vix</strong> - Sleek, Fast and Token Efficient AI Coding Agent</summary>
 
 - **Source**: source

--- a/checks/t3code-packaging.nix
+++ b/checks/t3code-packaging.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  flake,
+  system,
+  ...
+}:
+
+let
+  packages = flake.packages.${system};
+  t3code = packages.t3code;
+  desktop = packages.t3code-desktop;
+in
+assert t3code.meta.mainProgram == "t3";
+assert desktop.meta.mainProgram == "t3code-desktop";
+assert !(desktop ? version);
+assert t3code.passthru ? resourceMonitor;
+assert pkgs.lib.hasInfix "package.json').dependencies.electron" (
+  builtins.readFile ../packages/t3code/package.nix
+);
+assert map pkgs.lib.getName t3code.passthru.providerPackages == [
+  "grok"
+  "claude-code"
+  "codex"
+  "opencode"
+  "cursor-agent"
+];
+pkgs.runCommand "t3code-packaging-check" { } ''
+  touch $out
+''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -29,6 +29,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 73943355;
         name = "chernistry";
       };
+      dancodes = {
+        github = "dan-online";
+        githubId = 41877062;
+        name = "DanCodes";
+      };
       ypares = {
         github = "YPares";
         githubId = 1377233;

--- a/packages/t3code-desktop/package.nix
+++ b/packages/t3code-desktop/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  flake,
+  symlinkJoin,
+  t3code,
+}:
+
+symlinkJoin {
+  name = "t3code-desktop";
+  paths = [ t3code.desktop ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Desktop control surface for coding agents";
+    homepage = "https://t3.codes";
+    changelog = "https://github.com/pingdotgg/t3code/releases/tag/v${t3code.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ dancodes ];
+    mainProgram = "t3code-desktop";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/t3code/nix-update-args
+++ b/packages/t3code/nix-update-args
@@ -1,0 +1,5 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$
+--subpackage
+resourceMonitor

--- a/packages/t3code/package.nix
+++ b/packages/t3code/package.nix
@@ -1,0 +1,258 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_11,
+  pnpmConfigHook,
+  pnpmBuildHook,
+  nodejs_24,
+  node-gyp,
+  python3,
+  grok,
+  claude-code,
+  codex,
+  opencode,
+  cursor-agent,
+  cacert,
+  electron_41,
+  makeBinaryWrapper,
+  installShellFiles,
+  makeDesktopItem,
+  rustPlatform,
+  versionCheckHook,
+  versionCheckHomeHook,
+  cctools,
+  libicns,
+  writeDarwinBundle,
+  xcbuild,
+}:
+
+let
+  pname = "t3code";
+  version = "0.0.31";
+  pnpm = pnpm_11;
+
+  src = fetchFromGitHub {
+    owner = "pingdotgg";
+    repo = "t3code";
+    tag = "v${version}";
+    hash = "sha256-KFGwgAIOqHbi3enmNAPt95+UAakm6pmClPK1nYNoOlk=";
+  };
+
+  resourceMonitor = rustPlatform.buildRustPackage {
+    pname = "t3code-resource-monitor";
+    inherit version src;
+
+    sourceRoot = "${src.name}/native/resource-monitor";
+    cargoHash = "sha256-5cmG2daM1bVOA23gjjoalbx0fEL1hmqV6WZov0sUZp8=";
+  };
+
+  platformKey =
+    {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    }
+    .${stdenv.hostPlatform.system};
+
+  pnpmWorkspaces = [
+    "@t3tools/monorepo"
+    "t3..."
+    "@t3tools/desktop..."
+    "@t3tools/scripts..."
+  ];
+
+  providerPackages = [
+    grok
+    claude-code
+    codex
+    opencode
+    cursor-agent
+  ];
+
+  appName = "T3 Code (Alpha)";
+  desktopIcon =
+    if stdenv.hostPlatform.isDarwin then
+      "assets/prod/black-macos-1024.png"
+    else
+      "assets/prod/black-universal-1024.png";
+
+  desktopItem = makeDesktopItem {
+    name = "t3code";
+    desktopName = appName;
+    comment = "Control surface for coding agents";
+    exec = "t3code-desktop %U";
+    icon = "t3code";
+    categories = [ "Development" ];
+    startupWMClass = "t3code";
+  };
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    pnpmWorkspaces
+    ;
+
+  outputs = [
+    "out"
+    "desktop"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit
+      pnpm
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    fetcherVersion = 4;
+    hash = "sha256-6tuT9MS+PIMV0PFiw1q6vtZyk3yFB5Y4yHgWohMJczs=";
+  };
+
+  nativeBuildInputs = [
+    cacert
+    installShellFiles
+    makeBinaryWrapper
+    node-gyp
+    nodejs_24
+    pnpm
+    pnpmBuildHook
+    pnpmConfigHook
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+    libicns
+    writeDarwinBundle
+    xcbuild
+  ];
+
+  preBuild = ''
+    export pnpm_config_verify_deps_before_run=false
+
+    node scripts/update-release-package-versions.ts ${version}
+
+    upstream_electron=$(node -p "require('./apps/desktop/package.json').dependencies.electron")
+    upstream_major=''${upstream_electron#^}
+    upstream_major=''${upstream_major%%.*}
+    nix_major=${lib.versions.major electron_41.version}
+    if (( upstream_major > nix_major )); then
+      echo "error: upstream expects Electron $upstream_electron but nixpkgs provides ${electron_41.version}" >&2
+      exit 1
+    fi
+
+    export npm_config_nodedir=${nodejs_24}
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+    pnpm rebuild --pending "''${pnpmInstallFlags[@]}" \
+      --filter '!@t3tools/monorepo'
+  '';
+
+  pnpmBuildScript = "build:desktop";
+
+  # Dependencies include prebuilt artifacts for foreign systems and statically
+  # linked executables, which must not be patched or audited as host binaries.
+  dontPatchELF = true;
+  noAuditTmpdir = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/libexec/t3code/apps/server"
+    cp -r --no-preserve=mode node_modules "$out/libexec/t3code/"
+    cp -r --no-preserve=mode apps/server/{node_modules,dist} "$out/libexec/t3code/apps/server/"
+
+    mkdir -p "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}"
+    install -Dm755 ${resourceMonitor}/bin/t3-resource-monitor \
+      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor"
+
+    mkdir -p "$out/bin"
+    makeWrapper ${lib.getExe nodejs_24} "$out/bin/t3" \
+      --add-flags "$out/libexec/t3code/apps/server/dist/bin.mjs" \
+      --prefix PATH : ${lib.makeBinPath providerPackages}
+
+    mkdir -p "$desktop/libexec/t3code/apps/desktop"
+    cp -r --no-preserve=mode \
+      apps/desktop/{package.json,node_modules,dist-electron} \
+      "$desktop/libexec/t3code/apps/desktop/"
+    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources"
+    install -Dm444 ${desktopIcon} \
+      "$desktop/libexec/t3code/apps/desktop/prod-resources/icon.png"
+
+    ln -s "$out/libexec/t3code/node_modules" "$desktop/libexec/t3code/node_modules"
+    ln -s "$out/libexec/t3code/apps/server" "$desktop/libexec/t3code/apps/server"
+
+    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor"
+    ln -s \
+      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor" \
+      "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor/t3-resource-monitor"
+
+    find "$out/libexec/t3code" "$desktop/libexec/t3code" -xtype l -delete
+
+    mkdir -p "$desktop/bin"
+    makeWrapper ${lib.getExe electron_41} "$desktop/bin/t3code-desktop" \
+      --add-flags "$desktop/libexec/t3code/apps/desktop" \
+      --prefix PATH : ${lib.makeBinPath providerPackages} \
+      --inherit-argv0
+
+    mkdir -p "$desktop/share/icons/hicolor/scalable/apps"
+    install -Dm444 ${desktopIcon} "$desktop/share/icons/t3code.png"
+    install -Dm444 assets/prod/logo.svg "$desktop/share/icons/hicolor/scalable/apps/t3code.svg"
+    cp -r ${desktopItem}/share/applications "$desktop/share/"
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      find "$desktop/libexec/t3code" \
+        -path '*/node-pty/prebuilds/darwin-*/spawn-helper' \
+        -exec chmod 755 {} +
+
+      mkdir -p "$desktop/Applications/${appName}.app/Contents/"{MacOS,Resources}
+      png2icns \
+        "$desktop/Applications/${appName}.app/Contents/Resources/t3code.icns" \
+        ${desktopIcon}
+      ${stdenv.shell} ${lib.getExe writeDarwinBundle} \
+        "$desktop" "${appName}" t3code-desktop t3code
+    ''}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      installShellCompletion --cmd t3 --"$shell" <("$out/bin/t3" --completions "$shell")
+    done
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    category = "AI Coding Agents";
+    inherit providerPackages resourceMonitor;
+  };
+
+  meta = {
+    description = "Control surface for coding agents";
+    homepage = "https://t3.codes";
+    changelog = "https://github.com/pingdotgg/t3code/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ dancodes ];
+    mainProgram = "t3";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds [T3 Code](https://t3.codes) 0.0.31 with both the CLI and desktop app.

Includes Claude Code, Codex, Grok, OpenCode, and Cursor in `PATH` so provider detection works out of the box.

## Test plan

- [x] `nix build .#t3code .#t3code-desktop`
- [x] `t3 --version`
- [x] `nix-update` round trip
- [x] `codex review --uncommitted`
- [ ] `nix flake check` blocked on main

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.