### PR TITLE
ci/update: bump companion packages in the same PR

### DIFF
--- a/.github/ci/discovery.py
+++ b/.github/ci/discovery.py
@@ -56,6 +56,22 @@ class MatrixItem:
         }
 
 
+def companion_packages() -> set[str]:
+    """Return packages listed in any update-companions file.
+
+    Companions are updated together with their primary package, so they
+    get no matrix entry of their own.
+    """
+    companions: set[str] = set()
+    for companions_file in Path("packages").glob("*/update-companions"):
+        companions.update(
+            stripped
+            for line in companions_file.read_text().splitlines()
+            if (stripped := line.strip()) and not stripped.startswith("#")
+        )
+    return companions
+
+
 def discover_packages(
     packages_filter: list[str] | None, system: str
 ) -> list[MatrixItem]:
@@ -75,16 +91,20 @@ def discover_packages(
         return []
 
     versions: dict[str, str | None] = json.loads(result.stdout)
+    # An explicit filter overrides companion handling.
+    companions = companion_packages() if packages_filter is None else set()
     items = [
         MatrixItem(type="package", name=name, current_version=version)
         for name, version in sorted(versions.items())
-        if version is not None
+        if version is not None and name not in companions
     ]
 
     if packages_filter is None:
         for name, version in sorted(versions.items()):
             if version is None:
                 log.info("Skipping %s (no version attribute)", name)
+            elif name in companions:
+                log.info("Skipping %s (updated as a companion package)", name)
     else:
         found = set(versions.keys())
         for pkg in packages_filter:

--- a/.github/ci/update.py
+++ b/.github/ci/update.py
@@ -102,6 +102,22 @@ def run_update_command(cmd: list[str], error_label: str) -> None:
         sys.exit(1)
 
 
+def load_companions(name: str) -> list[str]:
+    """Load companion package names from packages/<name>/update-companions.
+
+    Companions must be bumped in the same commit as the primary package,
+    e.g. because they assert matching versions at build time.
+    """
+    companions_file = Path(f"packages/{name}/update-companions")
+    if not companions_file.exists():
+        return []
+    return [
+        stripped
+        for line in companions_file.read_text().splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    ]
+
+
 def has_declarative_updater(name: str) -> bool:
     """Whether the package carries a declarative passthru.updater config.
 
@@ -135,8 +151,8 @@ def load_nix_update_args(name: str) -> list[str]:
     ]
 
 
-def update_package(name: str) -> None:
-    """Update a single package using its update script or nix-update."""
+def run_package_updater(name: str) -> None:
+    """Run one package's updater: update script, updateScript, or nix-update."""
     log.info("Updating package %s...", name)
 
     update_script = Path(f"packages/{name}/update.py")
@@ -160,6 +176,13 @@ def update_package(name: str) -> None:
             ),
             f"nix-update failed for package {name}",
         )
+
+
+def update_package(name: str) -> None:
+    """Update a package and its companions."""
+    run_package_updater(name)
+    for companion in load_companions(name):
+        run_package_updater(companion)
 
     if not git_has_changes():
         log.info("No changes detected")

--- a/packages/kandev/update-companions
+++ b/packages/kandev/update-companions
@@ -1,0 +1,2 @@
+# kandev-desktop asserts at build time that its version matches kandev.
+kandev-desktop


### PR DESCRIPTION
kandev-desktop asserts at build time that its version matches the kandev runtime, but the updater bumps each package in a separate PR, so both PRs always fail CI (#8020/#8011).

Packages listed in `packages/<name>/update-companions` are now dropped from the discovery matrix and updated in the same job as their primary package. An explicit package filter still updates a companion alone.

Declares kandev-desktop as a companion of kandev.