### PR TITLE
kandev: add opt-in packaged agent runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Homepage**: https://github.com/kdlbs/kandev
 - **Usage**: `nix run github:numtide/llm-agents.nix#kandev -- --help`
 - **Nix**: [packages/kandev/package.nix](packages/kandev/package.nix)
+- **Documentation**: See [packages/kandev/README.md](packages/kandev/README.md) for detailed usage
 
 </details>
 <details>

--- a/packages/grok/package.nix
+++ b/packages/grok/package.nix
@@ -44,13 +44,15 @@ stdenv.mkDerivation {
 
     install -Dm755 $src $out/libexec/grok/grok
 
+    # Disable self-updates without injecting --no-auto-update into argv. Callers
+    # such as Kandev already pass that documented flag themselves.
     makeWrapper $out/libexec/grok/grok $out/libexec/grok/grok-launcher \
       --argv0 grok \
-      --add-flags --no-auto-update
+      --set GROK_DISABLE_AUTOUPDATER 1
 
     makeWrapper $out/libexec/grok/grok $out/libexec/grok/agent-launcher \
       --argv0 agent \
-      --add-flags --no-auto-update
+      --set GROK_DISABLE_AUTOUPDATER 1
 
     # bin → launcher on all platforms. A former Linux-only bubblewrap shim
     # faked /bin/{bash,zsh} for older Grok builds that hardcoded those paths
@@ -70,6 +72,12 @@ stdenv.mkDerivation {
     versionCheckHook
     versionCheckHomeHook
   ];
+  postInstallCheck = ''
+    grep -q GROK_DISABLE_AUTOUPDATER $out/libexec/grok/grok-launcher
+    grep -q GROK_DISABLE_AUTOUPDATER $out/libexec/grok/agent-launcher
+    $out/bin/grok --no-auto-update --version
+    $out/bin/agent --no-auto-update --version
+  '';
 
   passthru.category = "AI Coding Agents";
   passthru.updater = mkUpdater (

--- a/packages/kandev-desktop/package.nix
+++ b/packages/kandev-desktop/package.nix
@@ -9,9 +9,6 @@
   pnpm_10,
   fetchurl,
   nodejs_24,
-  codex,
-  codex-acp,
-  gemini-cli,
   cargo-tauri,
   pkg-config,
   wrapGAppsHook3,
@@ -21,9 +18,7 @@
   openssl,
   webkitgtk_4_1,
   kandev,
-  git,
-  bash,
-  openssh,
+  kandevRuntime ? kandev,
 }:
 
 let
@@ -98,15 +93,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   preBuild = ''
-    if [[ ${kandev.version} != ${finalAttrs.version} ]]; then
-      echo "Kandev Desktop ${finalAttrs.version} requires the matching Kandev runtime; got ${kandev.version}." >&2
+    if [[ ${kandevRuntime.version} != ${finalAttrs.version} ]]; then
+      echo "Kandev Desktop ${finalAttrs.version} requires the matching Kandev runtime; got ${kandevRuntime.version}." >&2
       exit 1
     fi
 
     runtime=apps/desktop/src-tauri/resources/kandev
     rm -rf "$runtime"
     mkdir -p "$runtime/bin"
-    cp -L ${kandev}/libexec/kandev/bin/* "$runtime/bin/"
+    cp -L ${kandevRuntime}/libexec/kandev/bin/* "$runtime/bin/"
     chmod +x "$runtime/bin/"*
   '';
 
@@ -115,17 +110,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     gappsWrapperArgs+=(
-      --prefix PATH : ${
-        lib.makeBinPath [
-          nodejs_24
-          codex
-          codex-acp
-          gemini-cli
-          git
-          bash
-          openssh
-        ]
-      }
+      ${lib.escapeShellArgs kandevRuntime.agentRuntimeWrapperArgs}
+      --prefix PATH : ${kandevRuntime.agentPath}
     )
   '';
 
@@ -136,17 +122,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     makeBinaryWrapper \
       "$launcher-unwrapped" \
       "$launcher" \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          nodejs_24
-          codex
-          codex-acp
-          gemini-cli
-          git
-          bash
-          openssh
-        ]
-      }
+      ${lib.escapeShellArgs kandevRuntime.agentRuntimeWrapperArgs} \
+      --prefix PATH : ${kandevRuntime.agentPath}
     mkdir -p "$out/bin"
     ln -s "$launcher" "$out/bin/kandev-desktop"
   '';
@@ -168,7 +145,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     runHook preInstallCheck
 
     test -x "$out/bin/kandev-desktop"
-    grep -aF '${nodejs_24}/bin' "$out/bin/kandev-desktop" >/dev/null
+    ${lib.concatMapStringsSep "\n" (
+      package: ''grep -aF '${lib.getBin package}/bin' "$out/bin/kandev-desktop" >/dev/null''
+    ) kandevRuntime.agentRuntimePackages}
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: value: ''
+        grep -aF '${name}' "$out/bin/kandev-desktop" >/dev/null
+        grep -aF '${value}' "$out/bin/kandev-desktop" >/dev/null
+      '') kandevRuntime.agentRuntimeEnvironment
+    )}
     runtime=$out/${
       if stdenv.hostPlatform.isDarwin then "Applications/Kandev.app/Contents/Resources" else "lib/Kandev"
     }/kandev
@@ -186,7 +171,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.category = "Workflow & Project Management";
+  passthru = {
+    category = "Workflow & Project Management";
+    inherit kandevRuntime;
+  };
 
   meta = {
     description = "Native desktop application for the Kandev agentic development platform";

--- a/packages/kandev/README.md
+++ b/packages/kandev/README.md
@@ -37,6 +37,10 @@ agents use it as their ACP runtime. Claude support also points
 `claude-agent-acp` at the Nix-packaged executable instead of its incompatible
 bundled binary on NixOS.
 
+Pi chat and inference retain Kandev's upstream `npx pi-acp` path. This package's
+passthrough patch launches the local `pi` CLI, so enable `piSupport` or otherwise
+provide `pi` on `PATH` before selecting Pi passthrough.
+
 ## Custom TUI agents and tools
 
 `extraPackages` adds arbitrary executables to the same runtime `PATH`:

--- a/packages/kandev/README.md
+++ b/packages/kandev/README.md
@@ -66,3 +66,21 @@ command, static `{{model}}` substitution, and optional MCP strategy.
 
 These packages affect Local and Worktree execution on the Kandev host. Docker
 images and SSH hosts need their own executable and credential provisioning.
+
+## Desktop runtime
+
+Build one runtime and pass it to Kandev Desktop so its embedded backend and
+Finder-launched application use identical packages and environment:
+
+```nix
+let
+  kandevRuntime = pkgs.kandev.override {
+    claudeSupport = true;
+    ompSupport = true;
+    extraPackages = [ pkgs.gh ];
+  };
+in
+pkgs.kandev-desktop.override {
+  inherit kandevRuntime;
+}
+```

--- a/packages/kandev/README.md
+++ b/packages/kandev/README.md
@@ -38,8 +38,9 @@ OpenCode, Copilot, Gemini, Droid, Kilocode, and Qwen prefer the packaged CLI for
 host ACP probes, inference, command previews, and task launches. Claude, Codex,
 Pi, and Amp retain their separate ACP adapters. Other CLIs serve their built-in
 profile's discovery, login, passthrough, or native runtime behavior. Claude
-support also points `claude-agent-acp` at the Nix-packaged executable instead of
-its incompatible bundled binary on NixOS.
+and Codex support also point their adapters (`claude-agent-acp` via
+`CLAUDE_CODE_EXECUTABLE`, `codex-acp` via `CODEX_PATH`) at the Nix-packaged
+executables instead of their incompatible bundled binaries on NixOS.
 
 Pi chat and inference retain Kandev's upstream `npx pi-acp` path. This package's
 passthrough patch launches the local `pi` CLI, so enable `piSupport` or otherwise

--- a/packages/kandev/README.md
+++ b/packages/kandev/README.md
@@ -1,8 +1,10 @@
 # Kandev
 
 Kandev manages its built-in agent runtimes according to each upstream
-integration. Managed npm profiles keep using Kandev's `npx` execution paths;
-native ACP profiles run their packaged CLI directly.
+integration. On Local and Worktree executors, direct ACP CLIs prefer an
+executable already on `PATH`; managed `npx` commands remain the fallback and
+the container runtime default. Separate ACP adapter profiles keep using their
+adapter rather than substituting the underlying CLI.
 
 ## Local runtime packages
 
@@ -31,11 +33,13 @@ kandev.override {
 ```
 
 The flags control executable availability, not Kandev's agent registry or the
-profile selected for a task. Their exact role follows the built-in integration:
-managed npm agents use the CLI for discovery, login, or passthrough while native
-agents use it as their ACP runtime. Claude support also points
-`claude-agent-acp` at the Nix-packaged executable instead of its incompatible
-bundled binary on NixOS.
+profile selected for a task. Their exact role follows the built-in integration.
+OpenCode, Copilot, Gemini, Droid, Kilocode, and Qwen prefer the packaged CLI for
+host ACP probes, inference, command previews, and task launches. Claude, Codex,
+Pi, and Amp retain their separate ACP adapters. Other CLIs serve their built-in
+profile's discovery, login, passthrough, or native runtime behavior. Claude
+support also points `claude-agent-acp` at the Nix-packaged executable instead of
+its incompatible bundled binary on NixOS.
 
 Pi chat and inference retain Kandev's upstream `npx pi-acp` path. This package's
 passthrough patch launches the local `pi` CLI, so enable `piSupport` or otherwise

--- a/packages/kandev/README.md
+++ b/packages/kandev/README.md
@@ -1,0 +1,60 @@
+# Kandev
+
+Kandev manages its built-in agent runtimes according to each upstream
+integration. Managed npm profiles keep using Kandev's `npx` execution paths;
+native ACP profiles run their packaged CLI directly.
+
+## Local runtime packages
+
+Agent support flags add known CLIs to the local runtime `PATH`. They are opt-in
+so the default package remains independent of every provider:
+
+```nix
+kandev.override {
+  claudeSupport = true;
+  codexSupport = true;
+  geminiSupport = true;
+  piSupport = true;
+  ompSupport = true;
+  opencodeSupport = true;
+  copilotSupport = true;
+  hermesSupport = true;
+  ampSupport = true;
+  cursorSupport = true;
+  droidSupport = true;
+  grokSupport = true;
+  kilocodeSupport = true;
+  kimiSupport = true;
+  qoderSupport = true;
+  qwenSupport = true;
+}
+```
+
+The flags control executable availability, not Kandev's agent registry or the
+profile selected for a task. Their exact role follows the built-in integration:
+managed npm agents use the CLI for discovery, login, or passthrough while native
+agents use it as their ACP runtime. Claude support also points
+`claude-agent-acp` at the Nix-packaged executable instead of its incompatible
+bundled binary on NixOS.
+
+## Custom TUI agents and tools
+
+`extraPackages` adds arbitrary executables to the same runtime `PATH`:
+
+```nix
+kandev.override {
+  extraPackages = [
+    pkgs.gh
+    pkgs.my-custom-agent
+  ];
+}
+```
+
+This supports **Settings > Agents > Add TUI Agent**, where Kandev looks up the
+registered binary name on `PATH`. Register a stable bare command such as
+`my-custom-agent`, not a versioned Nix store path. Adding a package does not
+create or configure an agent; the Kandev UI still owns its display name,
+command, static `{{model}}` substitution, and optional MCP strategy.
+
+These packages affect Local and Worktree execution on the Kandev host. Docker
+images and SSH hosts need their own executable and credential provisioning.

--- a/packages/kandev/package.nix
+++ b/packages/kandev/package.nix
@@ -111,11 +111,15 @@ let
   ++ lib.optional qoderSupport "qodercli"
   ++ lib.optional qwenSupport "qwen";
   agentPath = lib.makeBinPath agentRuntimePackages;
-  # claude-agent-acp ignores PATH and defaults to an npm-bundled native binary
-  # whose FHS interpreter is unavailable on NixOS.
-  agentRuntimeEnvironment = lib.optionalAttrs claudeSupport {
-    CLAUDE_CODE_EXECUTABLE = lib.getExe claude-code;
-  };
+  # The npm ACP adapters bundle native CLI binaries whose FHS interpreters are
+  # unavailable on NixOS. Both adapters honor these overrides and ignore PATH.
+  agentRuntimeEnvironment =
+    lib.optionalAttrs claudeSupport {
+      CLAUDE_CODE_EXECUTABLE = lib.getExe claude-code;
+    }
+    // lib.optionalAttrs codexSupport {
+      CODEX_PATH = lib.getExe codex;
+    };
   agentRuntimeWrapperArgs = lib.concatLists (
     lib.mapAttrsToList (name: value: [
       "--set"
@@ -283,8 +287,7 @@ buildGoModule (_finalAttrs: {
     for command in ${lib.escapeShellArgs agentRuntimeCommands}; do
       PATH=${agentPath} command -v "$command" >/dev/null
     done
-    ${lib.concatStringsSep "
-" (
+    ${lib.concatStringsSep "\n" (
       lib.mapAttrsToList (name: value: ''
         grep -aF '${name}' $out/bin/kandev >/dev/null
         grep -aF '${value}' $out/bin/kandev >/dev/null

--- a/packages/kandev/package.nix
+++ b/packages/kandev/package.nix
@@ -10,9 +10,39 @@
   pnpm_10,
   fetchurl,
   nodejs_24,
+  claude-code,
   codex,
-  codex-acp,
   gemini-cli,
+  pi,
+  omp,
+  opencode,
+  copilot-cli,
+  hermes-agent,
+  amp,
+  cursor-agent,
+  droid,
+  grok,
+  kilocode-cli,
+  kimi-code,
+  qoder-cli,
+  qwen-code,
+  claudeSupport ? false,
+  codexSupport ? false,
+  geminiSupport ? false,
+  piSupport ? false,
+  ompSupport ? false,
+  opencodeSupport ? false,
+  copilotSupport ? false,
+  hermesSupport ? false,
+  ampSupport ? false,
+  cursorSupport ? false,
+  droidSupport ? false,
+  grokSupport ? false,
+  kilocodeSupport ? false,
+  kimiSupport ? false,
+  qoderSupport ? false,
+  qwenSupport ? false,
+  extraPackages ? [ ],
   makeWrapper,
   rcodesign,
   git,
@@ -32,6 +62,67 @@ let
     tag = "v${version}";
     hash = "sha256-YLJ6shH/CCh7I8412Fw6tVuma4bCiBFheH9BDM49T1k=";
   };
+
+  runtimeTools = [
+    nodejs_24
+    git
+    bash
+    openssh
+  ];
+  agentRuntimePackages =
+    runtimeTools
+    ++ lib.optional claudeSupport claude-code
+    ++ lib.optional codexSupport codex
+    ++ lib.optional geminiSupport gemini-cli
+    ++ lib.optional piSupport pi
+    ++ lib.optional ompSupport omp
+    ++ lib.optional opencodeSupport opencode
+    ++ lib.optional copilotSupport copilot-cli
+    ++ lib.optional hermesSupport hermes-agent
+    ++ lib.optional ampSupport amp
+    ++ lib.optional cursorSupport cursor-agent
+    ++ lib.optional droidSupport droid
+    ++ lib.optional grokSupport grok
+    ++ lib.optional kilocodeSupport kilocode-cli
+    ++ lib.optional kimiSupport kimi-code
+    ++ lib.optional qoderSupport qoder-cli
+    ++ lib.optional qwenSupport qwen-code
+    ++ extraPackages;
+  agentRuntimeCommands = [
+    "node"
+    "git"
+    "bash"
+    "ssh"
+  ]
+  ++ lib.optional claudeSupport "claude"
+  ++ lib.optional codexSupport "codex"
+  ++ lib.optional geminiSupport "gemini"
+  ++ lib.optional piSupport "pi"
+  ++ lib.optional ompSupport "omp"
+  ++ lib.optional opencodeSupport "opencode"
+  ++ lib.optional copilotSupport "copilot"
+  ++ lib.optional hermesSupport "hermes"
+  ++ lib.optional ampSupport "amp"
+  ++ lib.optional cursorSupport "cursor-agent"
+  ++ lib.optional droidSupport "droid"
+  ++ lib.optional grokSupport "grok"
+  ++ lib.optional kilocodeSupport "kilocode"
+  ++ lib.optional kimiSupport "kimi"
+  ++ lib.optional qoderSupport "qodercli"
+  ++ lib.optional qwenSupport "qwen";
+  agentPath = lib.makeBinPath agentRuntimePackages;
+  # claude-agent-acp ignores PATH and defaults to an npm-bundled native binary
+  # whose FHS interpreter is unavailable on NixOS.
+  agentRuntimeEnvironment = lib.optionalAttrs claudeSupport {
+    CLAUDE_CODE_EXECUTABLE = lib.getExe claude-code;
+  };
+  agentRuntimeWrapperArgs = lib.concatLists (
+    lib.mapAttrsToList (name: value: [
+      "--set"
+      name
+      value
+    ]) agentRuntimeEnvironment
+  );
 
   pnpm = pnpm_10.overrideAttrs (_: {
     version = "9.15.9";
@@ -99,16 +190,12 @@ buildGoModule (_finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace apps/backend/internal/agent/agents/codex_acp.go \
-      --replace-fail 'a.ManagedNPMRuntime().CachedACPCommand()' 'NewCommand("codex-acp")' \
-      --replace-fail 'NewCommand("npx", "-y", "@openai/codex")' 'NewCommand("codex")'
-    substituteInPlace apps/backend/internal/agent/agents/gemini.go \
-      --replace-fail 'a.ManagedNPMRuntime().CachedACPCommand()' 'NewCommand("gemini", "--acp")' \
-      --replace-fail 'NewCommand("npx", "--yes", "--prefer-offline", geminiPackage)' 'NewCommand("gemini")'
-    old_probe_command='"npx":           "npx",'
-    new_probe_commands=$'"codex-acp":     "codex-acp",\n\t"gemini":        "gemini",\n\t"npx":           "npx",'
-    substituteInPlace apps/backend/internal/agentctl/server/utility/acp_executor.go \
-      --replace-fail "$old_probe_command" "$new_probe_commands"
+    # Nix sandboxes do not populate FHS bin directories. Preserve the fake curl
+    # precedence while letting this upstream test find mktemp and shell tools.
+    old_path='"PATH=" + binDir + ":/usr/bin:/bin",'
+    sandbox_path='"PATH=" + binDir + ":" + os.Getenv("PATH"),'
+    substituteInPlace apps/backend/internal/agent/agents/devin_acp_test.go \
+      --replace-fail "$old_path" "$sandbox_path"
   '';
 
   preBuild = ''
@@ -145,17 +232,8 @@ buildGoModule (_finalAttrs: {
     makeWrapper $out/libexec/kandev/bin/kandev $out/bin/kandev \
       --set KANDEV_BUNDLE_DIR $out/libexec/kandev \
       --set KANDEV_VERSION ${version} \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          nodejs_24
-          codex
-          codex-acp
-          gemini-cli
-          git
-          bash
-          openssh
-        ]
-      }
+      ${lib.escapeShellArgs agentRuntimeWrapperArgs} \
+      --prefix PATH : ${agentPath}
   '';
 
   # Do not let fixup mutate the cross-platform helpers. Re-sign every Darwin
@@ -175,7 +253,12 @@ buildGoModule (_finalAttrs: {
       $out/libexec/kandev/bin/agentctl
   '';
 
-  doCheck = false;
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    go test ./internal/agent/agents ./internal/agentctl/server/utility
+    runHook postCheck
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [
@@ -185,9 +268,23 @@ buildGoModule (_finalAttrs: {
   ];
   versionCheckProgramArg = "--version";
 
-  postInstallCheck = ''
+  installCheckPhase = ''
+    runHook preInstallCheck
+
     $out/bin/kandev --help >/dev/null
-    grep -aF '${nodejs_24}/bin' $out/bin/kandev >/dev/null
+    ${lib.concatMapStringsSep "\n" (
+      package: "grep -aF '${lib.getBin package}/bin' $out/bin/kandev >/dev/null"
+    ) agentRuntimePackages}
+    for command in ${lib.escapeShellArgs agentRuntimeCommands}; do
+      PATH=${agentPath} command -v "$command" >/dev/null
+    done
+    ${lib.concatStringsSep "
+" (
+      lib.mapAttrsToList (name: value: ''
+        grep -aF '${name}' $out/bin/kandev >/dev/null
+        grep -aF '${value}' $out/bin/kandev >/dev/null
+      '') agentRuntimeEnvironment
+    )}
 
     set +e
     output="$($out/libexec/kandev/bin/agentctl kandev 2>&1)"
@@ -203,11 +300,40 @@ buildGoModule (_finalAttrs: {
 
     node ${src}/scripts/release/validate-darwin-arm64-helper.mjs \
       $out/libexec/kandev/bin/agentctl-darwin-arm64
+
+    runHook postInstallCheck
   '';
 
   passthru = {
     category = "Workflow & Project Management";
-    inherit frontend;
+    inherit
+      agentPath
+      agentRuntimePackages
+      agentRuntimeCommands
+      agentRuntimeEnvironment
+      agentRuntimeWrapperArgs
+      frontend
+      ;
+    agentSupport = {
+      inherit
+        claudeSupport
+        codexSupport
+        geminiSupport
+        piSupport
+        ompSupport
+        opencodeSupport
+        copilotSupport
+        hermesSupport
+        ampSupport
+        cursorSupport
+        droidSupport
+        grokSupport
+        kilocodeSupport
+        kimiSupport
+        qoderSupport
+        qwenSupport
+        ;
+    };
   };
 
   meta = {

--- a/packages/kandev/package.nix
+++ b/packages/kandev/package.nix
@@ -189,7 +189,10 @@ buildGoModule (_finalAttrs: {
     "-X main.Version=v${version}"
   ];
 
-  patches = [ ./use-pi-cli-passthrough.patch ];
+  patches = [
+    ./prefer-native-acp-runtimes.patch
+    ./use-pi-cli-passthrough.patch
+  ];
 
   postPatch = ''
     # Nix sandboxes do not populate FHS bin directories. Preserve the fake curl

--- a/packages/kandev/package.nix
+++ b/packages/kandev/package.nix
@@ -189,6 +189,8 @@ buildGoModule (_finalAttrs: {
     "-X main.Version=v${version}"
   ];
 
+  patches = [ ./use-pi-cli-passthrough.patch ];
+
   postPatch = ''
     # Nix sandboxes do not populate FHS bin directories. Preserve the fake curl
     # precedence while letting this upstream test find mktemp and shell tools.

--- a/packages/kandev/prefer-native-acp-runtimes.patch
+++ b/packages/kandev/prefer-native-acp-runtimes.patch
@@ -1,0 +1,507 @@
+diff --git a/apps/backend/internal/agent/agents/copilot_acp.go b/apps/backend/internal/agent/agents/copilot_acp.go
+index cd3c8c76e..0c97d2ee6 100644
+--- a/apps/backend/internal/agent/agents/copilot_acp.go
++++ b/apps/backend/internal/agent/agents/copilot_acp.go
+@@ -21,2 +21,2 @@ const copilotACPPackage = "@github/copilot"
+-// npm package. It remains available for discovery and preflight checks, but
+-// ACP launches always use the exact package pin.
++// npm package. Host and SSH launches prefer it when preflight finds it;
++// container and missing-binary fallbacks keep the managed npm command.
+@@ -93,0 +94,3 @@ func (a *CopilotACP) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd(copilotNativeBinary, "--acp").Build()
++	}
+diff --git a/apps/backend/internal/agent/agents/copilot_acp_test.go b/apps/backend/internal/agent/agents/copilot_acp_test.go
+index 640ab4b85..22224908c 100644
+--- a/apps/backend/internal/agent/agents/copilot_acp_test.go
++++ b/apps/backend/internal/agent/agents/copilot_acp_test.go
+@@ -83,4 +83,3 @@ func TestCopilotACP_UsesManagedPackageOnEveryNPMCommandSurface(t *testing.T) {
+-// TestCopilotACP_BuildCommand_KeepsManagedPackageWhenNativeBinaryIsPresent
+-// prevents a globally installed Copilot binary from bypassing the managed npm
+-// runtime selected for capability discovery and future launches.
+-func TestCopilotACP_BuildCommand_KeepsManagedPackageWhenNativeBinaryIsPresent(t *testing.T) {
++// TestCopilotACP_BuildCommand_UsesNativeBinaryWhenPreferred
++// confirms host preflight can bypass npm while missing-binary fallback stays managed.
++func TestCopilotACP_BuildCommand_UsesNativeBinaryWhenPreferred(t *testing.T) {
+@@ -94 +93 @@ func TestCopilotACP_BuildCommand_KeepsManagedPackageWhenNativeBinaryIsPresent(t
+-	wantNative := []string{"npx", "--yes", "--prefer-offline", "@github/copilot", "--acp"}
++	wantNative := []string{"copilot", "--acp"}
+diff --git a/apps/backend/internal/agent/agents/droid_acp.go b/apps/backend/internal/agent/agents/droid_acp.go
+index 3423d8305..ab99413d7 100644
+--- a/apps/backend/internal/agent/agents/droid_acp.go
++++ b/apps/backend/internal/agent/agents/droid_acp.go
+@@ -21,3 +21,4 @@ var (
+-	_ Agent            = (*DroidACP)(nil)
+-	_ PassthroughAgent = (*DroidACP)(nil)
+-	_ InferenceAgent   = (*DroidACP)(nil)
++	_ Agent             = (*DroidACP)(nil)
++	_ PassthroughAgent  = (*DroidACP)(nil)
++	_ InferenceAgent    = (*DroidACP)(nil)
++	_ NativeBinaryAgent = (*DroidACP)(nil)
+@@ -79,0 +81,2 @@ func (a *DroidACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
++func (a *DroidACP) NativeBinaryName() string { return "droid" }
++
+@@ -80,0 +84,3 @@ func (a *DroidACP) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd("droid", "exec", "--output-format", "acp").Build()
++	}
+diff --git a/apps/backend/internal/agent/agents/gemini.go b/apps/backend/internal/agent/agents/gemini.go
+index 759f569b2..27f60b7a7 100644
+--- a/apps/backend/internal/agent/agents/gemini.go
++++ b/apps/backend/internal/agent/agents/gemini.go
+@@ -24,0 +25 @@ var (
++	_ NativeBinaryAgent      = (*Gemini)(nil)
+@@ -79,0 +81,2 @@ func (a *Gemini) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
++func (a *Gemini) NativeBinaryName() string { return "gemini" }
++
+@@ -80,0 +84,3 @@ func (a *Gemini) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd("gemini", "--acp").Build()
++	}
+diff --git a/apps/backend/internal/agent/agents/kilocode_acp.go b/apps/backend/internal/agent/agents/kilocode_acp.go
+index 8ce9f99bc..20431750a 100644
+--- a/apps/backend/internal/agent/agents/kilocode_acp.go
++++ b/apps/backend/internal/agent/agents/kilocode_acp.go
+@@ -21,3 +21,4 @@ var (
+-	_ Agent            = (*KilocodeACP)(nil)
+-	_ PassthroughAgent = (*KilocodeACP)(nil)
+-	_ InferenceAgent   = (*KilocodeACP)(nil)
++	_ Agent             = (*KilocodeACP)(nil)
++	_ PassthroughAgent  = (*KilocodeACP)(nil)
++	_ InferenceAgent    = (*KilocodeACP)(nil)
++	_ NativeBinaryAgent = (*KilocodeACP)(nil)
+@@ -75,0 +77,2 @@ func (a *KilocodeACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error)
++func (a *KilocodeACP) NativeBinaryName() string { return "kilocode" }
++
+@@ -76,0 +80,3 @@ func (a *KilocodeACP) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd("kilocode", "acp").Build()
++	}
+diff --git a/apps/backend/internal/agent/agents/native_binary_agents_test.go b/apps/backend/internal/agent/agents/native_binary_agents_test.go
+new file mode 100644
+index 000000000..eb1292ca0
+--- /dev/null
++++ b/apps/backend/internal/agent/agents/native_binary_agents_test.go
+@@ -0,0 +1,48 @@
++package agents
++
++import (
++	"slices"
++	"testing"
++)
++
++func TestNPMACPAgentsPreferNativeBinary(t *testing.T) {
++	tests := []struct {
++		name, binary     string
++		agent            Agent
++		native, fallback []string
++	}{
++		{"opencode", "opencode", NewOpenCodeACP(), []string{"opencode", "acp", "--print-logs", "--log-level", "ERROR"}, []string{"npx", "--yes", "--prefer-offline", "opencode-ai", "acp", "--print-logs", "--log-level", "ERROR"}},
++		{"copilot", "copilot", NewCopilotACP(), []string{"copilot", "--acp"}, []string{"npx", "--yes", "--prefer-offline", "@github/copilot", "--acp"}},
++		{"gemini", "gemini", NewGemini(), []string{"gemini", "--acp"}, []string{"npx", "--yes", "--prefer-offline", "@google/gemini-cli", "--acp"}},
++		{"droid", "droid", NewDroidACP(), []string{"droid", "exec", "--output-format", "acp"}, []string{"npx", "-y", "droid", "exec", "--output-format", "acp"}},
++		{"kilocode", "kilocode", NewKilocodeACP(), []string{"kilocode", "acp"}, []string{"npx", "-y", "@kilocode/cli", "acp"}},
++		{"qwen", "qwen", NewQwenACP(), []string{"qwen", "--acp"}, []string{"npx", "-y", "@qwen-code/qwen-code", "--acp"}},
++	}
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			n, ok := tt.agent.(NativeBinaryAgent)
++			if !ok {
++				t.Fatal("missing NativeBinaryAgent")
++			}
++			if got := n.NativeBinaryName(); got != tt.binary {
++				t.Fatalf("binary = %q, want %q", got, tt.binary)
++			}
++			if got := tt.agent.BuildCommand(CommandOptions{PreferNativeBinary: true}).Args(); !slices.Equal(got, tt.native) {
++				t.Fatalf("native = %#v, want %#v", got, tt.native)
++			}
++			if got := tt.agent.BuildCommand(CommandOptions{}).Args(); !slices.Equal(got, tt.fallback) {
++				t.Fatalf("fallback = %#v, want %#v", got, tt.fallback)
++			}
++		})
++	}
++}
++
++func TestManagedNPMACPAgentsKeepExactPinFallback(t *testing.T) {
++	for _, a := range []Agent{NewOpenCodeACP(), NewCopilotACP(), NewGemini()} {
++		want := a.(ManagedNPMRuntimeAgent).ManagedNPMRuntime().ACPCommand("1.2.3").Args()
++		got := a.BuildCommand(CommandOptions{ManagedRuntimeVersion: "1.2.3"}).Args()
++		if !slices.Equal(got, want) {
++			t.Fatalf("%s fallback = %#v, want %#v", a.ID(), got, want)
++		}
++	}
++}
+diff --git a/apps/backend/internal/agent/agents/opencode_acp.go b/apps/backend/internal/agent/agents/opencode_acp.go
+index 1af18bbed..c1f4743dd 100644
+--- a/apps/backend/internal/agent/agents/opencode_acp.go
++++ b/apps/backend/internal/agent/agents/opencode_acp.go
+@@ -25,0 +26 @@ var (
++	_ NativeBinaryAgent      = (*OpenCodeACP)(nil)
+@@ -86,0 +88,2 @@ func (a *OpenCodeACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error)
++func (a *OpenCodeACP) NativeBinaryName() string { return "opencode" }
++
+@@ -87,0 +91,3 @@ func (a *OpenCodeACP) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd("opencode", "acp", "--print-logs", "--log-level", "ERROR").Build()
++	}
+diff --git a/apps/backend/internal/agent/agents/qwen_acp.go b/apps/backend/internal/agent/agents/qwen_acp.go
+index f55aa4728..b98f9adbf 100644
+--- a/apps/backend/internal/agent/agents/qwen_acp.go
++++ b/apps/backend/internal/agent/agents/qwen_acp.go
+@@ -21,3 +21,4 @@ var (
+-	_ Agent            = (*QwenACP)(nil)
+-	_ PassthroughAgent = (*QwenACP)(nil)
+-	_ InferenceAgent   = (*QwenACP)(nil)
++	_ Agent             = (*QwenACP)(nil)
++	_ PassthroughAgent  = (*QwenACP)(nil)
++	_ InferenceAgent    = (*QwenACP)(nil)
++	_ NativeBinaryAgent = (*QwenACP)(nil)
+@@ -75,0 +77,2 @@ func (a *QwenACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
++func (a *QwenACP) NativeBinaryName() string { return "qwen" }
++
+@@ -76,0 +80,3 @@ func (a *QwenACP) BuildCommand(opts CommandOptions) Command {
++	if opts.PreferNativeBinary {
++		return Cmd("qwen", "--acp").Build()
++	}
+diff --git a/apps/backend/internal/agent/hostutility/manager.go b/apps/backend/internal/agent/hostutility/manager.go
+index 4eca56472..239876ce5 100644
+--- a/apps/backend/internal/agent/hostutility/manager.go
++++ b/apps/backend/internal/agent/hostutility/manager.go
+@@ -7,0 +8 @@ import (
++	"os/exec"
+@@ -23,0 +25 @@ import (
++	"github.com/kandev/kandev/internal/agentruntime"
+@@ -708,4 +709,0 @@ func (m *Manager) resolveInferenceCommand(
+-	if !ok || m.managedRuntimeSelections == nil {
+-		return command, nil
+-	}
+-	managed, ok := ag.(agents.ManagedNPMRuntimeAgent)
+@@ -715,4 +713,4 @@ func (m *Manager) resolveInferenceCommand(
+-	spec := managed.ManagedNPMRuntime()
+-	selection, found, err := m.managedRuntimeSelections.Get(ctx, agentType, spec.Package)
+-	if err != nil {
+-		return agents.Command{}, fmt.Errorf("resolve active managed runtime version for %s: %w", agentType, err)
++	preferNative := false
++	if native, ok := ag.(agents.NativeBinaryAgent); ok && native.NativeBinaryName() != "" {
++		_, err := exec.LookPath(native.NativeBinaryName())
++		preferNative = err == nil
+@@ -720,2 +718,5 @@ func (m *Manager) resolveInferenceCommand(
+-	if !found || selection.Package != spec.Package {
+-		return command, nil
++	if preferNative {
++		return ag.BuildCommand(agents.CommandOptions{
++			Runtime:            agentruntime.RuntimeStandalone,
++			PreferNativeBinary: true,
++		}), nil
+@@ -723 +724,18 @@ func (m *Manager) resolveInferenceCommand(
+-	return spec.ACPCommand(selection.Version), nil
++	managedVersion := ""
++	if managed, ok := ag.(agents.ManagedNPMRuntimeAgent); ok && m.managedRuntimeSelections != nil {
++		spec := managed.ManagedNPMRuntime()
++		selection, found, err := m.managedRuntimeSelections.Get(ctx, agentType, spec.Package)
++		if err != nil {
++			return agents.Command{}, fmt.Errorf("resolve active managed runtime version for %s: %w", agentType, err)
++		}
++		if found && selection.Package == spec.Package {
++			managedVersion = selection.Version
++		}
++	}
++	if managedVersion != "" {
++		return ag.BuildCommand(agents.CommandOptions{
++			Runtime:               agentruntime.RuntimeStandalone,
++			ManagedRuntimeVersion: managedVersion,
++		}), nil
++	}
++	return command, nil
+diff --git a/apps/backend/internal/agent/hostutility/native_binary_test.go b/apps/backend/internal/agent/hostutility/native_binary_test.go
+new file mode 100644
+index 000000000..f0f6cd418
+--- /dev/null
++++ b/apps/backend/internal/agent/hostutility/native_binary_test.go
+@@ -0,0 +1,43 @@
++package hostutility
++
++import (
++	"context"
++	"os"
++	"path/filepath"
++	"slices"
++	"testing"
++
++	"github.com/kandev/kandev/internal/agent/agents"
++)
++
++func TestResolveInferenceCommandUsesHostNativeBinary(t *testing.T) {
++	tests := []struct {
++		name, binary string
++		agent        agents.Agent
++		want         []string
++	}{
++		{"opencode", "opencode", agents.NewOpenCodeACP(), []string{"opencode", "acp", "--print-logs", "--log-level", "ERROR"}},
++		{"copilot", "copilot", agents.NewCopilotACP(), []string{"copilot", "--acp"}},
++		{"gemini", "gemini", agents.NewGemini(), []string{"gemini", "--acp"}},
++		{"droid", "droid", agents.NewDroidACP(), []string{"droid", "exec", "--output-format", "acp"}},
++		{"kilocode", "kilocode", agents.NewKilocodeACP(), []string{"kilocode", "acp"}},
++		{"qwen", "qwen", agents.NewQwenACP(), []string{"qwen", "--acp"}},
++	}
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			dir := t.TempDir()
++			path := filepath.Join(dir, tt.binary)
++			if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
++				t.Fatal(err)
++			}
++			t.Setenv("PATH", dir)
++			got, err := (&Manager{}).resolveInferenceCommand(context.Background(), tt.agent.ID(), tt.agent.(agents.InferenceAgent), agents.Command{})
++			if err != nil {
++				t.Fatal(err)
++			}
++			if !slices.Equal(got.Args(), tt.want) {
++				t.Fatalf("command = %#v, want %#v", got.Args(), tt.want)
++			}
++		})
++	}
++}
+diff --git a/apps/backend/internal/agent/registry/provider.go b/apps/backend/internal/agent/registry/provider.go
+index 55cd4e5ae..18c690d0f 100644
+--- a/apps/backend/internal/agent/registry/provider.go
++++ b/apps/backend/internal/agent/registry/provider.go
+@@ -5,0 +6 @@ import (
++	"os/exec"
+@@ -123,3 +124,12 @@ func (r *Registry) resolveProviderCommand(
+-	managedRuntimeVersion, ok := r.resolveManagedProviderVersion(ctx, providerID, ag)
+-	if !ok {
+-		return nil, nil, false
++	preferNative := false
++	if native, ok := ag.(agents.NativeBinaryAgent); ok && native.NativeBinaryName() != "" {
++		_, err := exec.LookPath(native.NativeBinaryName())
++		preferNative = err == nil
++	}
++	managedRuntimeVersion := ""
++	if !preferNative {
++		var resolved bool
++		managedRuntimeVersion, resolved = r.resolveManagedProviderVersion(ctx, providerID, ag)
++		if !resolved {
++			return nil, nil, false
++		}
+@@ -128,0 +139 @@ func (r *Registry) resolveProviderCommand(
++		PreferNativeBinary:    preferNative,
+diff --git a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+index daa28e86b..6cf0a2c3e 100644
+--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
++++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+@@ -342,3 +342,6 @@ func (m *Manager) buildAgentCommandWithContext(
+-	managedRuntimeVersion, err := m.resolveManagedRuntimeVersion(ctx, runtime, agentConfig)
+-	if err != nil {
+-		return agentCommands{}, err
++	managedRuntimeVersion := ""
++	if !preferNative {
++		managedRuntimeVersion, err = m.resolveManagedRuntimeVersion(ctx, runtime, agentConfig)
++		if err != nil {
++			return agentCommands{}, err
++		}
+diff --git a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+index 492de496b..2d328a876 100644
+--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
++++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+@@ -134 +134,9 @@ func TestBuildAgentCommand_ResumeFlag(t *testing.T) {
+-func TestBuildAgentCommand_UsesManagedNPMRuntimes(t *testing.T) {
++func TestBuildAgentCommand_UsesHostRuntimeSelection(t *testing.T) {
++	dir := t.TempDir()
++	for _, binary := range []string{"opencode", "copilot", "gemini", "droid", "kilocode", "qwen"} {
++		if err := os.WriteFile(filepath.Join(dir, binary), []byte("#!/bin/sh\n"), 0o755); err != nil {
++			t.Fatal(err)
++		}
++	}
++	t.Setenv("PATH", dir)
++
+@@ -154 +162 @@ func TestBuildAgentCommand_UsesManagedNPMRuntimes(t *testing.T) {
+-			want:  "npx --yes --prefer-offline opencode-ai acp --print-logs --log-level ERROR",
++			want:  "opencode acp --print-logs --log-level ERROR",
+@@ -159 +167 @@ func TestBuildAgentCommand_UsesManagedNPMRuntimes(t *testing.T) {
+-			want:  "npx --yes --prefer-offline @github/copilot --acp",
++			want:  "copilot --acp",
+@@ -164 +172,16 @@ func TestBuildAgentCommand_UsesManagedNPMRuntimes(t *testing.T) {
+-			want:  "npx --yes --prefer-offline @google/gemini-cli --acp",
++			want:  "gemini --acp",
++		},
++		{
++			name:  "droid",
++			agent: agents.NewDroidACP(),
++			want:  "droid exec --output-format acp",
++		},
++		{
++			name:  "kilocode",
++			agent: agents.NewKilocodeACP(),
++			want:  "kilocode acp",
++		},
++		{
++			name:  "qwen",
++			agent: agents.NewQwenACP(),
++			want:  "qwen --acp",
+diff --git a/apps/backend/internal/agent/runtime/lifecycle/utility.go b/apps/backend/internal/agent/runtime/lifecycle/utility.go
+index ac7fa7184..4c6ac7216 100644
+--- a/apps/backend/internal/agent/runtime/lifecycle/utility.go
++++ b/apps/backend/internal/agent/runtime/lifecycle/utility.go
+@@ -12,0 +13,29 @@ import (
++// resolveExecutionInferenceCommand mirrors task launch selection for session-bound
++// inference: native binaries are host/SSH-only, while npm remains container fallback.
++func (m *Manager) resolveExecutionInferenceCommand(ctx context.Context, ia agents.InferenceAgent, execution *AgentExecution) (agents.Command, error) {
++	cfg := ia.InferenceConfig()
++	ag, ok := ia.(agents.Agent)
++	if !ok {
++		return cfg.Command, nil
++	}
++	_, nativeCapable := ag.(agents.NativeBinaryAgent)
++	_, managed := ag.(agents.ManagedNPMRuntimeAgent)
++	if !nativeCapable && !managed {
++		return cfg.Command, nil
++	}
++	preferNative := m.preferNativeBinary(ag, execution.RuntimeName, execution.MetadataSnapshot())
++	version := ""
++	if !preferNative {
++		var err error
++		version, err = m.resolveManagedRuntimeVersion(ctx, execution.RuntimeName, ag)
++		if err != nil {
++			return agents.Command{}, err
++		}
++	}
++	return ag.BuildCommand(agents.CommandOptions{
++		Runtime:               execution.RuntimeName,
++		PreferNativeBinary:    preferNative,
++		ManagedRuntimeVersion: version,
++	}), nil
++}
++
+@@ -49,0 +79,5 @@ func (m *Manager) ExecuteInferencePrompt(ctx context.Context, sessionID, agentID
++	command, err := m.resolveExecutionInferenceCommand(ctx, ia, execution)
++	if err != nil {
++		return nil, fmt.Errorf("resolve inference command: %w", err)
++	}
++
+@@ -57 +91 @@ func (m *Manager) ExecuteInferencePrompt(ctx context.Context, sessionID, agentID
+-			Command:   cfg.Command.Args(),
++			Command:   command.Args(),
+@@ -128,0 +163,4 @@ func (m *Manager) ExecuteInferenceProfilePrompt(ctx context.Context, sessionID,
++	command, err := m.resolveExecutionInferenceCommand(ctx, ia, execution)
++	if err != nil {
++		return nil, fmt.Errorf("resolve inference command: %w", err)
++	}
+@@ -134 +172 @@ func (m *Manager) ExecuteInferenceProfilePrompt(ctx context.Context, sessionID,
+-			Command: cfg.Command.Args(), ModelFlag: cfg.ModelFlag.Args(), WorkDir: execution.WorkspacePath,
++			Command: command.Args(), ModelFlag: cfg.ModelFlag.Args(), WorkDir: execution.WorkspacePath,
+diff --git a/apps/backend/internal/agent/runtime/lifecycle/utility_test.go b/apps/backend/internal/agent/runtime/lifecycle/utility_test.go
+index 82327cfac..6ae9fce11 100644
+--- a/apps/backend/internal/agent/runtime/lifecycle/utility_test.go
++++ b/apps/backend/internal/agent/runtime/lifecycle/utility_test.go
+@@ -9,0 +10,3 @@ import (
++	"os"
++	"path/filepath"
++	"slices"
+@@ -18,0 +22 @@ import (
++	"github.com/kandev/kandev/internal/agentruntime"
+@@ -455,0 +460,38 @@ func TestManagerListInferenceAgentsOnlyReturnsInstalledOnes(t *testing.T) {
++
++func TestResolveExecutionInferenceCommandSelectsRuntimeCommand(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(filepath.Join(dir, "opencode"), []byte("#!/bin/sh\n"), 0o755); err != nil {
++		t.Fatal(err)
++	}
++	t.Setenv("PATH", dir)
++
++	manager := &Manager{}
++	agent := agents.NewOpenCodeACP()
++	tests := []struct {
++		name    string
++		runtime agentruntime.Runtime
++		want    []string
++	}{
++		{
++			name:    "standalone prefers native",
++			runtime: agentruntime.RuntimeStandalone,
++			want:    []string{"opencode", "acp", "--print-logs", "--log-level", "ERROR"},
++		},
++		{
++			name:    "container retains npm",
++			runtime: agentruntime.RuntimeDocker,
++			want:    []string{"npx", "--yes", "--prefer-offline", "opencode-ai", "acp", "--print-logs", "--log-level", "ERROR"},
++		},
++	}
++	for _, test := range tests {
++		t.Run(test.name, func(t *testing.T) {
++			command, err := manager.resolveExecutionInferenceCommand(t.Context(), agent, &AgentExecution{RuntimeName: test.runtime})
++			if err != nil {
++				t.Fatal(err)
++			}
++			if got := command.Args(); !slices.Equal(got, test.want) {
++				t.Fatalf("command = %#v, want %#v", got, test.want)
++			}
++		})
++	}
++}
+diff --git a/apps/backend/internal/agent/settings/controller/agent_config.go b/apps/backend/internal/agent/settings/controller/agent_config.go
+index 6b7467b77..cffd5323b 100644
+--- a/apps/backend/internal/agent/settings/controller/agent_config.go
++++ b/apps/backend/internal/agent/settings/controller/agent_config.go
+@@ -205,0 +206 @@ func (c *Controller) PreviewAgentCommand(ctx context.Context, agentName string,
++		preferNative := previewPrefersNativeBinary(agentConfig)
+@@ -208 +209 @@ func (c *Controller) PreviewAgentCommand(ctx context.Context, agentName string,
+-		if managed, ok := agentConfig.(agents.ManagedNPMRuntimeAgent); ok {
++		if managed, ok := agentConfig.(agents.ManagedNPMRuntimeAgent); ok && !preferNative {
+@@ -222 +223 @@ func (c *Controller) PreviewAgentCommand(ctx context.Context, agentName string,
+-			PreferNativeBinary:    previewPrefersNativeBinary(agentConfig),
++			PreferNativeBinary:    preferNative,
+diff --git a/apps/backend/internal/agent/settings/controller/controller_test.go b/apps/backend/internal/agent/settings/controller/controller_test.go
+index 5694c0868..8eca7c688 100644
+--- a/apps/backend/internal/agent/settings/controller/controller_test.go
++++ b/apps/backend/internal/agent/settings/controller/controller_test.go
+@@ -661,4 +661,3 @@ func TestDetectAgents_E2EMockPropagatesSupportsMCP(t *testing.T) {
+-// TestController_PreviewAgentCommand_CopilotKeepsManagedPackage verifies that
+-// a globally installed Copilot CLI does not make the command preview bypass
+-// the managed npm runtime.
+-func TestController_PreviewAgentCommand_CopilotKeepsManagedPackage(t *testing.T) {
++// TestController_PreviewAgentCommand_CopilotUsesNativeBinary verifies that
++// command preview mirrors local launches when Copilot is already on PATH.
++func TestController_PreviewAgentCommand_CopilotUsesNativeBinary(t *testing.T) {
+@@ -669 +668 @@ func TestController_PreviewAgentCommand_CopilotKeepsManagedPackage(t *testing.T)
+-	// A copilot binary on PATH must not change the previewed launch command.
++	// A copilot binary on PATH changes local preview to native ACP command.
+@@ -679 +678 @@ func TestController_PreviewAgentCommand_CopilotKeepsManagedPackage(t *testing.T)
+-	want := []string{"npx", "--yes", "--prefer-offline", "@github/copilot", "--acp"}
++	want := []string{"copilot", "--acp"}
+diff --git a/apps/backend/internal/agentctl/server/utility/acp_executor.go b/apps/backend/internal/agentctl/server/utility/acp_executor.go
+index 0bb1d2fa9..605ac50e8 100644
+--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
++++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
+@@ -1168,0 +1169 @@ var allowedProbeCommands = map[string]string{
++	"copilot":       "copilot",
+@@ -1170,0 +1172,2 @@ var allowedProbeCommands = map[string]string{
++	"droid":         "droid",
++	"gemini":        "gemini",
+@@ -1172,0 +1176 @@ var allowedProbeCommands = map[string]string{
++	"kilocode":      "kilocode",
+@@ -1179,0 +1184 @@ var allowedProbeCommands = map[string]string{
++	"qwen":          "qwen",
+diff --git a/apps/backend/internal/agentctl/server/utility/probe_allowlist_test.go b/apps/backend/internal/agentctl/server/utility/probe_allowlist_test.go
+index c6d2ef0ed..ecb5d4995 100644
+--- a/apps/backend/internal/agentctl/server/utility/probe_allowlist_test.go
++++ b/apps/backend/internal/agentctl/server/utility/probe_allowlist_test.go
+@@ -42,0 +43,18 @@ func TestProbeAllowlist_CoversEveryEnabledInferenceAgent(t *testing.T) {
++
++func TestProbeAllowlist_CoversPreferredNativeCommands(t *testing.T) {
++	t.Parallel()
++
++	for _, ag := range []agents.Agent{
++		agents.NewOpenCodeACP(),
++		agents.NewCopilotACP(),
++		agents.NewGemini(),
++		agents.NewDroidACP(),
++		agents.NewKilocodeACP(),
++		agents.NewQwenACP(),
++	} {
++		command := ag.BuildCommand(agents.CommandOptions{PreferNativeBinary: true}).Args()[0]
++		if resolveProbeCommand(command) == "" {
++			t.Errorf("agent %q: preferred native probe binary %q missing from allowedProbeCommands", ag.ID(), command)
++		}
++	}
++}

--- a/packages/kandev/use-pi-cli-passthrough.patch
+++ b/packages/kandev/use-pi-cli-passthrough.patch
@@ -1,0 +1,14 @@
+diff --git a/apps/backend/internal/agent/agents/new_acp_agents_test.go b/apps/backend/internal/agent/agents/new_acp_agents_test.go
+index 15af7f5..b382df7 100644
+--- a/apps/backend/internal/agent/agents/new_acp_agents_test.go
++++ b/apps/backend/internal/agent/agents/new_acp_agents_test.go
+@@ -82 +82 @@ var newACPAgentSpecs = []struct {
+-		passthroughArgv:    []string{"npx", "-y", "pi-acp"},
++		passthroughArgv:    []string{"pi"},
+diff --git a/apps/backend/internal/agent/agents/pi_acp.go b/apps/backend/internal/agent/agents/pi_acp.go
+index ae3bdf4..d36387c 100644
+--- a/apps/backend/internal/agent/agents/pi_acp.go
++++ b/apps/backend/internal/agent/agents/pi_acp.go
+@@ -40 +40 @@ func NewPiACP() *PiACP {
+-				PassthroughCmd: NewCommand("npx", "-y", piACPPkg),
++				PassthroughCmd: NewCommand("pi"),


### PR DESCRIPTION
## Summary

Add opt-in packaged agent runtimes to Kandev without changing its
provider-independent default closure.

Each packaged built-in agent can be enabled independently, and`extraPackages` allows consumers to add tools such as `gh`. The resulting runtime path, packages, commands, environment, wrapper arguments, and support
flags are exposed through passthru metadata so Kandev Desktop can consume the same configured runtime as a NixOS service.

For Local and Worktree execution, Kandev prefers equivalent native ACP commands when they are available:

- OpenCode
- Copilot
- Gemini
- Droid
- Kilocode
- Qwen

Docker and Sprites continue using Kandev's managed npm commands, and host execution falls back to those commands when a native binary is unavailable.

Pi keeps `pi-acp` for structured ACP chat and inference while using the packaged `pi` CLI for interactive passthrough. The Pi behavior backports kdlbs/kandev#2708 until it is included in a packaged release.

Grok self-update suppression now uses the documented `GROK_DISABLE_AUTOUPDATER=1` environment variable. This preserves the public CLI contract when Kandev also passes `--no-auto-update`.

## Why

Kandev discovers local agents through `PATH`, but Finder launches and NixOS services do not inherit shell-managed paths. Several agent definitions also hard-code managed npm commands after discovery, preventing equivalent
Nix-packaged ACP binaries from running on NixOS.

A configured runtime keeps package selection explicit, lets Desktop and headless deployments share one environment, and preserves managed container behavior.

## Test plan

- [x] `nix build .#<package>` succeeds
- [x] Built Kandev with all packaged agent support flags enabled
- [x] Built Kandev Desktop with the configured all-agent runtime
- [x] Evaluated the Kandev runtime for `x86_64-linux`
- [x] Ran Kandev Go tests for:
  - `./internal/agent/agents`
  - `./internal/agent/hostutility`
  - `./internal/agent/registry`
  - `./internal/agent/runtime/lifecycle`
  - `./internal/agent/settings/controller`
  - `./internal/agentctl/server/utility`
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
