### PR TITLE
flake: apply bun2nix overlay directly instead of pkgs.extend (~2.4s eval)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,8 +108,10 @@
               # every store path in the set.
               bun = pkgsFor.${system}.bun or pkgs.bun;
               # bun2nix builder set (hook, fetchBunDeps, ...); the `bun2nix`
-              # scope attribute is the CLI package.
-              bun2nixLib = (pkgs.extend inputs."bun2nix".overlays.default).bun2nix;
+              # scope attribute is the CLI package. Apply the overlay directly
+              # (final=prev=pkgs) instead of pkgs.extend, which would re-run the
+              # whole nixpkgs fixpoint just to add this one leaf (~5s of eval).
+              bun2nixLib = (inputs."bun2nix".overlays.default pkgs pkgs).bun2nix;
               # makeScope reserves `packages`, so expose the package set as allPackages.
               allPackages = packages;
             }


### PR DESCRIPTION
## What

`bun2nixLib` was computed as `(pkgs.extend inputs.bun2nix.overlays.default).bun2nix`. `pkgs.extend` re-runs the **entire nixpkgs fixpoint** just to add the single `bun2nix` leaf attribute — and that cost is paid whenever any bun2nix package is evaluated.

Applying the overlay function directly (`inputs.bun2nix.overlays.default pkgs pkgs`) computes only the `bun2nix` leaf against the existing `pkgs`, with no re-fixpoint.

## Impact

Full package-set eval (force all `drvPath`s, warm): **24.5s → 22.1s** (~2.4s / 10%).

**Verified functionally identical:** `gno`, `ax`, `qmd`, `backlog-md` drvPaths are byte-for-byte unchanged (the overlay is a leaf addition, so `final = prev = pkgs` yields the same `bun2nix`).

## Profiling context (for the record)

- Forcing every package's `meta` (the `filterAttrs` predicate) is only ~0.4s; the eval time is forcing the 160 derivations.
- The **12 bun2nix packages account for ~7.9s (36%)** of eval from 7.5% of packages — each `bun.nix` forces thousands of per-dependency `fetchurl` derivations (`fetch-bun-deps.nix` shows up as exactly 12 calls in the trace). That's inherent to bun2nix's vendoring format; collapsing it would need a single-FOD mode upstream, not a flake change.
- The rest is inherent nixpkgs derivation machinery (`make-derivation`, `customisation`, ~487 python-package derivations). No other redundant flake wiring found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)