### PR TITLE
hermes-agent: drop setuptools skip-dependency-check workaround

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -388,10 +388,6 @@ python3.pkgs.buildPythonApplication {
   # (uv2nix-style) build; upstream gates it behind this env var.
   env.HERMES_NIX_BUILD = "1";
 
-  # Upstream pins setuptools<83 in build-system.requires, which nixpkgs'
-  # setuptools 83 no longer satisfies; the pin is only about metadata quirks.
-  pypaBuildFlags = [ "--skip-dependency-check" ];
-
   dependencies = hermesDeps;
   optional-dependencies = optionalDeps;
 


### PR DESCRIPTION
Upstream now pins `setuptools==83.0.0` in build-system.requires, which nixpkgs' setuptools satisfies, so the build-time dependency check no longer needs to be skipped (part of #7211).

The firecrawl-py metadata override stays: nixpkgs' firecrawl-py 2.8.0 still builds a wheel whose METADATA reports 4.14.0 (verified, still fails its `pythonMetadataCheckPhase`).

Verified: `pkgs-hermes-agent` passes on x86_64-linux and aarch64-darwin.