### PR TITLE
omp: compile with immutable Bun 1.3.14 template

### DIFF
--- a/packages/omp/compile-standalone.ts
+++ b/packages/omp/compile-standalone.ts
@@ -7,13 +7,15 @@
 //
 // Usage (from packages/coding-agent, like upstream's build-binary.ts, so that
 // bare package imports emitted by the virtual-module plugin resolve the same
-// way): bun compile-standalone.ts <bun-compile-target>
+// way): bun compile-standalone.ts <bun-executable-template>
 
 import { createRequire } from "node:module";
 import * as path from "node:path";
 
-const target = process.argv[2];
-if (!target) throw new Error("usage: compile-standalone.ts <bun-compile-target>");
+const executablePath = process.argv[2];
+if (!executablePath) {
+	throw new Error("usage: compile-standalone.ts <bun-executable-template>");
+}
 
 const codingAgentDir = process.cwd();
 const repoRoot = path.resolve(codingAgentDir, "..", "..");
@@ -34,5 +36,5 @@ await compileCodingAgent({
 	entrypoint: path.join(codingAgentDir, "src", "cli.ts"),
 	outfile: path.join(repoRoot, "dist", "omp"),
 	transformersVersion: transformersManifest.version,
-	target: target as Bun.Build.CompileTarget,
+	executablePath,
 });

--- a/packages/omp/package.nix
+++ b/packages/omp/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
+  fetchurl,
   fetchFromGitHub,
   bun2nixLib,
   bun,
@@ -17,6 +19,7 @@
   zig,
   cmake,
   libpulseaudio,
+  unzip,
 }:
 
 let
@@ -24,17 +27,26 @@ let
   inherit (versionData) version hash cargoHash;
   platformsBySystem = {
     aarch64-darwin = {
-      bunTarget = "bun-darwin-arm64";
+      bunTemplate = {
+        name = "bun-darwin-aarch64";
+        hash = "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=";
+      };
       nativeLib = "libpi_natives.dylib";
       nodeTag = "darwin-arm64";
     };
     aarch64-linux = {
-      bunTarget = "bun-linux-arm64";
+      bunTemplate = {
+        name = "bun-linux-aarch64";
+        hash = "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=";
+      };
       nativeLib = "libpi_natives.so";
       nodeTag = "linux-arm64";
     };
     x86_64-linux = {
-      bunTarget = "bun-linux-x64-modern";
+      bunTemplate = {
+        name = "bun-linux-x64";
+        hash = "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=";
+      };
       nativeLib = "libpi_natives.so";
       nodeTag = "linux-x64";
     };
@@ -42,6 +54,34 @@ let
   platform =
     platformsBySystem.${stdenv.hostPlatform.system}
       or (throw "Unsupported platform for omp: ${stdenv.hostPlatform.system}");
+  # Bun 1.3.14 adds Bun.Image, but its compiler corrupts Nix-patched
+  # executable templates: https://github.com/oven-sh/bun/issues/31023
+  # Bun 1.3.13 writes OMP into the unmodified 1.3.14 template instead.
+  # Remove this split after a stable Bun release contains oven-sh/bun#31024.
+  bunRuntimeVersion = "1.3.14";
+  bunRuntimeTemplate = stdenvNoCC.mkDerivation {
+    pname = "omp-bun-runtime-template";
+    version = bunRuntimeVersion;
+
+    src = fetchurl {
+      url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunRuntimeVersion}/${platform.bunTemplate.name}.zip";
+      inherit (platform.bunTemplate) hash;
+    };
+
+    sourceRoot = platform.bunTemplate.name;
+    nativeBuildInputs = [ unzip ];
+    dontConfigure = true;
+    dontBuild = true;
+    # The ELF must keep its original three PT_LOAD segments. It is build data,
+    # not an executable that runs in this derivation.
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 ./bun $out/libexec/bun
+      runHook postInstall
+    '';
+  };
   rustTarget = stdenv.hostPlatform.rust.rustcTarget;
 
   src = fetchFromGitHub {
@@ -54,6 +94,7 @@ in
 stdenv.mkDerivation {
   pname = "omp";
   inherit version src;
+  patches = [ ./use-bun-executable-template.patch ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     name = "omp-${version}-cargo-vendor";
@@ -154,11 +195,6 @@ stdenv.mkDerivation {
     done
     sed -i 's/: "\^/: "/g; s/: "~/: "/g' bun.lock
 
-    # Relax engines.bun to the bun doing the compile, otherwise omp refuses
-    # to start when the embedded runtime is older than upstream's minimum
-    # (issue #4996).
-    sed -i 's/"bun": ">=[0-9.]*"/"bun": ">='"$(bun --version)"'"/' \
-      packages/utils/package.json
 
     # Placeholder client bundle avoids building the full React dashboard.
     cat > packages/stats/src/embedded-client.generated.txt <<'PLACEHOLDER'
@@ -233,7 +269,7 @@ stdenv.mkDerivation {
     # Bun.build() plugin from upstream's compile-binary.ts can provide, so
     # drive that helper instead of `bun build --compile`.
     echo "Compiling standalone binary..."
-    (cd packages/coding-agent && bun ${./compile-standalone.ts} "${platform.bunTarget}")
+    (cd packages/coding-agent && bun ${./compile-standalone.ts} "${bunRuntimeTemplate}/libexec/bun")
 
     runHook postBuild
   '';
@@ -271,6 +307,8 @@ stdenv.mkDerivation {
   installCheckPhase = ''
     runHook preInstallCheck
     HOME=$TMPDIR $out/bin/omp --smoke-test | grep -q "smoke-test: ok"
+    BUN_BE_BUN=1 $out/lib/omp/omp -e \
+      'if (Bun.version !== "${bunRuntimeVersion}" || typeof Bun.Image !== "function") process.exit(1)'
     runHook postInstallCheck
   '';
 

--- a/packages/omp/use-bun-executable-template.patch
+++ b/packages/omp/use-bun-executable-template.patch
@@ -1,0 +1,24 @@
+diff --git a/packages/coding-agent/scripts/compile-binary.ts b/packages/coding-agent/scripts/compile-binary.ts
+index 36e08ab..fbd7f32 100644
+--- a/packages/coding-agent/scripts/compile-binary.ts
++++ b/packages/coding-agent/scripts/compile-binary.ts
+@@ -17,6 +17,8 @@ export interface CodingAgentCompileOptions {
+ 	readonly transformersVersion: string;
+ 	/** Optional cross-compilation runtime target. */
+ 	readonly target?: Bun.Build.CompileTarget;
++	/** Optional Bun executable used as the standalone runtime template. */
++	readonly executablePath?: string;
+ 	/** Match release builds that minify identifiers while retaining names. */
+ 	readonly minifyIdentifiers?: boolean;
+ 	/** Disable Bun's built-in Darwin signing before the caller re-signs. */
+@@ -42,7 +44,9 @@ export async function compileCodingAgent(options: CodingAgentCompileOptions): Pr
+ 			},
+ 			plugins: [await createLegacyPiVirtualModulePlugin()],
+ 			compile: {
+-				...(options.target ? { target: options.target } : {}),
++				...(options.executablePath
++					? { executablePath: options.executablePath }
++					: options.target ? { target: options.target } : {}),
+ 				outfile: options.outfile,
+ 				autoloadBunfig: false,
+ 				autoloadDotenv: false,


### PR DESCRIPTION
## Summary

- restore OMP's upstream `Bun >= 1.3.14` runtime requirement
- keep Bun 1.3.13 as the compiler, but supply the unmodified Bun 1.3.14 release executable through `CompileOptions.executablePath`
- add an install check for the embedded runtime version and `Bun.Image`

Fixes #7598.

## Design

Bun 1.3.14 introduced `Bun.Image`, but its standalone compiler corrupts Nix-patched executable templates because of [oven-sh/bun#31023](https://github.com/oven-sh/bun/issues/31023).

This change avoids that writer path. Bun 1.3.13 performs the compile and copies the hash-pinned, unmodified Bun 1.3.14 release executable as the final runtime template. Normal Nix fixup still applies to the completed OMP executable.

This is temporary. The compiler/runtime split can be removed after a stable Bun release contains [oven-sh/bun#31024](https://github.com/oven-sh/bun/pull/31024).

## Verification

- `nix fmt --accept-flake-config -- packages/omp/package.nix packages/omp/compile-standalone.ts`
- `nix build --accept-flake-config --no-warn-dirty -L .#omp`
- `./result/bin/omp --version` → `omp/17.2.12`
- embedded runtime probe → `1.3.14 function`
- `./result/bin/omp --smoke-test` → `smoke-test: ok`
- real JPEG resize → `2650x1600 -> 2000x1208`
- Agent Hub close sequence returned to the main prompt; OMP remained active
- `nix build --accept-flake-config --no-warn-dirty -L .#checks.x86_64-linux.pkgs-omp`
- `nix flake check --accept-flake-config --no-warn-dirty -L` → all checks passed

Runtime behavior was exercised on `x86_64-linux`. The package definitions for the other supported platforms evaluate, but their binaries were not executed.