### PR TITLE
rules: quote the attribute after inputs.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,18 +11,18 @@
     systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs."nixpkgs".follows = "nixpkgs";
     };
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
+      inputs."nixpkgs-lib".follows = "nixpkgs";
     };
     bun2nix = {
       url = "github:nix-community/bun2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.treefmt-nix.follows = "treefmt-nix";
-      inputs.flake-parts.follows = "flake-parts";
+      inputs."nixpkgs".follows = "nixpkgs";
+      inputs."systems".follows = "systems";
+      inputs."treefmt-nix".follows = "treefmt-nix";
+      inputs."flake-parts".follows = "flake-parts";
     };
   };
 
@@ -90,7 +90,7 @@
               bun = pkgsFor.${system}.bun or pkgs.bun;
               # bun2nix builder set (hook, fetchBunDeps, ...); the `bun2nix`
               # scope attribute is the CLI package.
-              bun2nixLib = (pkgs.extend inputs.bun2nix.overlays.default).bun2nix;
+              bun2nixLib = (pkgs.extend inputs."bun2nix".overlays.default).bun2nix;
               # makeScope reserves `packages`, so expose the package set as allPackages.
               allPackages = packages;
             }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,5 @@
 { inputs, ... }:
-inputs.nixpkgs.lib.extend (
+inputs."nixpkgs".lib.extend (
   _final: prev: {
     licenses = prev.licenses // {
       # nixpkgs' unfree license, but with `free = true` so evaluating these

--- a/packages/bun2nix/package.nix
+++ b/packages/bun2nix/package.nix
@@ -6,7 +6,7 @@
 # cache and update jobs don't have to build it from source (crates.io
 # rejects nix's crate downloads with 403).
 let
-  bun2nix = flake.inputs.bun2nix.packages.${pkgs.stdenv.hostPlatform.system}.bun2nix;
+  bun2nix = flake.inputs."bun2nix".packages.${pkgs.stdenv.hostPlatform.system}.bun2nix;
 in
 bun2nix
 // {

--- a/packages/formatter/package.nix
+++ b/packages/formatter/package.nix
@@ -5,7 +5,7 @@
 }:
 # treefmt with config
 let
-  formatter = inputs.treefmt-nix.lib.mkWrapper pkgs {
+  formatter = inputs."treefmt-nix".lib.mkWrapper pkgs {
     _file = __curPos.file;
     imports = [ ./treefmt.nix ];
   };

--- a/rules/quote-input-name.yml
+++ b/rules/quote-input-name.yml
@@ -1,0 +1,34 @@
+id: quote-input-name
+language: nix
+severity: error
+message: >-
+  Quote the attribute after `inputs.` — write `inputs."foo"`, not `inputs.foo`. Flake input names are external identifiers, not code; quoting marks them as such and keeps names with dots or dashes uniform.
+note: |
+  inputs."nixpkgs".follows = "nixpkgs";  # not: inputs.nixpkgs.follows
+  flake.inputs."bun2nix".overlays.default
+rule:
+  pattern: $NAME
+  kind: identifier
+  any:
+    # inputs.foo.follows / flake.inputs.foo — second segment of an
+    # attrpath whose first segment is `inputs`
+    - nthChild: 2
+      inside:
+        kind: attrpath
+        has:
+          nthChild: 1
+          kind: identifier
+          regex: '^inputs$'
+    # inputs.foo — first attrpath segment when the receiver
+    # expression is the `inputs` variable
+    - nthChild: 1
+      inside:
+        kind: attrpath
+        inside:
+          kind: select_expression
+          has:
+            field: expression
+            has:
+              kind: identifier
+              regex: '^inputs$'
+fix: '"$NAME"'


### PR DESCRIPTION
## Description

Redo of #7888 the right way, as an ast-grep rule per the #7886 setup.

`rules/quote-input-name.yml` enforces `inputs."foo"` over `inputs.foo`:

- Matches the input name in both syntactic positions: binding attrpaths (`inputs.nixpkgs.follows`) and select chains (`flake.inputs.bun2nix...`, `inputs.blueprint { }`).
- Already-quoted names and `inputs.${...}` interpolations don't match.
- Carries a `fix:`, so `ast-grep scan -U` auto-rewrites violations.

Applied to the tree: `flake.nix`, `lib/default.nix`, `packages/bun2nix/package.nix`, `packages/formatter/package.nix` (10 sites).

Note: ast-grep's `follows` relation stops at the anonymous `.` token inside `attrpath`, so the rule anchors on `nthChild` instead of sibling relations.

## Testing

- Probe files cover: both match positions, already-quoted, interpolation, `inherit (inputs) x`, `inherit inputs x`, `{ inputs = 1; }`, formal args — no false positives, second `scan -U` run is a no-op.
- `ast-grep scan` exits 0 after the rewrite.
- `nix fmt` clean (includes the ast-grep treefmt check).
- `.#formatter`, `.#bun2nix`, and the devshell still evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gvyqKkEPBeMgSd3khpnf9