### PR TITLE
kandev: init at 0.87.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>kandev-desktop</strong> - Native desktop application for the Kandev agentic development platform</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-only
+- **Homepage**: https://github.com/kdlbs/kandev
+- **Usage**: `nix run github:numtide/llm-agents.nix#kandev-desktop -- --help`
+- **Nix**: [packages/kandev-desktop/package.nix](packages/kandev-desktop/package.nix)
+
+</details>
+<details>
 <summary><strong>mardi-gras</strong> - Terminal UI for Beads issue tracking with a parade-inspired workflow view</summary>
 
 - **Source**: source

--- a/README.md
+++ b/README.md
@@ -846,6 +846,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>kandev</strong> - Manage tasks, orchestrate agents, review changes, and ship value</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-only
+- **Homepage**: https://github.com/kdlbs/kandev
+- **Usage**: `nix run github:numtide/llm-agents.nix#kandev -- --help`
+- **Nix**: [packages/kandev/package.nix](packages/kandev/package.nix)
+
+</details>
+<details>
 <summary><strong>mardi-gras</strong> - Terminal UI for Beads issue tracking with a parade-inspired workflow view</summary>
 
 - **Source**: source

--- a/packages/kandev-desktop/nix-update-args
+++ b/packages/kandev-desktop/nix-update-args
@@ -1,0 +1,2 @@
+--subpackage
+pnpmDeps

--- a/packages/kandev-desktop/package.nix
+++ b/packages/kandev-desktop/package.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  flake,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  fetchurl,
+  nodejs_24,
+  codex,
+  codex-acp,
+  gemini-cli,
+  cargo-tauri,
+  pkg-config,
+  wrapGAppsHook3,
+  makeBinaryWrapper,
+  rcodesign,
+  glib-networking,
+  openssl,
+  webkitgtk_4_1,
+  kandev,
+  git,
+  bash,
+  openssh,
+}:
+
+let
+  pnpm = pnpm_10.overrideAttrs (_: {
+    version = "9.15.9";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz";
+      hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";
+    };
+  });
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kandev-desktop";
+  version = "0.87.1";
+
+  src = fetchFromGitHub {
+    owner = "kdlbs";
+    repo = "kandev";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-StFmh8pa9X7dllbpxbVFYraucsvrTJNtwQBNWElgCiU=";
+  };
+
+  cargoRoot = "apps/desktop/src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-a/rh4HYT5Gmfjd/gIVH48cLt6Y/4d8CgXbrhNer5e70=";
+
+  pnpmRoot = "apps";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/apps";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-EQ07LBl6WIoeHZwbo6HaZC+ZHullTJO2aCh20/5WDQ0=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs_24
+    pnpm
+    pnpmConfigHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
+    rcodesign
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  buildFeatures = [ "desktop-runtime" ];
+  doCheck = false;
+
+  postPatch = ''
+    # The package has a second helper binary. Tauri otherwise bundles that
+    # binary instead of the feature-gated desktop application.
+    substituteInPlace apps/desktop/src-tauri/Cargo.toml \
+      --replace-fail '[package]' $'[package]\ndefault-run = "kandev-desktop"'
+
+    # Nix owns upgrades. Keep release discovery, but never replace the running
+    # immutable application with an upstream installer.
+    substituteInPlace apps/desktop/src-tauri/src/updater.rs \
+      --replace-fail \
+        'UpdatePlatform::MacOs | UpdatePlatform::Windows => InstallSupport::supported(),' \
+        'UpdatePlatform::MacOs | UpdatePlatform::Windows => InstallSupport::unsupported("Update Kandev through Nix."),'
+  '';
+
+  preBuild = ''
+    if [[ ${kandev.version} != ${finalAttrs.version} ]]; then
+      echo "Kandev Desktop ${finalAttrs.version} requires the matching Kandev runtime; got ${kandev.version}." >&2
+      exit 1
+    fi
+
+    runtime=apps/desktop/src-tauri/resources/kandev
+    rm -rf "$runtime"
+    mkdir -p "$runtime/bin"
+    cp -L ${kandev}/libexec/kandev/bin/* "$runtime/bin/"
+    chmod +x "$runtime/bin/"*
+  '';
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nodejs_24
+          codex
+          codex-acp
+          gemini-cli
+          git
+          bash
+          openssh
+        ]
+      }
+    )
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    app="$out/Applications/Kandev.app"
+    launcher="$app/Contents/MacOS/kandev-desktop"
+    mv "$launcher" "$launcher-unwrapped"
+    makeBinaryWrapper \
+      "$launcher-unwrapped" \
+      "$launcher" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nodejs_24
+          codex
+          codex-acp
+          gemini-cli
+          git
+          bash
+          openssh
+        ]
+      }
+    mkdir -p "$out/bin"
+    ln -s "$launcher" "$out/bin/kandev-desktop"
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    app="$out/Applications/Kandev.app"
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      "$app/Contents/Resources/kandev/bin/agentctl-darwin-arm64"
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      "$app/Contents/Resources/kandev/bin/agentctl-darwin-amd64"
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      "$app/Contents/MacOS/kandev-desktop-unwrapped"
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      "$app/Contents/MacOS/kandev-desktop"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    test -x "$out/bin/kandev-desktop"
+    grep -aF '${nodejs_24}/bin' "$out/bin/kandev-desktop" >/dev/null
+    runtime=$out/${
+      if stdenv.hostPlatform.isDarwin then "Applications/Kandev.app/Contents/Resources" else "lib/Kandev"
+    }/kandev
+    test -x "$runtime/bin/kandev"
+    test -x "$runtime/bin/agentctl"
+    for helper in \
+      agentctl-linux-amd64 \
+      agentctl-linux-arm64 \
+      agentctl-darwin-arm64 \
+      agentctl-darwin-amd64
+    do
+      test -x "$runtime/bin/$helper"
+    done
+
+    runHook postInstallCheck
+  '';
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = {
+    description = "Native desktop application for the Kandev agentic development platform";
+    homepage = "https://github.com/kdlbs/kandev";
+    changelog = "https://github.com/kdlbs/kandev/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mulatta ];
+    mainProgram = "kandev-desktop";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/packages/kandev/nix-update-args
+++ b/packages/kandev/nix-update-args
@@ -1,0 +1,2 @@
+--subpackage
+frontend

--- a/packages/kandev/package.nix
+++ b/packages/kandev/package.nix
@@ -1,0 +1,227 @@
+{
+  lib,
+  flake,
+  stdenv,
+  stdenvNoCC,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  fetchurl,
+  nodejs_24,
+  codex,
+  codex-acp,
+  gemini-cli,
+  makeWrapper,
+  rcodesign,
+  git,
+  bash,
+  openssh,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  pname = "kandev";
+  version = "0.87.1";
+
+  src = fetchFromGitHub {
+    owner = "kdlbs";
+    repo = "kandev";
+    tag = "v${version}";
+    hash = "sha256-StFmh8pa9X7dllbpxbVFYraucsvrTJNtwQBNWElgCiU=";
+  };
+
+  pnpm = pnpm_10.overrideAttrs (_: {
+    version = "9.15.9";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz";
+      hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";
+    };
+  });
+
+  frontend = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "kandev-web";
+    inherit version src;
+
+    sourceRoot = "${src.name}/apps";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      inherit pnpm;
+      fetcherVersion = 4;
+      hash = "sha256-EQ07LBl6WIoeHZwbo6HaZC+ZHullTJO2aCh20/5WDQ0=";
+    };
+
+    nativeBuildInputs = [
+      nodejs_24
+      pnpm
+      pnpmConfigHook
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      KANDEV_VERSION=${version} VITE_KANDEV_API_PORT= VITE_KANDEV_DEBUG= \
+        pnpm --filter @kandev/web build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r web/dist $out
+      runHook postInstall
+    '';
+  });
+in
+buildGoModule (_finalAttrs: {
+  inherit pname version src;
+
+  modRoot = "apps/backend";
+  vendorHash = "sha256-68fOqzojvBNAFL6MDw7G8NpLf1PBgAjwJipQcWdple8=";
+
+  subPackages = [
+    "cmd/kandev"
+    "cmd/agentctl"
+  ];
+
+  tags = [ "fts5" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=v${version}"
+  ];
+
+  postPatch = ''
+    substituteInPlace apps/backend/internal/agent/agents/codex_acp.go \
+      --replace-fail 'a.ManagedNPMRuntime().CachedACPCommand()' 'NewCommand("codex-acp")' \
+      --replace-fail 'NewCommand("npx", "-y", "@openai/codex")' 'NewCommand("codex")'
+    substituteInPlace apps/backend/internal/agent/agents/gemini.go \
+      --replace-fail 'a.ManagedNPMRuntime().CachedACPCommand()' 'NewCommand("gemini", "--acp")' \
+      --replace-fail 'NewCommand("npx", "--yes", "--prefer-offline", geminiPackage)' 'NewCommand("gemini")'
+    old_probe_command='"npx":           "npx",'
+    new_probe_commands=$'"codex-acp":     "codex-acp",\n\t"gemini":        "gemini",\n\t"npx":           "npx",'
+    substituteInPlace apps/backend/internal/agentctl/server/utility/acp_executor.go \
+      --replace-fail "$old_probe_command" "$new_probe_commands"
+  '';
+
+  preBuild = ''
+    generated=internal/webapp/embedded/generated
+    find "$generated" -mindepth 1 ! -name .gitignore ! -name keep.txt -exec rm -rf {} +
+    cp -r ${frontend}/. "$generated/"
+  '';
+
+  postBuild = ''
+    helper_ldflags="-s -w"
+    env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+      go build -ldflags "$helper_ldflags" -o agentctl-linux-amd64 ./cmd/agentctl
+    env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+      go build -ldflags "$helper_ldflags" -o agentctl-linux-arm64 ./cmd/agentctl
+    env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 \
+      go build -ldflags "$helper_ldflags" -o agentctl-darwin-arm64 ./cmd/agentctl
+    env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
+      go build -ldflags "$helper_ldflags" -o agentctl-darwin-amd64 ./cmd/agentctl
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    rcodesign
+  ];
+
+  postInstall = ''
+    mkdir -p $out/libexec/kandev/bin
+    mv $out/bin/kandev $out/bin/agentctl $out/libexec/kandev/bin/
+    install -Dm755 agentctl-linux-amd64 $out/libexec/kandev/bin/agentctl-linux-amd64
+    install -Dm755 agentctl-linux-arm64 $out/libexec/kandev/bin/agentctl-linux-arm64
+    install -Dm755 agentctl-darwin-arm64 $out/libexec/kandev/bin/agentctl-darwin-arm64
+    install -Dm755 agentctl-darwin-amd64 $out/libexec/kandev/bin/agentctl-darwin-amd64
+
+    makeWrapper $out/libexec/kandev/bin/kandev $out/bin/kandev \
+      --set KANDEV_BUNDLE_DIR $out/libexec/kandev \
+      --set KANDEV_VERSION ${version} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nodejs_24
+          codex
+          codex-acp
+          gemini-cli
+          git
+          bash
+          openssh
+        ]
+      }
+  '';
+
+  # Do not let fixup mutate the cross-platform helpers. Re-sign every Darwin
+  # binary after fixup because Mach-O mutations invalidate ad-hoc signatures.
+  dontStrip = true;
+
+  postFixup = ''
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      $out/libexec/kandev/bin/agentctl-darwin-arm64
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      $out/libexec/kandev/bin/agentctl-darwin-amd64
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      $out/libexec/kandev/bin/kandev
+    ${lib.getExe rcodesign} sign --code-signature-flags linker-signed \
+      $out/libexec/kandev/bin/agentctl
+  '';
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+    nodejs_24
+  ];
+  versionCheckProgramArg = "--version";
+
+  postInstallCheck = ''
+    $out/bin/kandev --help >/dev/null
+    grep -aF '${nodejs_24}/bin' $out/bin/kandev >/dev/null
+
+    set +e
+    output="$($out/libexec/kandev/bin/agentctl kandev 2>&1)"
+    status=$?
+    set -e
+    test "$status" -eq 1
+    grep -F "Usage: agentctl kandev" <<<"$output"
+
+    helpers="agentctl-linux-amd64 agentctl-linux-arm64 agentctl-darwin-arm64 agentctl-darwin-amd64"
+    for helper in $helpers; do
+      test -x "$out/libexec/kandev/bin/$helper"
+    done
+
+    node ${src}/scripts/release/validate-darwin-arm64-helper.mjs \
+      $out/libexec/kandev/bin/agentctl-darwin-arm64
+  '';
+
+  passthru = {
+    category = "Workflow & Project Management";
+    inherit frontend;
+  };
+
+  meta = {
+    description = "Manage tasks, orchestrate agents, review changes, and ship value";
+    homepage = "https://github.com/kdlbs/kandev";
+    changelog = "https://github.com/kdlbs/kandev/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mulatta ];
+    mainProgram = "kandev";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
## Summary

Makes Kandev's agent orchestration workflow available through Nix by packaging both the CLI and native desktop application at 0.87.1. The packages build the web frontend and backend from source, bundle matching cross-platform helpers and runtime dependencies, disable desktop self-installation in favor of Nix-managed upgrades, and include updater configuration and generated documentation.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
