### PR TITLE
pdfvision: init at 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1395,6 +1395,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>pdfvision</strong> - Extract text, metadata, and page images from PDF files, designed for AI agents</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://pdfvision.dev/
+- **Usage**: `nix run github:numtide/llm-agents.nix#pdfvision -- --help`
+- **Nix**: [packages/pdfvision/package.nix](packages/pdfvision/package.nix)
+
+</details>
+<details>
 <summary><strong>rtk</strong> - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands</summary>
 
 - **Source**: source

--- a/packages/pdfvision/package.nix
+++ b/packages/pdfvision/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  npmDepsFetcherVersion = 2;
+  pname = "pdfvision";
+  version = "0.16.0";
+
+  src = fetchFromGitHub {
+    owner = "yamadashy";
+    repo = "pdfvision";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KdLuxKn+qfhoXN0hKHnA+DG0igGUOlwz+aZ7lQRXzW8=";
+  };
+
+  npmDepsHash = "sha256-vVUwY3iqeYF1JbKAnSj4Y9hOiPNuzoRWukccuCOAe5g=";
+  makeCacheWritable = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  doInstallCheck = true;
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Extract text, metadata, and page images from PDF files, designed for AI agents";
+    homepage = "https://pdfvision.dev/";
+    changelog = "https://github.com/yamadashy/pdfvision/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "pdfvision";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Summary

Adds [pdfvision](https://github.com/yamadashy/pdfvision) 0.16.0 — a CLI and TypeScript library for evidence-first PDF reading by AI agents. It extracts native text and quality signals first, and falls back to targeted search, layout analysis, page rendering, and OCR when needed.

## What Changed

- New \`packages/pdfvision/package.nix\`, built from source with \`buildNpmPackage\` (\`npmDepsFetcherVersion = 2\`) and pinned via \`fetchFromGitHub\` with \`tag = "v${version}"\`.
- \`versionCheckHook\` + \`versionCheckHomeHook\` for the install check.
- \`passthru.category = "Utilities"\`.
- README package section regenerated with \`./scripts/generate-package-docs.py\`.

No custom \`update.py\`: \`nix-update\` handles this package.

## Testing

- \`nix build .#pdfvision\` succeeds on aarch64-darwin; the install check reports \`0.16.0\`.
- \`pdfvision --help\` works.
- Smoke-tested real PDF rendering (\`-r --render-output …\`), which produced the expected PNGs — this exercises the native \`@napi-rs/canvas\` dependency.
- \`nix fmt\` (no changes) and \`ast-grep scan packages/pdfvision\` (clean).
- Verified the updater: downgraded to 0.15.0, ran \`nix-update --flake pdfvision\`, and version, src hash, and npmDepsHash were all restored correctly.

Not verified locally: the Linux build (no Linux builder available here). \`@napi-rs/canvas\` ships prebuilt \`.node\` binaries that nixpkgs consumers use without \`autoPatchelfHook\`, so it is expected to work, but CI is the real check.
