### PR TITLE
qoder-cli-cn: init at 1.1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>qoder-cli-cn</strong> - 终端原生的 AI 编程搭档，也是可被集成的智能体引擎。</summary>
+<summary><strong>qoder-cli-cn</strong> - Qoder CLI (mainland China edition) - terminal-based AI coding assistant for China-region accounts</summary>
 
 - **Source**: binary
 - **License**: unfree

--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>qoder-cli-cn</strong> - 终端原生的 AI 编程搭档，也是可被集成的智能体引擎。</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://qoder.cn
+- **Usage**: `nix run github:numtide/llm-agents.nix#qoder-cli-cn -- --help`
+- **Nix**: [packages/qoder-cli-cn/package.nix](packages/qoder-cli-cn/package.nix)
+
+</details>
+<details>
 <summary><strong>qwen-code</strong> - Command-line AI workflow tool for Qwen3-Coder models</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -199,6 +199,11 @@ inputs.nixpkgs.lib.extend (
         githubId = 24687232;
         name = "Selmison Miranda";
       };
+      RyougiShiki-214 = {
+        github = "RyougiShiki-214";
+        githubId = 53418317;
+        name = "Shiki";
+      };
     };
   }
 )

--- a/packages/qoder-cli-cn/hashes.json
+++ b/packages/qoder-cli-cn/hashes.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.1.17",
+  "platforms": {
+    "aarch64-darwin": {
+      "url": "https://static.qoder.com.cn/qoder-cli-cn/releases/1.1.17/qoderclicn-darwin-arm64.tar.gz",
+      "hash": "sha256-p98HJKoSpBsKyia4csRrG+ekS5cQawrU8YUi8uKtU8w="
+    },
+    "aarch64-linux": {
+      "url": "https://static.qoder.com.cn/qoder-cli-cn/releases/1.1.17/qoderclicn-linux-arm64.tar.gz",
+      "hash": "sha256-7SurevubFP/WsufiycLBn5akj6VTLRp2bvjkG0dZUqU="
+    },
+    "x86_64-linux": {
+      "url": "https://static.qoder.com.cn/qoder-cli-cn/releases/1.1.17/qoderclicn-linux-x64.tar.gz",
+      "hash": "sha256-Dum8xGqRv0LkVt1qa7GtCVBhz+XE0TziRFejEkE/4fs="
+    }
+  }
+}

--- a/packages/qoder-cli-cn/package.nix
+++ b/packages/qoder-cli-cn/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   passthru.category = "AI Coding Agents";
 
   meta = with lib; {
-    description = "终端原生的 AI 编程搭档，也是可被集成的智能体引擎。";
+    description = "Qoder CLI (mainland China edition) - terminal-based AI coding assistant for China-region accounts";
     homepage = "https://qoder.cn";
     changelog = "https://qoder.cn/changelog";
     downloadPage = "https://qoder.cn/download";

--- a/packages/qoder-cli-cn/package.nix
+++ b/packages/qoder-cli-cn/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version platforms;
+
+  platform = stdenv.hostPlatform.system;
+  src = platforms.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "qoder-cli-cn";
+  inherit version;
+
+  src = fetchurl {
+    inherit (src) url hash;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  sourceRoot = ".";
+
+  dontStrip = true; # do not mess with the bun runtime
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 qoderclicn $out/bin/qoderclicn
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "终端原生的 AI 编程搭档，也是可被集成的智能体引擎。";
+    homepage = "https://qoder.cn";
+    changelog = "https://qoder.cn/changelog";
+    downloadPage = "https://qoder.cn/download";
+    license = flake.lib.licenses.unfree;
+    maintainers = with flake.lib.maintainers; [ RyougiShiki-214 ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "qoderclicn";
+  };
+}

--- a/packages/qoder-cli-cn/package.nix
+++ b/packages/qoder-cli-cn/package.nix
@@ -1,11 +1,8 @@
 {
-  lib,
-  flake,
   stdenv,
   fetchurl,
-  wrapBuddy,
-  versionCheckHook,
-  versionCheckHomeHook,
+  flake,
+  qoder-cli,
 }:
 
 let
@@ -15,19 +12,15 @@ let
   platform = stdenv.hostPlatform.system;
   src = platforms.${platform} or (throw "Unsupported system: ${platform}");
 in
-stdenv.mkDerivation {
+# Same bun-compiled binary as qoder-cli, but built for the mainland China
+# service: separate release channel/CDN, binary name and account backend.
+qoder-cli.overrideAttrs (old: {
   pname = "qoder-cli-cn";
   inherit version;
 
   src = fetchurl {
     inherit (src) url hash;
   };
-
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
-
-  sourceRoot = ".";
-
-  dontStrip = true; # do not mess with the bun runtime
 
   installPhase = ''
     runHook preInstall
@@ -37,28 +30,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  doInstallCheck = true;
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-    versionCheckHomeHook
-  ];
-
-  passthru.category = "AI Coding Agents";
-
-  meta = with lib; {
+  meta = old.meta // {
     description = "Qoder CLI (mainland China edition) - terminal-based AI coding assistant for China-region accounts";
     homepage = "https://qoder.cn";
     changelog = "https://qoder.cn/changelog";
     downloadPage = "https://qoder.cn/download";
-    license = flake.lib.licenses.unfree;
     maintainers = with flake.lib.maintainers; [ RyougiShiki-214 ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     mainProgram = "qoderclicn";
   };
-}
+})

--- a/packages/qoder-cli-cn/update.py
+++ b/packages/qoder-cli-cn/update.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update script for qoder-cli-cn package.
+
+Fetches version and hashes directly from the official manifest.
+"""
+
+import base64
+import binascii
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    fetch_json,
+    load_hashes,
+    save_hashes,
+    should_update,
+)
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+MANIFEST_URL = "https://static.qoder.com.cn/qoder-cli-cn/channels/manifest.json"
+
+# Map manifest os/arch to Nix platform names
+PLATFORM_MAP = {
+    ("linux", "amd64"): "x86_64-linux",
+    ("linux", "arm64"): "aarch64-linux",
+    ("darwin", "arm64"): "aarch64-darwin",
+}
+
+
+def hex_to_sri(hex_hash: str) -> str:
+    """Convert hex SHA256 hash to SRI format (sha256-base64)."""
+    raw_bytes = binascii.unhexlify(hex_hash)
+    b64 = base64.b64encode(raw_bytes).decode("ascii")
+    return f"sha256-{b64}"
+
+
+def main() -> None:
+    """Update the qoder-cli-cn package."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+
+    print("Fetching manifest from official source...")
+    response = fetch_json(MANIFEST_URL)
+    if not isinstance(response, dict):
+        msg = "Manifest is not a JSON object"
+        raise TypeError(msg)
+    manifest: dict[str, Any] = response
+    latest: str = manifest["latest"]
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    print(f"Updating qoder-cli-cn from {current} to {latest}")
+
+    # Extract URLs and hashes from manifest. Upstream has changed file naming
+    # before, so we record the exact URL rather than reconstructing it.
+    platforms: dict[str, dict[str, str]] = {}
+    for file_entry in manifest["files"]:
+        os_name = file_entry["os"]
+        arch = file_entry["arch"]
+        key = (os_name, arch)
+
+        if key in PLATFORM_MAP:
+            nix_platform = PLATFORM_MAP[key]
+            platforms[nix_platform] = {
+                "url": file_entry["url"],
+                "hash": hex_to_sri(file_entry["sha256"]),
+            }
+
+    # Verify we got all expected platforms
+    expected = set(PLATFORM_MAP.values())
+    got = set(platforms.keys())
+    missing = expected - got
+    if missing:
+        print(f"Warning: Missing platforms in manifest: {missing}")
+
+    save_hashes(HASHES_FILE, {"version": latest, "platforms": platforms})
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/qoder-cli-cn/update.py
+++ b/packages/qoder-cli-cn/update.py
@@ -1,90 +1,21 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for qoder-cli-cn package.
+"""Update script for qoder-cli-cn package (prebuilt binaries from manifest)."""
 
-Fetches version and hashes directly from the official manifest.
-"""
-
-import base64
-import binascii
 import sys
 from pathlib import Path
-from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    fetch_json,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_manifest_binaries
+
+update_manifest_binaries(
+    Path(__file__).parent,
+    manifest_url="https://static.qoder.com.cn/qoder-cli-cn/channels/manifest.json",
+    platform_map={
+        ("linux", "amd64"): "x86_64-linux",
+        ("linux", "arm64"): "aarch64-linux",
+        ("darwin", "arm64"): "aarch64-darwin",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-MANIFEST_URL = "https://static.qoder.com.cn/qoder-cli-cn/channels/manifest.json"
-
-# Map manifest os/arch to Nix platform names
-PLATFORM_MAP = {
-    ("linux", "amd64"): "x86_64-linux",
-    ("linux", "arm64"): "aarch64-linux",
-    ("darwin", "arm64"): "aarch64-darwin",
-}
-
-
-def hex_to_sri(hex_hash: str) -> str:
-    """Convert hex SHA256 hash to SRI format (sha256-base64)."""
-    raw_bytes = binascii.unhexlify(hex_hash)
-    b64 = base64.b64encode(raw_bytes).decode("ascii")
-    return f"sha256-{b64}"
-
-
-def main() -> None:
-    """Update the qoder-cli-cn package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-
-    print("Fetching manifest from official source...")
-    response = fetch_json(MANIFEST_URL)
-    if not isinstance(response, dict):
-        msg = "Manifest is not a JSON object"
-        raise TypeError(msg)
-    manifest: dict[str, Any] = response
-    latest: str = manifest["latest"]
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating qoder-cli-cn from {current} to {latest}")
-
-    # Extract URLs and hashes from manifest. Upstream has changed file naming
-    # before, so we record the exact URL rather than reconstructing it.
-    platforms: dict[str, dict[str, str]] = {}
-    for file_entry in manifest["files"]:
-        os_name = file_entry["os"]
-        arch = file_entry["arch"]
-        key = (os_name, arch)
-
-        if key in PLATFORM_MAP:
-            nix_platform = PLATFORM_MAP[key]
-            platforms[nix_platform] = {
-                "url": file_entry["url"],
-                "hash": hex_to_sri(file_entry["sha256"]),
-            }
-
-    # Verify we got all expected platforms
-    expected = set(PLATFORM_MAP.values())
-    got = set(platforms.keys())
-    missing = expected - got
-    if missing:
-        print(f"Warning: Missing platforms in manifest: {missing}")
-
-    save_hashes(HASHES_FILE, {"version": latest, "platforms": platforms})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/qoder-cli/update.py
+++ b/packages/qoder-cli/update.py
@@ -1,92 +1,21 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#python3 --command python3
 
-"""Update script for qoder-cli package.
+"""Update script for qoder-cli package (prebuilt binaries from manifest)."""
 
-Fetches version and hashes directly from the official manifest.
-"""
-
-import base64
-import binascii
 import sys
 from pathlib import Path
-from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from updater import (
-    fetch_json,
-    load_hashes,
-    save_hashes,
-    should_update,
+from updater import update_manifest_binaries
+
+update_manifest_binaries(
+    Path(__file__).parent,
+    manifest_url="https://qoder-ide.oss-ap-southeast-1.aliyuncs.com/qodercli/channels/manifest.json",
+    platform_map={
+        ("linux", "amd64"): "x86_64-linux",
+        ("linux", "arm64"): "aarch64-linux",
+        ("darwin", "arm64"): "aarch64-darwin",
+    },
 )
-
-HASHES_FILE = Path(__file__).parent / "hashes.json"
-MANIFEST_URL = (
-    "https://qoder-ide.oss-ap-southeast-1.aliyuncs.com/qodercli/channels/manifest.json"
-)
-
-# Map manifest os/arch to Nix platform names
-PLATFORM_MAP = {
-    ("linux", "amd64"): "x86_64-linux",
-    ("linux", "arm64"): "aarch64-linux",
-    ("darwin", "arm64"): "aarch64-darwin",
-}
-
-
-def hex_to_sri(hex_hash: str) -> str:
-    """Convert hex SHA256 hash to SRI format (sha256-base64)."""
-    raw_bytes = binascii.unhexlify(hex_hash)
-    b64 = base64.b64encode(raw_bytes).decode("ascii")
-    return f"sha256-{b64}"
-
-
-def main() -> None:
-    """Update the qoder-cli package."""
-    data = load_hashes(HASHES_FILE)
-    current = data["version"]
-
-    print("Fetching manifest from official source...")
-    response = fetch_json(MANIFEST_URL)
-    if not isinstance(response, dict):
-        msg = "Manifest is not a JSON object"
-        raise TypeError(msg)
-    manifest: dict[str, Any] = response
-    latest: str = manifest["latest"]
-
-    print(f"Current: {current}, Latest: {latest}")
-
-    if not should_update(current, latest):
-        print("Already up to date")
-        return
-
-    print(f"Updating qoder-cli from {current} to {latest}")
-
-    # Extract URLs and hashes from manifest. Upstream has changed file naming
-    # before, so we record the exact URL rather than reconstructing it.
-    platforms: dict[str, dict[str, str]] = {}
-    for file_entry in manifest["files"]:
-        os_name = file_entry["os"]
-        arch = file_entry["arch"]
-        key = (os_name, arch)
-
-        if key in PLATFORM_MAP:
-            nix_platform = PLATFORM_MAP[key]
-            platforms[nix_platform] = {
-                "url": file_entry["url"],
-                "hash": hex_to_sri(file_entry["sha256"]),
-            }
-
-    # Verify we got all expected platforms
-    expected = set(PLATFORM_MAP.values())
-    got = set(platforms.keys())
-    missing = expected - got
-    if missing:
-        print(f"Warning: Missing platforms in manifest: {missing}")
-
-    save_hashes(HASHES_FILE, {"version": latest, "platforms": platforms})
-    print(f"Updated to {latest}")
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/updater/__init__.py
+++ b/scripts/updater/__init__.py
@@ -18,6 +18,7 @@ from .deps import calculate_dependency_hash, update_dependency_hash
 from .flows import (
     update_bun_github,
     update_github_source,
+    update_manifest_binaries,
     update_npm_package,
     update_platform_binaries,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "update_bun_github",
     "update_dependency_hash",
     "update_github_source",
+    "update_manifest_binaries",
     "update_npm_package",
     "update_platform_binaries",
 ]

--- a/scripts/updater/flows/__init__.py
+++ b/scripts/updater/flows/__init__.py
@@ -7,12 +7,14 @@ per-package update scripts only need to supply their configuration.
 
 from .bun_github import update_bun_github
 from .github_source import update_github_source
+from .manifest_binaries import update_manifest_binaries
 from .npm_package import update_npm_package
 from .platform_binaries import update_platform_binaries
 
 __all__ = [
     "update_bun_github",
     "update_github_source",
+    "update_manifest_binaries",
     "update_npm_package",
     "update_platform_binaries",
 ]

--- a/scripts/updater/flows/manifest_binaries.py
+++ b/scripts/updater/flows/manifest_binaries.py
@@ -1,0 +1,60 @@
+"""Update flow for packages whose upstream ships a JSON manifest of binaries."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from updater.hash import hex_to_sri
+from updater.hashes_file import load_hashes, save_hashes
+from updater.http import fetch_json
+from updater.version import should_update
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def update_manifest_binaries(
+    pkg_dir: Path,
+    *,
+    manifest_url: str,
+    platform_map: dict[tuple[str, str], str],
+) -> None:
+    """Update a package from a manifest listing per-platform urls and sha256.
+
+    The manifest must contain ``latest`` and a ``files`` list with ``os``,
+    ``arch``, ``url`` and ``sha256`` (hex) entries. ``platform_map`` maps
+    ``(os, arch)`` pairs to Nix platform names. Upstream has changed file
+    naming before, so the exact URL is recorded rather than reconstructed.
+    """
+    hashes_file = pkg_dir / "hashes.json"
+    data = load_hashes(hashes_file)
+    current = data["version"]
+
+    manifest = fetch_json(manifest_url)
+    if not isinstance(manifest, dict):
+        msg = "Manifest is not a JSON object"
+        raise TypeError(msg)
+    latest: str = manifest["latest"]
+
+    print(f"Current: {current}, Latest: {latest}")
+
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    platforms: dict[str, dict[str, str]] = {}
+    for file_entry in manifest["files"]:
+        nix_platform = platform_map.get((file_entry["os"], file_entry["arch"]))
+        if nix_platform is not None:
+            platforms[nix_platform] = {
+                "url": file_entry["url"],
+                "hash": hex_to_sri(file_entry["sha256"]),
+            }
+
+    missing = set(platform_map.values()) - set(platforms)
+    if missing:
+        msg = f"Missing platforms in manifest: {missing}"
+        raise RuntimeError(msg)
+
+    save_hashes(hashes_file, {"version": latest, "platforms": platforms})
+    print(f"Updated to {latest}")


### PR DESCRIPTION
## Summary

Add `qoder-cli-cn`, packaging the China-channel build of the Qoder CLI. It is a
bun-compiled binary distributed through the official `static.qoder.com.cn`
manifest, and is modeled directly on the existing `qoder-cli` package.

Differences from `qoder-cli`:

- Manifest/download source: `https://static.qoder.com.cn/qoder-cli-cn/channels/manifest.json`
- Binary name: `qoderclicn`
- Metadata points at `https://qoder.cn`

Like `qoder-cli`, it uses `wrapBuddy` on Linux and `dontStrip` (bun runtime), and
ships a custom `update.py` because nix-update cannot handle the custom manifest
source.

## Test plan

- [x] `nix build .#qoder-cli-cn` succeeds
- [x] Package updates via a custom `update.py` (nix-update doesn't work for the manifest source)

Additional verification run locally:

- `./result/bin/qoderclicn --version` prints `1.1.17`
- `nix flake check` — all checks passed
- `nix fmt` applied
- README regenerated via `./scripts/generate-package-docs.py`
- `check_maintainers.py` passes (new package declares a maintainer)
