### PR TITLE
feat(omp): build and link with pipewire for computer use

### DIFF
--- a/packages/omp/compile-standalone.ts
+++ b/packages/omp/compile-standalone.ts
@@ -1,13 +1,9 @@
-// Compile the omp standalone binary via upstream's compileCodingAgent helper.
+// Compile the omp standalone binary via upstream's compileCodingAgent helper:
+// the binary needs the `omp-legacy-pi-modules` virtual module, whose Bun.build()
+// plugin `bun build --compile` cannot load.
 //
-// Since v16.4.6 the compiled binary needs the in-memory `omp-legacy-pi-modules`
-// virtual module, which is only provided by a Bun.build() plugin
-// (scripts/legacy-pi-virtual-module.ts). The `bun build --compile` CLI cannot
-// load plugins, so we call the upstream compile function directly.
-//
-// Usage (from packages/coding-agent, like upstream's build-binary.ts, so that
-// bare package imports emitted by the virtual-module plugin resolve the same
-// way): bun compile-standalone.ts <bun-executable-template>
+// Usage (from packages/coding-agent, so bare package imports resolve like
+// upstream's build-binary.ts): bun compile-standalone.ts <bun-executable-template>
 
 import { createRequire } from "node:module";
 import * as path from "node:path";
@@ -24,8 +20,7 @@ const { compileCodingAgent } = await import(
 	path.join(codingAgentDir, "scripts", "compile-binary.ts")
 );
 
-// Mirror scripts/build-binary.ts: embed the concrete Transformers.js version so
-// the tiny-model worker can pin its runtime install.
+// Embed the Transformers.js version so the tiny-model worker can pin its install.
 const require = createRequire(path.join(codingAgentDir, "package.json"));
 const transformersManifest = require("@huggingface/transformers/package.json") as {
 	version: string;

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -20,6 +20,7 @@
   cmake,
   libpulseaudio,
   unzip,
+  pipewire,
 }:
 
 let
@@ -125,6 +126,8 @@ stdenv.mkDerivation {
     zlib
     # audiopus_sys links against opus (found via pkg-config)
     libopus
+    # pi-natives' wayland-pipewire feature links system libpipewire (pkg-config)
+    pipewire
   ];
 
   # cmake is only needed by the audiopus_sys build script, not for configuring
@@ -212,7 +215,9 @@ stdenv.mkDerivation {
 
     # Build the Rust native addon
     echo "Building Rust native addon..."
-    cargo build --release -p pi-natives --target ${rustTarget} --target-dir target
+    cargo build --release -p pi-natives \
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--features wayland-pipewire"} \
+      --target ${rustTarget} --target-dir target
 
     # Install the native addon where the JS code expects it
     mkdir -p packages/natives/native
@@ -289,6 +294,7 @@ stdenv.mkDerivation {
         zlib
         stdenv.cc.cc.lib
         libpulseaudio
+        pipewire
       ]
     }"}
 

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -55,10 +55,9 @@ let
   platform =
     platformsBySystem.${stdenv.hostPlatform.system}
       or (throw "Unsupported platform for omp: ${stdenv.hostPlatform.system}");
-  # Bun 1.3.14 adds Bun.Image, but its compiler corrupts Nix-patched
-  # executable templates: https://github.com/oven-sh/bun/issues/31023
-  # Bun 1.3.13 writes OMP into the unmodified 1.3.14 template instead.
-  # Remove this split after a stable Bun release contains oven-sh/bun#31024.
+  # Bun 1.3.14's compiler corrupts Nix-patched executable templates
+  # (oven-sh/bun#31023), so Bun 1.3.13 writes OMP into an unmodified 1.3.14
+  # template. Remove once a stable release contains oven-sh/bun#31024.
   bunRuntimeVersion = "1.3.14";
   bunRuntimeTemplate = stdenvNoCC.mkDerivation {
     pname = "omp-bun-runtime-template";
@@ -73,8 +72,7 @@ let
     nativeBuildInputs = [ unzip ];
     dontConfigure = true;
     dontBuild = true;
-    # The ELF must keep its original three PT_LOAD segments. It is build data,
-    # not an executable that runs in this derivation.
+    # This is build data, not run here. Fixup would alter the PT_LOAD layout.
     dontFixup = true;
 
     installPhase = ''
@@ -109,8 +107,7 @@ stdenv.mkDerivation {
     rustc
     cargo
     rustPlatform.cargoSetupHook
-    # bindgen (zlob, maudio-sys) needs libclang plus the correct clang flags
-    # to find libc headers such as pthread.h.
+    # bindgen (zlob, maudio-sys) needs libclang and clang flags for libc headers
     rustPlatform.bindgenHook
     pkg-config
     makeWrapper
@@ -130,13 +127,11 @@ stdenv.mkDerivation {
     pipewire
   ];
 
-  # cmake is only needed by the audiopus_sys build script, not for configuring
-  # this derivation itself.
+  # cmake is only for audiopus_sys' build script, not this derivation
   dontUseCmakeConfigure = true;
 
-  # smallvec's `specialization` feature requires nightly Rust.
-  # RUSTC_BOOTSTRAP=1 enables nightly features on stable rustc.
   env = {
+    # smallvec's `specialization` feature needs nightly features on stable rustc
     RUSTC_BOOTSTRAP = 1;
     # audiopus_sys' bundled opus ships a cmake_minimum_required older than
     # what nixpkgs' cmake 4.x still accepts.
@@ -180,12 +175,11 @@ stdenv.mkDerivation {
     "
   '';
 
-  # We handle build and install ourselves
   dontUseBunBuild = true;
   dontUseBunInstall = true;
   dontRunLifecycleScripts = true;
 
-  # bun compile embeds JS in the binary; stripping would break it
+  # bun compile embeds JS in the binary. Stripping would break it.
   dontStrip = true;
 
   postPatch = ''
@@ -208,23 +202,19 @@ stdenv.mkDerivation {
   buildPhase = ''
     runHook preBuild
 
-    # Native node modules like @napi-rs/cli need libstdc++ at build time
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       export LD_LIBRARY_PATH="${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
     ''}
 
-    # Build the Rust native addon
     echo "Building Rust native addon..."
     cargo build --release -p pi-natives \
       ${lib.optionalString stdenv.hostPlatform.isLinux "--features wayland-pipewire"} \
       --target ${rustTarget} --target-dir target
 
-    # Install the native addon where the JS code expects it
     mkdir -p packages/natives/native
     cp target/${rustTarget}/release/${platform.nativeLib} \
        packages/natives/native/pi_natives.${platform.nodeTag}.node
 
-    # Generate the napi type definitions and JS loader
     napiBin="$(pwd)/node_modules/.bin/napi"
     if [ -x "$napiBin" ]; then
       "$napiBin" build \
@@ -238,41 +228,35 @@ stdenv.mkDerivation {
         || echo "napi CLI post-processing failed; using cargo output directly"
     fi
 
-    # Generate runtime enum exports from const enums in the type definitions
     if [ -f packages/natives/scripts/gen-enums.ts ] && \
        [ -f packages/natives/native/index.d.ts ]; then
       bun packages/natives/scripts/gen-enums.ts || true
     fi
 
-    # --generate embeds the omp:// docs index; without it the script is a no-op
+    # --generate embeds the omp:// docs index. Without it the script is a no-op
     # and the binary ships no docs, breaking omp:// reads.
     echo "Generating docs index..."
     bun packages/coding-agent/scripts/generate-docs-index.ts --generate
 
-    # Generate the embedded stats dashboard client bundle. Bun.Archive.write
-    # stamps each tar header with the current time, so normalize the archive
-    # afterwards to keep the compiled binary reproducible (issue #6534).
+    # Bun.Archive.write stamps tar headers with the current time. Normalize
+    # afterwards for reproducibility (issue #6534).
     echo "Generating embedded stats dashboard..."
     bun --cwd packages/stats scripts/generate-client-bundle.ts --generate
     bun ${./normalize-embedded-client.ts} \
       packages/stats/src/embedded-client.generated.txt
 
-    # Generate the embedded HTML-export tool-views bundle (coding-agent prepack
-    # step): export/html/index.ts text-imports ./tool-views.generated.js, which
-    # bun compile cannot resolve unless it is generated first.
+    # export/html/index.ts text-imports ./tool-views.generated.js, which must
+    # exist before bun compile.
     echo "Generating embedded HTML-export tool-views..."
     bun --cwd packages/collab-web scripts/build-tool-views.ts
 
-    # Since v16.4.6 mupdf is bundled into the binary and its wasm blob is
-    # embedded via a generated helper (upstream gen:mupdf); --external mupdf
-    # no longer works because the compiled bunfs cannot resolve it.
+    # Since v16.4.6 mupdf's wasm blob must be embedded via a generated helper.
+    # --external mupdf no longer works in the compiled bunfs.
     echo "Embedding mupdf wasm..."
     bun packages/coding-agent/scripts/embed-mupdf-wasm.ts --generate
 
-    # Compile the standalone binary. Since v16.4.6 the binary needs the
-    # in-memory omp-legacy-pi-modules virtual module, which only the
-    # Bun.build() plugin from upstream's compile-binary.ts can provide, so
-    # drive that helper instead of `bun build --compile`.
+    # compile-standalone.ts drives upstream's compile-binary.ts helper because
+    # `bun build --compile` cannot load the required virtual-module plugin.
     echo "Compiling standalone binary..."
     (cd packages/coding-agent && bun ${./compile-standalone.ts} "${bunRuntimeTemplate}/libexec/bun")
 
@@ -301,14 +285,13 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  # Re-sign the bun-compiled binary after fixup. fixDarwinDylibNames may run
-  # install_name_tool, and Bun can produce invalid signatures on newer macOS.
+  # Re-sign after fixup: install_name_tool and Bun can leave invalid signatures
   postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     ${lib.getExe rcodesign} sign --code-signature-flags linker-signed $out/lib/omp/omp
   '';
 
   # Workers and the stats dashboard only fail at runtime when their bunfs
-  # entrypoints are missing; the smoke test catches that at build time.
+  # entrypoints are missing. The smoke test catches that at build time.
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck

--- a/packages/omp/update.py
+++ b/packages/omp/update.py
@@ -48,7 +48,6 @@ def main() -> None:
 
     print(f"Updating omp from {current} to {latest}")
 
-    # Step 1: Calculate new source hash
     print("Calculating source hash...")
     url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
     source_hash = calculate_url_hash(url, unpack=True)
@@ -60,7 +59,6 @@ def main() -> None:
     }
     save_hashes(HASHES_FILE, data)
 
-    # Step 2: Regenerate bun.nix from upstream bun.lock
     clone_and_generate_bun_nix(
         OWNER,
         REPO,
@@ -71,7 +69,6 @@ def main() -> None:
     )
     strip_workspace_entries(BUN_NIX, "@oh-my-pi", FLAKE_ROOT)
 
-    # Step 3: Calculate cargoHash
     update_dependency_hash(".#omp", "cargoHash", HASHES_FILE, data)
 
     print(f"Updated omp to {latest}")


### PR DESCRIPTION
The ability for it to take screenshots etc is gated behind a cargo feature for Wayland, [because their CI cannot build it](https://github.com/can1357/oh-my-pi/blob/main/crates/pi-natives/Cargo.toml#L16-L22) so we need to explicitly enable it.

Always including this on linux is fine because on X11 systems there will be no `WAYLAND_DISPLAY` defined so it will still use the X11 backend.

## Summary

Give `omp` the ability to use pipewire to interact with the desktop on Wayland for the computer use functionality.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
