### PR TITLE
ast-grep: broaden tag rule, enforce changelog/category/hash conventions

### DIFF
--- a/checks/t3code-packaging.nix
+++ b/checks/t3code-packaging.nix
@@ -17,13 +17,14 @@ assert t3code.passthru ? resourceMonitor;
 assert pkgs.lib.hasInfix "package.json').dependencies.electron" (
   builtins.readFile ../packages/t3code/package.nix
 );
-assert map pkgs.lib.getName t3code.passthru.providerPackages == [
-  "grok"
-  "claude-code"
-  "codex"
-  "opencode"
-  "cursor-agent"
-];
+assert
+  map pkgs.lib.getName t3code.passthru.providerPackages == [
+    "grok"
+    "claude-code"
+    "codex"
+    "opencode"
+    "cursor-agent"
+  ];
 pkgs.runCommand "t3code-packaging-check" { } ''
   touch $out
 ''

--- a/packages/chainlink/package.nix
+++ b/packages/chainlink/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "dollspace-gay";
     repo = "chainlink";
-    rev = "chainlink-${version}";
+    tag = "chainlink-${version}";
     hash = "sha256-2n+cM1ADmeDrKZKjMY5Ct4mVxl38as4iu1Y4ZSCuBho=";
   };
 

--- a/packages/gnhf/package.nix
+++ b/packages/gnhf/package.nix
@@ -17,7 +17,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "kunchenguid";
     repo = "gnhf";
-    rev = "gnhf-v${version}";
+    tag = "gnhf-v${version}";
     hash = "sha256-bNxY0MGkWaHqK5OFcjrqB+WKVR6KdzXR3aV8VuPkEas=";
   };
 

--- a/packages/goose-cli/fetchers.nix
+++ b/packages/goose-cli/fetchers.nix
@@ -12,7 +12,7 @@
     fetchurl {
       name = "librusty_v8-${args.version}";
       url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-      sha256 = args.shas.${stdenv.hostPlatform.system};
+      hash = args.shas.${stdenv.hostPlatform.system};
       meta = {
         inherit (args) version;
         sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/packages/icm/package.nix
+++ b/packages/icm/package.nix
@@ -19,7 +19,7 @@ let
   icm-web-src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "icm";
-    rev = "icm-v${hashes.version}";
+    tag = "icm-v${hashes.version}";
     hash = hashes.hash;
   };
 
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "icm";
-    rev = "icm-v${hashes.version}";
+    tag = "icm-v${hashes.version}";
     hash = hashes.hash;
   };
 

--- a/packages/pi/package.nix
+++ b/packages/pi/package.nix
@@ -53,7 +53,8 @@ buildNpmPackage {
   # The package from npm is already built
   dontNpmBuild = true;
 
-  nativeBuildInputs = lib.optional useBun bun
+  nativeBuildInputs =
+    lib.optional useBun bun
     ++ lib.optionals (useBun && stdenv.hostPlatform.isDarwin) [
       rcodesign
     ];

--- a/packages/vibe-kanban/package.nix
+++ b/packages/vibe-kanban/package.nix
@@ -31,7 +31,7 @@ let
   src = fetchFromGitHub {
     owner = "BloopAI";
     repo = "vibe-kanban";
-    rev = tag;
+    inherit tag;
     inherit hash;
   };
 

--- a/rules/no-legacy-sha256.yml
+++ b/rules/no-legacy-sha256.yml
@@ -1,0 +1,10 @@
+id: no-legacy-sha256
+language: nix
+severity: error
+message: >-
+  Use `hash = "sha256-..."` (SRI format) instead of the legacy `sha256`/`cargoSha256`/`vendorSha256` attributes. All fetchers and builders in this repo accept `hash`.
+rule:
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^(sha256|cargoSha256|vendorSha256)$'

--- a/rules/no-unpinned-rev.yml
+++ b/rules/no-unpinned-rev.yml
@@ -1,0 +1,13 @@
+id: no-unpinned-rev
+language: nix
+severity: error
+message: >-
+  Do not pin sources to a branch name. Branches move, so the fetch breaks the moment upstream pushes. Pin a tag (`tag = ...`) or a full commit hash (`rev = ...`).
+rule:
+  kind: string_expression
+  regex: '^"(main|master|HEAD|trunk|develop)"$'
+  inside:
+    kind: binding
+    has:
+      field: attrpath
+      regex: '^(rev|ref)$'

--- a/rules/prefer-tag-over-rev.yml
+++ b/rules/prefer-tag-over-rev.yml
@@ -2,19 +2,29 @@ id: prefer-tag-over-rev
 language: nix
 severity: error
 message: >-
-  Use `tag = "v${version}"` instead of `rev = "v${version}"` for GitHub sources. A bare `rev` fetches the ambiguous `archive/v${version}.tar.gz` URL, which breaks when a repo has both a branch and a tag of that name. `tag` resolves to `refs/tags/` and is hash-identical.
+  Use `tag = ...` instead of `rev = ...` when the value is a tag name. A bare `rev` fetches the ambiguous `archive/<rev>.tar.gz` URL, which breaks when a repo has both a branch and a tag of that name. `tag` resolves to `refs/tags/` and is hash-identical. Commit hashes stay in `rev`.
 note: |
   fetchFromGitHub {
     owner = "owner";
     repo = "repo";
-    tag = "v${version}";  # not: rev = "v${version}";
+    tag = "v${version}";  # not: rev = "v${version}"; nor rev = "app-v${version}";
     hash = "sha256-...";
   }
 rule:
-  kind: string_expression
-  regex: '^"v\$\{'
-  inside:
-    kind: binding
-    has:
-      field: attrpath
-      regex: '^rev$'
+  any:
+    # rev = "<anything>${version}<anything>" — version-derived strings are tags
+    - kind: string_expression
+      regex: '\$\{[^}]*version[^}]*\}'
+      inside:
+        kind: binding
+        has:
+          field: attrpath
+          regex: '^rev$'
+    # rev = tag — a variable literally named "tag" holds a tag name
+    - kind: variable_expression
+      regex: '^tag$'
+      inside:
+        kind: binding
+        has:
+          field: attrpath
+          regex: '^rev$'

--- a/rules/require-meta-changelog.yml
+++ b/rules/require-meta-changelog.yml
@@ -1,0 +1,42 @@
+id: require-meta-changelog
+language: nix
+severity: error
+message: >-
+  Every package `meta` must have a `changelog` attribute. The updater uses it to generate release notes. Use a version-specific URL matching the upstream tag format; fall back to `/releases` when tags are inconsistent.
+note: |
+  meta = {
+    changelog = "https://github.com/owner/repo/releases/tag/v${version}";
+    # ...
+  };
+# Only the top-level package definition; vendored-dependency metas inside
+# other .nix files do not need a changelog.
+files:
+  - 'packages/**/package.nix'
+# In-repo helpers and build hooks have no upstream releases.
+ignores:
+  - 'packages/buildNpmPackage/**'
+  - 'packages/darwinOpenptyHook/**'
+  - 'packages/default/**'
+  - 'packages/dolt/**'
+  - 'packages/formatelf/**'
+  - 'packages/go-bin/**'
+  - 'packages/unpinCargoMsrvHook/**'
+  - 'packages/unpinGoModVersionHook/**'
+  - 'packages/versionCheckHomeHook/**'
+  - 'packages/wrapBuddy/**'
+# Anchor on the whole file: a package.nix that defines a `meta` but never a
+# `changelog` anywhere is missing it. Per-meta matching would flag vendored
+# dependency derivations whose small metas legitimately skip changelog.
+rule:
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^meta$'
+  inside:
+    kind: source_code
+    stopBy: end
+    not:
+      has:
+        stopBy: end
+        kind: attrpath
+        regex: '^changelog$'

--- a/rules/require-passthru-category.yml
+++ b/rules/require-passthru-category.yml
@@ -1,0 +1,38 @@
+id: require-passthru-category
+language: nix
+severity: error
+message: >-
+  Every package must set `passthru.category` — the README generator groups packages by it. See CLAUDE.md for the list of categories.
+note: |
+  passthru.category = "AI Coding Agents";
+# Only the top-level package definition; vendored-dependency metas inside
+# other .nix files do not need a category.
+files:
+  - 'packages/**/package.nix'
+# In-repo helpers and build hooks are not listed in the README.
+# qoder-cli-cn inherits passthru.category from qoder-cli via overrideAttrs.
+ignores:
+  - 'packages/buildNpmPackage/**'
+  - 'packages/darwinOpenptyHook/**'
+  - 'packages/default/**'
+  - 'packages/dolt/**'
+  - 'packages/formatelf/**'
+  - 'packages/go-bin/**'
+  - 'packages/qoder-cli-cn/**'
+  - 'packages/unpinCargoMsrvHook/**'
+  - 'packages/unpinGoModVersionHook/**'
+  - 'packages/versionCheckHomeHook/**'
+  - 'packages/wrapBuddy/**'
+rule:
+  kind: binding
+  has:
+    field: attrpath
+    regex: '^meta$'
+  inside:
+    kind: source_code
+    stopBy: end
+    not:
+      has:
+        stopBy: end
+        kind: attrpath
+        regex: '(^|\.)category$'


### PR DESCRIPTION
## What

Better ast-grep lint coverage, from an inventory of the repo, past PRs and issues.

### New rules

- `require-meta-changelog`: CLAUDE.md requires it; the updater uses it for release notes. Anchored on the whole file so vendored-dependency `meta` blocks inside a `package.nix` (hermes-agent, semble, mistral-vibe) do not false-positive.
- `require-passthru-category`: the README generator groups packages by it.
- `no-legacy-sha256`: use `hash =` (SRI) instead of `sha256`/`cargoSha256`/`vendorSha256`.
- `no-unpinned-rev`: reject `rev = "main"`-style branch pins; they break on upstream push.

### Broadened rule

`prefer-tag-over-rev` only matched `rev = "v${version}"`. Tags like `"chainlink-${version}"` and `rev = tag` slipped through. It now matches any `${version}` interpolation and the `tag` variable.

### Fixes the new rules found

- chainlink, gnhf, icm (×2), vibe-kanban: tag-shaped `rev =` → `tag =`
- goose-cli: legacy `sha256 =` → `hash =` in the librusty_v8 fetcher
- plus pre-existing nixfmt drift in two files (first commit)

In-repo helpers and hooks (formatelf, wrapBuddy, versionCheckHomeHook, ...) are ignore-listed where a rule does not apply, with a comment saying why.

## Testing

- `ast-grep scan packages checks scripts` exits 0
- All four re-tagged sources re-fetch with unchanged hashes (`nix build .#<pkg>.src`)
- `nix eval .#goose-cli.drvPath` still evaluates
- `nix fmt` passes (runs the ast-grep check via treefmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JNcxmscizA17DGLfsT7cM