### PR TITLE
updater/http: match GitHub API host exactly before sending token

### DIFF
--- a/scripts/updater/http.py
+++ b/scripts/updater/http.py
@@ -4,6 +4,17 @@ import json
 import os
 import urllib.request
 from typing import Any
+from urllib.parse import urlparse
+
+# Only these hosts receive the Authorization header. Matched against the
+# parsed hostname, never a substring: "api.github.com" appears inside
+# attacker-shaped hosts like api.github.com.evil.com or evil.com/?api.github.com.
+GITHUB_API_HOSTS = frozenset({"api.github.com"})
+
+
+def _is_github_api(url: str) -> bool:
+    """Return True only when url's host is exactly a GitHub API host."""
+    return urlparse(url).hostname in GITHUB_API_HOSTS
 
 
 def _github_request(url: str) -> urllib.request.Request:
@@ -40,10 +51,7 @@ def fetch_text(
         urllib.error.URLError: If the request fails
 
     """
-    if "api.github.com" in url:
-        req = _github_request(url)
-    else:
-        req = urllib.request.Request(url)
+    req = _github_request(url) if _is_github_api(url) else urllib.request.Request(url)
     req.add_header("User-Agent", user_agent)
     with urllib.request.urlopen(req, timeout=timeout) as response:
         data: bytes = response.read()


### PR DESCRIPTION
## Description

From the repo security review. `fetch_text()` attached the `GITHUB_TOKEN` `Authorization` header whenever the URL *contained the substring* `api.github.com`:

```python
if "api.github.com" in url:
    req = _github_request(url)
```

That also matches attacker-shaped hosts — `https://api.github.com.evil.com/...`, `https://evil.com/?api.github.com`, `https://api.github.com@evil.com/...`. A custom `update.py` fed an upstream-controlled URL (or following a redirect) could leak the token to an arbitrary host. Impact is bounded — the token is `contents: read` on a public repo — but it's a real credential-exfiltration path and the fix is trivial.

Now gated on the parsed hostname:

```python
GITHUB_API_HOSTS = frozenset({"api.github.com"})

def _is_github_api(url: str) -> bool:
    return urlparse(url).hostname in GITHUB_API_HOSTS
```

## Testing

Verified the matcher against benign and malicious URLs — accepts `https://api.github.com/...` (any path/query, any case, http or https) and rejects the `.evil.com` suffix, the `?api.github.com` query, the `/api.github.com/` path, and the `@evil.com` userinfo trick. `nix fmt` clean (ruff `ALL` ruleset).