### PR TITLE
dsh: fix runtime crash & clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 <details>
 <summary><strong>dsh</strong> - Open-source agent harness developed by DeepSeek AI</summary>
 
-- **Source**: bytecode
+- **Source**: source
 - **License**: MIT
 - **Homepage**: https://github.com/deepseek-ai/deepseek-harness
 - **Usage**: `nix run github:numtide/llm-agents.nix#dsh -- --help`

--- a/packages/dsh/package.nix
+++ b/packages/dsh/package.nix
@@ -3,18 +3,17 @@
   buildNpmPackage,
   fetchurl,
   flake,
-  nodejs_22,
-  runCommand,
   makeWrapper,
+  nodejs,
+  runCommand,
   versionCheckHook,
   versionCheckHomeHook,
 }:
 
 let
   versionData = lib.importJSON ./hashes.json;
-  version = versionData.version;
+  inherit (versionData) version;
 
-  # The npm tarball ships no lockfile. Vendor one, kept in sync by update.py.
   srcWithLock = runCommand "dsh-source" { } ''
     mkdir -p $out
     tar -xzf ${
@@ -31,27 +30,19 @@ buildNpmPackage {
   inherit version;
   src = srcWithLock;
 
-  nodejs = nodejs_22;
   npmDepsFetcherVersion = 2;
   npmDepsHash = versionData.npmDepsHash;
 
-  # The npm package already contains the compiled CLI files.
   dontNpmBuild = true;
 
   nativeBuildInputs = [ makeWrapper ];
 
-  installPhase = ''
-    runHook preInstall
-
-    npm prune --omit=dev
-
-    mkdir -p $out/lib/dsh $out/bin
-    cp -r lib config package.json README* node_modules $out/lib/dsh/
-
-    makeWrapper ${lib.getExe nodejs_22} $out/bin/dsh \
-      --add-flags "$out/lib/dsh/lib/bin.js"
-
-    runHook postInstall
+  postInstall = ''
+    rm $out/bin/dsh
+    makeWrapper ${lib.getExe nodejs} $out/bin/dsh \
+      --argv0 dsh \
+      --add-flags "--expose-internals" \
+      --add-flags "$out/lib/node_modules/@deepseek-ai/dsh/lib/bin.js"
   '';
 
   doInstallCheck = true;
@@ -59,7 +50,7 @@ buildNpmPackage {
     versionCheckHook
     versionCheckHomeHook
   ];
-  versionCheckProgramArg = [ "--version" ];
+  versionCheckProgramArg = "--version";
 
   passthru.category = "AI Coding Agents";
 
@@ -67,10 +58,14 @@ buildNpmPackage {
     description = "Open-source agent harness developed by DeepSeek AI";
     homepage = "https://github.com/deepseek-ai/deepseek-harness";
     changelog = "https://github.com/deepseek-ai/deepseek-harness/releases";
+    downloadPage = "https://www.npmjs.com/package/@deepseek-ai/dsh";
     license = lib.licenses.mit;
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      fromSource
+    ];
     maintainers = with flake.lib.maintainers; [ JachinShen ];
     mainProgram = "dsh";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
## Summary

fix runtime crash

```
dsh web: http://127.0.0.1:3080
file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:299
	return new Error(`failed to ${stage} loader entry ${options.id} (${options.name}): ${detail}`, { cause });
	       ^

Error: failed to apply loader entry 9306504b (@deepseek-ai/cordis-plugin-hmr): --expose-internals is required for HMR service
    at updateError (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:299:9)
    at Entry._init (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:519:10)
    at async Entry.init (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:495:4)
    at async Entry.update (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:416:37)
    at async EntryGroup.create (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:55:4)
    at async Proxy.create (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:217:14)
    at async runProfile (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/lib/profile-boot-DG5t9aNs.js:259:4)
    at async file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/lib/bin.js:133:3 {
  [cause]: Error: --expose-internals is required for HMR service
      at new Hmr (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis-plugin-hmr/lib/index.js:107:40)
      at Fiber.execute (file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis/lib/index.js:1067:24)
      at file:///nix/store/2d0fsa03bmws32346109nfwv4gswkw1c-dsh-0.1.0-rc.6/lib/dsh/node_modules/@deepseek-ai/cordis/lib/index.js:1141:34
      at file:///home/ib/.dsh/profiles/web/#9306504b
}

Node.js v22.23.2
```