### PR TITLE
grok: drop transitional bubblewrap /bin shim

### DIFF
--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -7,9 +7,6 @@
   wrapBuddy,
   versionCheckHook,
   versionCheckHomeHook,
-  bashInteractive,
-  bubblewrap,
-  zsh,
 }:
 
 let
@@ -26,25 +23,6 @@ let
       "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${version}-${platform}";
   };
   inherit (source) version;
-
-  # Grok's run_command tool spawns shells via portable_pty, which execve's
-  # absolute paths like /bin/bash and /bin/zsh (derived from $SHELL, with
-  # /bin/bash as the hardcoded fallback). NixOS only ships /bin/sh, so every
-  # shell tool call fails with `Terminal error: IO Error: No such file or
-  # directory (os error 2)` before any user command runs.
-  #
-  # As a transitional workaround, wrap the Linux entry points with bubblewrap
-  # so /bin is replaced by a tmpfs containing symlinks to the matching shells
-  # from the Nix store. This wrapping should become unnecessary once upstream
-  # grok honors $SHELL (or PATH) instead of fixed /bin/* paths. Tracked in
-  # https://github.com/numtide/llm-agents.nix/issues/4912.
-  bwrapFlags = lib.concatStringsSep " " [
-    "--dev-bind / /"
-    "--tmpfs /bin"
-    "--symlink ${bashInteractive}/bin/bash /bin/bash"
-    "--symlink ${zsh}/bin/zsh /bin/zsh"
-    "--symlink ${bashInteractive}/bin/sh /bin/sh"
-  ];
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -74,24 +52,15 @@ stdenv.mkDerivation {
     makeWrapper $out/libexec/grok/grok $out/libexec/grok/agent-launcher \
       --argv0 agent \
       --add-flags --no-auto-update
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    install -d $out/bin
-    for name in grok agent; do
-      {
-        printf '#!%s\n' '${stdenv.shell}'
-        printf 'exec %s %s -- %s/libexec/grok/%s-launcher "$@"\n' \
-          '${bubblewrap}/bin/bwrap' '${bwrapFlags}' "$out" "$name"
-      } > $out/bin/$name
-      chmod +x $out/bin/$name
-    done
-  ''
-  + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
+
+    # bin → launcher on all platforms. A former Linux-only bubblewrap shim
+    # faked /bin/{bash,zsh} for older Grok builds that hardcoded those paths
+    # (#4912 / #4913). Current Grok resolves the shell via $SHELL / PATH, and
+    # the outer userns broke host tools (OpenSSH ownership checks, etc.).
+    # versionCheck already used the unwrapped launcher (#7158).
     install -d $out/bin
     ln -s $out/libexec/grok/grok-launcher $out/bin/grok
     ln -s $out/libexec/grok/agent-launcher $out/bin/agent
-  ''
-  + ''
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

Drop the Linux `bubblewrap` wrapper around `bin/grok` / `bin/agent`.

That shim was added in #4913 to work around Grok hardcoding `/bin/bash` and `/bin/zsh` (#4912). Current Grok resolves the tool shell via `$SHELL` / `PATH`, so the fake `/bin` is no longer needed.

The outer user namespace still hurts: root-owned host paths (store, `/etc/ssh` Includes such as systemd-ssh-proxy) appear as `nobody`, and OpenSSH refuses them. SSH is the canary; other host tools that check ownership or privileges fail the same way.

`bin/{grok,agent}` now symlink to the libexec launchers on all platforms (macOS already did this). `versionCheck` already used the unwrapped launcher (#7158).

## Test plan

- [x] Local: package wrapper execs `libexec/grok/grok-launcher` (no `bwrap`)
- [x] Local: headless `run_command` / shell tool prints expected output on NixOS without the packaging bwrap
- [ ] `nix build .#grok` (installCheck via launcher)
- [ ] On NixOS: interactive or headless tool shell (`pwd`) works with system `bash` on `PATH` / `$SHELL`
- [ ] Optional canary: from a session **not** inside another userns, `ssh -G localhost` does not hit store Include ownership errors

Follow-up to #4912; reverts packaging approach from #4913.