### PR TITLE
mcptoon: init at 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>mcptoon</strong> - Token-efficient MCP CLI client that converts tool discovery and results to compact TOON output</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/activeing123/mcptoon
+- **Usage**: `nix run github:numtide/llm-agents.nix#mcptoon -- --help`
+- **Nix**: [packages/mcptoon/package.nix](packages/mcptoon/package.nix)
+
+</details>
+<details>
 <summary><strong>officecli</strong> - CLI for creating and editing Office Open XML documents</summary>
 
 - **Source**: source

--- a/packages/mcptoon/default.nix
+++ b/packages/mcptoon/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.callPackage ./package.nix { }

--- a/packages/mcptoon/package.nix
+++ b/packages/mcptoon/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "mcptoon";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "activeing123";
+    repo = "mcptoon";
+    tag = "v${version}";
+    hash = "sha256-JoN3YmBVstzIFF5pxizwrSdSqPO5jlD1Qz0avU3PMgo=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "mcptoon" ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  # config.py creates ~/.config/mcptoon at import time; the tests
+  # import it, so they need a writable HOME.
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = with lib; {
+    description = "Token-efficient MCP CLI client that converts tool discovery and results to compact TOON output";
+    homepage = "https://github.com/activeing123/mcptoon";
+    changelog = "https://github.com/activeing123/mcptoon/releases/tag/v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ zimbatm ];
+    mainProgram = "mcptoon";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description

Adds [mcptoon](https://github.com/activeing123/mcptoon), a zero-dependency Python CLI client for MCP servers. It converts tool discovery and results to compact TOON output to reduce token use.

Distinct from the existing `toon` package (the Rust TOON formatter from toon-format/toon-rust).

Notes:
- Built from the GitHub tag; upstream is not published on PyPI despite its README.
- Tests need `HOME=$TMPDIR` because `config.py` creates `~/.config/mcptoon` at import time.
- No `versionCheckHook`: the CLI has no `--version` flag.

## Testing

- `nix build .#mcptoon` succeeds; per-package check `pkgs-mcptoon` builds.
- `nix-update --flake mcptoon` verified (downgraded to 0.0.9, re-updated to 0.1.0).
- `nix fmt` clean; README regenerated with `./scripts/generate-package-docs.py`.

Sample run:

```
$ nix run .#mcptoon
mcptoon — Token-efficient MCP CLI client

Usage:
    mcptoon list                         List configured servers
    mcptoon manifest                     List all tools (compact)
    ...

$ mcptoon list
No servers configured. Run: mcptoon init
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gvyqKkEPBeMgSd3khpnf9