### PR TITLE
chatgpt: support Wayland and command line arguments

### DIFF
--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -46,6 +46,7 @@
   libxfixes,
   libxrandr,
   libxcb,
+  commandLineArgs ? "",
 }:
 
 let
@@ -162,7 +163,9 @@ stdenv.mkDerivation {
           coreutils
           xdg-utils
         ]
-      }
+      } \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

- honor `NIXOS_OZONE_WL` by explicitly selecting Wayland when a Wayland display is available
- add `commandLineArgs` so downstream users can pass persistent Chromium/Electron arguments through a package override

## Electron/Ozone behavior

Electron 38 changed the default Ozone platform selection to `auto`. Chromium later removed `--ozone-platform-hint` in Chromium 140 because automatic selection became the default behavior, so `--ozone-platform-hint=auto` no longer forces Wayland in current Electron releases.

ChatGPT ships an Owl-customized Electron/Chromium runtime. In a Wayland session it was observed starting its Chromium child processes with `--ozone-platform=x11`; passing `--ozone-platform=wayland` explicitly makes it use native Wayland. The wrapper therefore adds that argument when both `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` are set. X11 users receive no additional platform arguments.

This is the only Wayland argument needed for the bundled Chromium 151 runtime. Chromium has enabled `WaylandTextInputV3` by default since M135, which also enables the native Wayland IME without `--enable-wayland-ime`. The explicit `--wayland-text-input-version=3` flag has since been deprecated. Adding either IME argument here would only duplicate the runtime defaults; downstream users can still supply application-specific arguments through `commandLineArgs`.

References:

- https://www.electronjs.org/docs/latest/breaking-changes
- https://github.com/electron/electron/issues/48001
- https://chromium-review.googlesource.com/c/chromium/src/+/6819616
- https://github.com/chromium/chromium/commit/e48954bdc391fcba2fd20a5a40a8a16332cf1638
- https://github.com/chromium/chromium/commit/cb0d6a8c7167f9fcc7b140e91cc3bf69cfc6ee7d

## Test plan

- [x] `nix fmt`
- [x] build `chatgpt.override { commandLineArgs = "--chatgpt-command-line-args-test"; }`
- [x] inspect the generated wrapper for the runtime Wayland condition and custom argument
- [x] `nix flake check --accept-flake-config`
- [x] verify that the equivalent explicit arguments launch the packaged ChatGPT natively on Wayland

## LLM disclosure

This change and pull request description were prepared with assistance from OpenAI Codex (GPT-5).
