### PR TITLE
flake: route bun2nix fetches through naked builtin:fetchurl (eval-perf, draft)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,13 @@
             inherit interpolate;
           };
 
+          # Route bun2nix's per-dep fetches through naked-fetchurl: ~3.4s (~15%)
+          # off eval, all in the bun packages. Output paths unchanged (FODs),
+          # only bun-cache .drv inputs differ, so it is a one-time cache rebuild.
+          pkgsBun = pkgs // {
+            fetchurl = import ./lib/naked-fetchurl.nix;
+          };
+
           scope = lib.makeScope pkgs.newScope (
             self:
             {
@@ -111,7 +118,7 @@
               # scope attribute is the CLI package. Apply the overlay directly
               # (final=prev=pkgs) instead of pkgs.extend, which would re-run the
               # whole nixpkgs fixpoint just to add this one leaf (~5s of eval).
-              bun2nixLib = (inputs."bun2nix".overlays.default pkgs pkgs).bun2nix;
+              bun2nixLib = (inputs."bun2nix".overlays.default pkgsBun pkgsBun).bun2nix;
               # makeScope reserves `packages`, so expose the package set as allPackages.
               allPackages = packages;
             }

--- a/lib/naked-fetchurl.nix
+++ b/lib/naked-fetchurl.nix
@@ -1,0 +1,24 @@
+# fetchurl on the builtin:fetchurl builder: a lone leaf derivation, no nixpkgs
+# fetchurl wrapper or stdenv thunk graph. Same output path as pkgs.fetchurl
+# for a given url + hash.
+#
+# Args are closed on purpose. bun2nix passes only { url, hash }, and the
+# builtin serves nothing else (no unpack, auth, or curl opts), so anything
+# extra fails loudly instead of being silently dropped.
+{
+  url,
+  hash,
+}:
+derivation {
+  inherit url;
+  name = baseNameOf url;
+  builder = "builtin:fetchurl";
+  system = "builtin";
+  urls = [ url ];
+  outputHash = hash;
+  outputHashMode = "flat";
+  outputHashAlgo = null;
+  preferLocalBuild = true;
+  unpack = false;
+  executable = false;
+}


### PR DESCRIPTION
Swap the `fetchurl` bun2nix's overlay uses for a naked `builtin:fetchurl`. bun2nix fetches one dep per npm package; nixpkgs' `fetchurl` drags the stdenv thunk graph into each, the builtin is a lone leaf derivation.

## Measurements

`nix eval .#packages.x86_64-linux --apply <force drvPaths>`, warm cache, x86_64-linux, on top of #7992:

| Eval target | `pkgs.fetchurl` | `builtin:fetchurl` | Δ |
|---|---|---|---|
| Bun tier (12 pkgs) | 15.7s | 12.4s | −3.4s (~22%) |
| Full set (~160 pkgs) | 22.9s | 19.0s | −3.5s (~15%) |

The full-set win *is* the bun tier (−3.5s ≈ −3.4s) — nothing else is touched. ~0.28s/package, lower than the isolated prototype's ~1.1s because a full eval already pays most of `pkgs.fetchurl`'s cost via the non-bun packages.

## Correctness

Output paths are unchanged (content-addressed FODs). Only the bun-cache `.drv` inputs differ, so this is a one-time rebuild of those 12 caches, no functional change.

## Why draft

Modest and eval-only. The cleaner home is an upstream `builtin:fetchurl` option in bun2nix, not an in-repo override. Filed to capture the numbers and decide: land it, or push it upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)