### PR TITLE
hermes-agent: fix Python 3.14 tool calls and pin agent-client-protocol to 0.9.0

### DIFF
--- a/packages/hermes-agent/daemon-pool-python314.patch
+++ b/packages/hermes-agent/daemon-pool-python314.patch
@@ -1,0 +1,52 @@
+diff --git a/tools/daemon_pool.py b/tools/daemon_pool.py
+index 2fb5a61..418c261 100644
+--- a/tools/daemon_pool.py
++++ b/tools/daemon_pool.py
+@@ -28,6 +28,7 @@ from __future__ import annotations
+ 
+ import threading
+ import weakref
++import sys
+ from concurrent.futures import ThreadPoolExecutor
+ from concurrent.futures.thread import _worker
+ 
+@@ -38,7 +39,7 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
+     """ThreadPoolExecutor variant whose workers do not block process exit."""
+ 
+     def _adjust_thread_count(self) -> None:
+-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
++        # Mirrors CPython's implementation (3.8–3.14) with two changes:
+         # daemon=True and no _threads_queues registration.
+         if self._idle_semaphore.acquire(timeout=0):
+             return
+@@ -49,15 +50,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
+         num_threads = len(self._threads)
+         if num_threads < self._max_workers:
+             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+-            t = threading.Thread(
+-                name=thread_name,
+-                target=_worker,
+-                args=(
++            if sys.version_info >= (3, 14):
++                # 3.14 refactored ThreadPoolExecutor around WorkerContext:
++                # _worker takes a context object instead of initializer/args.
++                worker_args = (
++                    weakref.ref(self, weakref_cb),
++                    self._create_worker_context(),
++                    self._work_queue,
++                )
++            else:
++                worker_args = (
+                     weakref.ref(self, weakref_cb),
+                     self._work_queue,
+                     self._initializer,
+                     self._initargs,
+-                ),
++                )
++            t = threading.Thread(
++                name=thread_name,
++                target=_worker,
++                args=worker_args,
+                 daemon=True,
+             )
+             t.start()

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -282,6 +282,23 @@ let
     ];
   });
 
+  # Upstream pins agent-client-protocol==0.9.0; nixpkgs' 0.11.x regenerated the
+  # ACP schema and dropped ModelInfo/SetSessionModelResponse/SessionModelState,
+  # which acp_adapter still imports, so hermes-acp fails at startup (#7650).
+  agent-client-protocol' = python3.pkgs.agent-client-protocol.overridePythonAttrs (old: {
+    version = "0.9.0";
+    src = old.src.override {
+      tag = "0.9.0";
+      hash = "sha256-8Xf2S85yNsP/HhpCw9UqdoDdeDHdggvYcnvJbilAVuU=";
+    };
+    # 0.9.0 predates the tests/http suite that nixpkgs' expression disables.
+    disabledTestPaths = [ ];
+    disabledTests = (old.disabledTests or [ ]) ++ [
+      # subprocess spawn exceeds the 2s timeout in the sandbox
+      "test_run_agent_stdio_buffer_limit"
+    ];
+  });
+
   optionalDeps = with python3.pkgs; {
     gateway = [
       # [messaging] / [slack]
@@ -316,7 +333,7 @@ let
       # [pty]
       ptyprocess
       # [acp]
-      agent-client-protocol
+      agent-client-protocol'
       # [voice]
       sounddevice
       numpy
@@ -450,6 +467,8 @@ python3.pkgs.buildPythonApplication {
     "hermes_cli"
     "hermes_cli.dashboard_auth"
     "hermes_cli.proxy"
+    # #7650: acp_adapter needs the pre-0.11 ACP schema; assert it imports.
+    "acp_adapter.server"
     # #4175: adapters swallow ImportError, so assert these import.
     "slack_bolt"
     "discord"

--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -354,7 +354,13 @@ python3.pkgs.buildPythonApplication {
   # import Hermes modules or its dependencies under Nix; run them with the
   # wrapper-provided interpreter and source root instead of leaking a global
   # PYTHONPATH into every subprocess Hermes spawns.
-  patches = [ ./slash-worker-hermes-python.patch ];
+  # DaemonThreadPoolExecutor mirrors CPython <=3.13 ThreadPoolExecutor
+  # internals; Python 3.14 refactored _worker around WorkerContext, so every
+  # tool call fails with AttributeError: no attribute '_initializer' (#7725).
+  patches = [
+    ./slash-worker-hermes-python.patch
+    ./daemon-pool-python314.patch
+  ];
 
   postPatch = ''
     substituteInPlace tools/lazy_deps.py \
@@ -479,6 +485,10 @@ python3.pkgs.buildPythonApplication {
     # Slash workers run HERMES_PYTHON with PYTHONPATH=HERMES_PYTHON_SRC_ROOT.
     PYTHONPATH="$out/${python3.sitePackages}" \
       ${pythonEnv}/bin/python3 -c 'import tui_gateway.slash_worker, yaml'
+    # #7725: DaemonThreadPoolExecutor mirrors CPython ThreadPoolExecutor
+    # internals; assert submit() actually executes work on this Python.
+    PYTHONPATH="$out/${python3.sitePackages}" \
+      ${pythonEnv}/bin/python3 -c 'from tools.daemon_pool import DaemonThreadPoolExecutor; assert DaemonThreadPoolExecutor(max_workers=1).submit(lambda: 42).result(timeout=30) == 42'
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Matrix E2EE: mautrix.crypto must import and the disable switch wired in.


### PR DESCRIPTION
## Summary

- Patch `tools/daemon_pool.py` so `DaemonThreadPoolExecutor` works with Python 3.14's refactored `ThreadPoolExecutor` internals (WorkerContext); adds an install-check asserting `submit()` executes work. Fixes #7725
- Override `agent-client-protocol` to upstream's pinned 0.9.0 so `hermes-acp` no longer ImportErrors on the regenerated 0.11.x ACP schema; adds `acp_adapter.server` to `pythonImportsCheck`. Fixes #7650

## Test

- `nix build .#hermes-agent` on x86_64-linux passes, including the new import and executor install checks.