### PR TITLE
treefmt: quote the attribute after inputs.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,30 +11,30 @@
     systems.url = "github:nix-systems/default";
     blueprint = {
       url = "github:numtide/blueprint";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+      inputs."nixpkgs".follows = "nixpkgs";
+      inputs."systems".follows = "systems";
     };
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs."nixpkgs".follows = "nixpkgs";
     };
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
+      inputs."nixpkgs-lib".follows = "nixpkgs";
     };
     bun2nix = {
       url = "github:nix-community/bun2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.treefmt-nix.follows = "treefmt-nix";
-      inputs.flake-parts.follows = "flake-parts";
+      inputs."nixpkgs".follows = "nixpkgs";
+      inputs."systems".follows = "systems";
+      inputs."treefmt-nix".follows = "treefmt-nix";
+      inputs."flake-parts".follows = "flake-parts";
     };
   };
 
   outputs =
     inputs:
     let
-      blueprintOutputs = inputs.blueprint {
+      blueprintOutputs = inputs."blueprint" {
         inherit inputs;
         nixpkgs.config.allowUnfree = true;
       };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,5 @@
 { inputs, ... }:
-inputs.nixpkgs.lib.extend (
+inputs."nixpkgs".lib.extend (
   _final: prev: {
     maintainers = prev.maintainers // {
       ak2k = {

--- a/packages/aionui/default.nix
+++ b/packages/aionui/default.nix
@@ -4,6 +4,6 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix { inherit bun2nix flake; }

--- a/packages/backlog-md/default.nix
+++ b/packages/backlog-md/default.nix
@@ -4,6 +4,6 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix { inherit bun2nix; }

--- a/packages/bun2nix/default.nix
+++ b/packages/bun2nix/default.nix
@@ -7,7 +7,7 @@
 # cache and update jobs don't have to build it from source (crates.io
 # rejects nix's crate downloads with 403).
 let
-  bun2nix = flake.inputs.bun2nix.packages.${pkgs.stdenv.hostPlatform.system}.bun2nix;
+  bun2nix = flake.inputs."bun2nix".packages.${pkgs.stdenv.hostPlatform.system}.bun2nix;
 in
 bun2nix
 // {

--- a/packages/formatter/default.nix
+++ b/packages/formatter/default.nix
@@ -6,7 +6,7 @@
 }:
 # treefmt with config
 let
-  formatter = inputs.treefmt-nix.lib.mkWrapper pkgs {
+  formatter = inputs."treefmt-nix".lib.mkWrapper pkgs {
     _file = __curPos.file;
     imports = [ ./treefmt.nix ];
   };

--- a/packages/formatter/treefmt.nix
+++ b/packages/formatter/treefmt.nix
@@ -9,6 +9,14 @@ let
     ];
     text = builtins.readFile ./../../scripts/check.sh;
   };
+
+  quote-flake-inputs = pkgs.writeShellApplication {
+    name = "quote-flake-inputs";
+    runtimeInputs = [ pkgs.python3 ];
+    text = ''
+      python3 ${./../../scripts/quote-flake-inputs.py} "$@"
+    '';
+  };
 in
 {
   package = pkgs.treefmt;
@@ -29,6 +37,14 @@ in
   # Python formatting and linting
   programs.ruff-format.enable = true;
   programs.ruff-check.enable = true;
+
+  # zimbatm's law: the attribute after `inputs.` must be quoted.
+  settings.formatter.quote-flake-inputs = {
+    command = "${quote-flake-inputs}/bin/quote-flake-inputs";
+    includes = [ "*.nix" ];
+    pipeline = "nix";
+    priority = 0;
+  };
 
   settings.formatter.deadnix.pipeline = "nix";
   settings.formatter.deadnix.priority = 1;

--- a/packages/gno/default.nix
+++ b/packages/gno/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit flake cudaSupport bun2nix;

--- a/packages/hunk/default.nix
+++ b/packages/hunk/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit flake bun2nix;

--- a/packages/icm/default.nix
+++ b/packages/icm/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit flake bun2nix;

--- a/packages/oh-my-opencode/default.nix
+++ b/packages/oh-my-opencode/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit bun2nix flake;

--- a/packages/omp/default.nix
+++ b/packages/omp/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit bun2nix;

--- a/packages/qmd/default.nix
+++ b/packages/qmd/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix {
   inherit flake bun2nix cudaSupport;

--- a/packages/ralph-tui/default.nix
+++ b/packages/ralph-tui/default.nix
@@ -4,6 +4,6 @@
   ...
 }:
 let
-  bun2nix = (pkgs.extend flake.inputs.bun2nix.overlays.default).bun2nix;
+  bun2nix = (pkgs.extend flake.inputs."bun2nix".overlays.default).bun2nix;
 in
 pkgs.callPackage ./package.nix { inherit flake bun2nix; }

--- a/scripts/quote-flake-inputs.py
+++ b/scripts/quote-flake-inputs.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Treefmt formatter: quote the attribute after `inputs.`.
+
+Rewrites `inputs.nixpkgs` to `inputs."nixpkgs"` in .nix files.
+
+A plain regex would also hit comments and strings, so this walks the
+file with a minimal Nix lexer and only rewrites in code context.
+Interpolations (`inputs.${...}`) and already-quoted names are left
+alone, which makes the rewrite idempotent.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_'-]*")
+
+
+class Rewriter:
+    """Single-pass rewriter over one Nix source file."""
+
+    def __init__(self, text: str) -> None:
+        """Set up the cursor and context stack for one file."""
+        self.text = text
+        self.out: list[str] = []
+        self.i = 0
+        # Context stack. "code" at the bottom; strings push themselves,
+        # interpolations push "code" again. Interpolation depth rides
+        # on the brace counter stack.
+        self.ctx: list[str] = ["code"]
+        self.braces: list[int] = []
+
+    def run(self) -> str:
+        """Walk the whole file and return the rewritten text."""
+        handlers = {
+            "code": self.code,
+            "dquote": self.dquote,
+            "indent": self.indent,
+        }
+        while self.i < len(self.text):
+            handlers[self.ctx[-1]]()
+        return "".join(self.out)
+
+    def emit(self, n: int) -> None:
+        """Copy n chars to the output verbatim."""
+        self.out.append(self.text[self.i : self.i + n])
+        self.i += n
+
+    def emit_until(self, marker: str, skip: int) -> None:
+        """Copy verbatim up to and including the next marker."""
+        j = self.text.find(marker, self.i + skip)
+        j = len(self.text) if j == -1 else j + len(marker)
+        self.out.append(self.text[self.i : j])
+        self.i = j
+
+    def enter_interpolation(self) -> None:
+        """Push a code context for a ${...} interpolation."""
+        self.ctx.append("code")
+        self.braces.append(0)
+        self.emit(2)
+
+    def code(self) -> None:
+        """Handle one token in code context."""
+        t, i = self.text, self.i
+        if t[i] == "#":
+            # line comments run to EOL, minus the newline itself
+            self.emit_until("\n", 1)
+            if self.out[-1].endswith("\n"):
+                self.out[-1] = self.out[-1][:-1]
+                self.i -= 1
+            return
+        if t.startswith("/*", i):
+            self.emit_until("*/", 2)
+            return
+        if t[i] == '"':
+            self.ctx.append("dquote")
+            self.emit(1)
+            return
+        if t.startswith("''", i):
+            self.ctx.append("indent")
+            self.emit(2)
+            return
+        if t[i] in "{}":
+            self.brace(t[i])
+            return
+        m = IDENT.match(t, i)
+        if m:
+            self.ident(m)
+            return
+        self.emit(1)
+
+    def brace(self, c: str) -> None:
+        """Track interpolation depth for { and }."""
+        if self.braces:
+            if c == "{":
+                self.braces[-1] += 1
+            elif self.braces[-1] == 0:
+                # end of interpolation, back into the string
+                self.braces.pop()
+                self.ctx.pop()
+            else:
+                self.braces[-1] -= 1
+        self.emit(1)
+
+    def ident(self, m: re.Match[str]) -> None:
+        """Quote the attribute that follows an `inputs.` token."""
+        t, i = self.text, self.i
+        prev = t[i - 1] if i > 0 else ""
+        boundary = not (prev.isalnum() or prev in "_'-")
+        end = m.end()
+        if m.group(0) == "inputs" and boundary and t[end : end + 1] == ".":
+            nm = IDENT.match(t, end + 1)
+            if nm:
+                self.out.append(f'inputs."{nm.group(0)}"')
+                self.i = nm.end()
+                return
+        self.emit(end - i)
+
+    def dquote(self) -> None:
+        """Handle one token inside a "..." string."""
+        t, i = self.text, self.i
+        if t[i] == "\\":
+            self.emit(2)
+        elif t.startswith("${", i):
+            self.enter_interpolation()
+        elif t[i] == '"':
+            self.ctx.pop()
+            self.emit(1)
+        else:
+            self.emit(1)
+
+    def indent(self) -> None:
+        """Handle one token inside an ''...'' string."""
+        t, i = self.text, self.i
+        if t.startswith("''$", i) or t.startswith("'''", i):
+            self.emit(3)
+        elif t.startswith("${", i):
+            self.enter_interpolation()
+        elif t.startswith("''", i):
+            self.ctx.pop()
+            self.emit(2)
+        else:
+            self.emit(1)
+
+
+def main() -> None:
+    """Rewrite each file given on the command line in place."""
+    for arg in sys.argv[1:]:
+        path = Path(arg)
+        text = path.read_text()
+        new = Rewriter(text).run()
+        if new != text:
+            path.write_text(new)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

New law: the attribute after `inputs.` must be quoted. :stuck_out_tongue:

- `scripts/quote-flake-inputs.py` — a treefmt formatter that rewrites `inputs.foo` to `inputs."foo"`. It is a minimal Nix lexer, not a regex, so comments, `"…"`/`''…''` string contents, and `inputs.${...}` interpolations are untouched. Idempotent.
- Registered in the `nix` pipeline at priority 0, before deadnix and nixfmt. nixfmt preserves quoted attr names, so the two do not fight.
- Applied to the tree: `flake.nix`, `lib/default.nix`, and the `flake.inputs.bun2nix` references in package wrappers (13 files).

## Testing

- Edge-case file covering already-quoted names, interpolation, comments, block comments, both string kinds, and `myinputs.foo` boundary — all handled; second run is a no-op.
- `nix fmt` clean (ruff, mypy, nixfmt all pass).
- `nix build .#formatter` succeeds; affected packages (`bun2nix`, `backlog-md`) still evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gvyqKkEPBeMgSd3khpnf9