### PR TITLE
hermes-agent: include bundled plugins

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -388,13 +388,16 @@ python3.pkgs.buildPythonApplication {
     "--set"
     "HERMES_NODE"
     "${nodejs}/bin/node"
-    # Skills are copied to $out/share/hermes in postInstall; point hermes at them.
+    # Runtime data is copied to $out/share/hermes in postInstall; point Hermes at it.
     "--set"
     "HERMES_BUNDLED_SKILLS"
     "${placeholder "out"}/share/hermes/skills"
     "--set"
     "HERMES_OPTIONAL_SKILLS"
     "${placeholder "out"}/share/hermes/optional-skills"
+    "--set"
+    "HERMES_BUNDLED_PLUGINS"
+    "${placeholder "out"}/share/hermes/plugins"
     # Disable runtime pip installs; absent extras disable cleanly.
     "--set"
     "HERMES_DISABLE_LAZY_INSTALLS"
@@ -406,12 +409,14 @@ python3.pkgs.buildPythonApplication {
     "${nodejs}/bin"
   ];
 
-  # Skills are shipped as setup.py data_files, which the wheel build drops;
-  # install them manually.
+  # Upstream keeps runtime data outside site-packages and locates it through
+  # wrapper environment variables. Preserve that layout because setuptools
+  # intentionally omits plugin manifests from the wheel since 2026.8.3.
   postInstall = ''
     mkdir -p $out/share/hermes
     cp -r ${src}/skills $out/share/hermes/skills
     cp -r ${src}/optional-skills $out/share/hermes/optional-skills
+    cp -r ${src}/plugins $out/share/hermes/plugins
   '';
 
   pythonRelaxDeps = [
@@ -464,10 +469,12 @@ python3.pkgs.buildPythonApplication {
     grep -q HERMES_PYTHON_SRC_ROOT $out/bin/hermes
     grep -q HERMES_BUNDLED_SKILLS $out/bin/hermes
     grep -q HERMES_OPTIONAL_SKILLS $out/bin/hermes
+    grep -q HERMES_BUNDLED_PLUGINS $out/bin/hermes
     test -f ${hermes-frontend}/lib/hermes-tui/dist/entry.js
     test -f ${hermes-frontend}/share/hermes-web/index.html
     test -d $out/share/hermes/skills
     test -d $out/share/hermes/optional-skills
+    test -n "$(find $out/share/hermes/plugins -name plugin.yaml -print -quit)"
     ${pythonEnv}/bin/python3 -c 'import dotenv, tenacity, openai'
     # Slash workers run HERMES_PYTHON with PYTHONPATH=HERMES_PYTHON_SRC_ROOT.
     PYTHONPATH="$out/${python3.sitePackages}" \


### PR DESCRIPTION
## Summary

Hermes 2026.8.3 stopped shipping plugin manifests as Python package data in [NousResearch/hermes-agent#68217](https://github.com/NousResearch/hermes-agent/pull/68217) ([commit](https://github.com/NousResearch/hermes-agent/commit/d84e11af4d9927c41ad0a3b4db72042cca250c64)), causing bundled platform discovery to fail with errors such as `No adapter available for slack`. This mirrors upstream's Nix packaging contract by shipping the `plugins` runtime tree separately, exposing it through `HERMES_BUNDLED_PLUGINS`, and checking that the Slack manifest remains available.

## Test plan

- [x] `nix build .#hermes-agent` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work 

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP Servers into various agents.
