### PR TITLE
orca: init at 1.4.184

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>orca</strong> - ADE for working with a fleet of parallel coding agents</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://onorca.dev
+- **Usage**: `nix run github:numtide/llm-agents.nix#orca -- --help`
+- **Nix**: [packages/orca/package.nix](packages/orca/package.nix)
+
+</details>
+<details>
 <summary><strong>pi</strong> - A terminal-based coding agent with multi-model support</summary>
 
 - **Source**: bytecode

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -19,6 +19,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 19240940;
         name = "Adam";
       };
+      andreszb = {
+        github = "andreszb";
+        githubId = 3385877;
+        name = "Andrés Zambrano";
+      };
       Bad3r = {
         github = "Bad3r";
         githubId = 25513724;

--- a/packages/orca/hashes.json
+++ b/packages/orca/hashes.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.4.184",
+  "hashes": {
+    "x86_64-linux": "sha256-FkB1MmCPT/x4AOnTZVd6Dd87Ruj4E0T0YSbtUKdVuoQ=",
+    "aarch64-linux": "sha256-s83Aq4S13RhYcmBGokIc8Z9qV02EsIGvWFw2Y0q3I7I="
+  }
+}

--- a/packages/orca/package.nix
+++ b/packages/orca/package.nix
@@ -1,0 +1,224 @@
+{
+  lib,
+  flake,
+  platformSource,
+  mkUpdater,
+  stdenvNoCC,
+  bintools,
+  formatelf,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gcc-unwrapped,
+  glib,
+  gtk3,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libxkbcommon,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+
+  # libs-only build of systemd to avoid pulling the whole systemd closure
+  systemdLibs,
+
+  libglvnd,
+  libsecret,
+  libnotify,
+  libpulseaudio,
+  libayatana-appindicator,
+  libXcursor,
+  pipewire,
+  wayland,
+
+  # `orca serve` and the computer-use surface shell out to these; the deb
+  # declares them as Depends.
+  git,
+  xclip,
+  xdotool,
+  xdg-utils,
+  xvfb-run,
+
+  # Needed for XDG_ICON_DIRS and GSETTINGS_SCHEMAS_PATH.
+  adwaita-icon-theme,
+  gsettings-desktop-schemas,
+}:
+
+let
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "amd64";
+      aarch64-linux = "arm64";
+    };
+    urlTemplate = "https://github.com/stablyai/orca/releases/download/v{version}/orca-ide_{version}_{platform}.deb";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "orca-ide";
+    desktopName = "Orca";
+    genericName = "Agentic Development Environment";
+    comment = "Next-gen IDE for parallel agentic development";
+    exec = "orca-ide %U";
+    icon = "orca-ide";
+    categories = [ "Development" ];
+    # Electron reports WM_CLASS=orca even though the executable is orca-ide,
+    # so docks only group the window with this exact value.
+    startupWMClass = "orca";
+    mimeTypes = [ "x-scheme-handler/orca" ];
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "orca";
+  inherit (source) version src;
+
+  nativeBuildInputs = [
+    formatelf
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildInputs = [
+    adwaita-icon-theme
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gcc-unwrapped.lib
+    glib
+    gsettings-desktop-schemas
+    gtk3
+    libgbm
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libxkbcommon
+    nspr
+    nss
+    pango
+    systemdLibs
+  ];
+
+  # dlopen()ed at runtime, so not discoverable from DT_NEEDED; list them
+  # here to put them on the RUNPATH. libglvnd is the exception and goes on the
+  # wrapper's LD_LIBRARY_PATH instead: ANGLE's bundled libEGL.so dlopen()s the
+  # native libEGL.so.1, and RUNPATH on that object alone does not survive
+  # fixup, so without it Chromium falls back to SwiftShader and the WebGL
+  # terminal renderer runs on the CPU.
+  runtimeDependencies = [
+    libayatana-appindicator
+    libnotify
+    libpulseaudio
+    libsecret
+    libXcursor
+    pipewire
+    wayland
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    ${lib.getExe' bintools "ar"} x $src
+    tar xf data.tar.*
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Keep the upstream opt/Orca layout so the bundled libs (libffmpeg.so),
+    # resources/, and app.asar.unpacked all resolve relative to the binary.
+    mkdir -p $out/lib $out/bin $out/share
+    cp -a opt/Orca $out/lib/Orca
+    cp -a usr/share/icons $out/share/icons
+
+    # chrome-sandbox needs setuid root, which a store path can never have.
+    # Electron falls back to user namespaces, as it does for every other
+    # prebuilt Electron app here.
+    rm -f $out/lib/Orca/chrome-sandbox
+
+    chmod +x $out/lib/Orca/orca-ide $out/lib/Orca/resources/bin/orca-ide
+
+    makeWrapper "$out/lib/Orca/orca-ide" "$out/bin/orca-ide" \
+      --suffix PATH : "${
+        lib.makeBinPath [
+          git
+          xclip
+          xdg-utils
+          xdotool
+          xvfb-run
+        ]
+      }" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}" \
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+    # The shim re-execs the Electron binary under ELECTRON_RUN_AS_NODE on the
+    # CLI entrypoint in app.asar.unpacked. Upstream's deb symlinks it onto PATH
+    # from after-install.sh; expose it as `orca`, the name the docs use.
+    makeWrapper "$out/lib/Orca/resources/bin/orca-ide" "$out/bin/orca" \
+      --suffix PATH : "${
+        lib.makeBinPath [
+          git
+          xclip
+          xdg-utils
+          xdotool
+          xvfb-run
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    category = "AI Coding Agents";
+
+    updater = mkUpdater (
+      source.updater
+      // {
+        # /releases/latest skips the -rc.N tags, which upstream marks as
+        # prereleases.
+        versionSource = {
+          type = "github";
+          owner = "stablyai";
+          repo = "orca";
+        };
+      }
+    );
+  };
+
+  meta = with lib; {
+    description = "ADE for working with a fleet of parallel coding agents";
+    homepage = "https://onorca.dev";
+    changelog = "https://github.com/stablyai/orca/releases/tag/v${source.version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ andreszb ];
+    mainProgram = "orca-ide";
+    platforms = source.platforms;
+  };
+}


### PR DESCRIPTION
## Summary

Adds [`stablyai/orca`](https://github.com/stablyai/orca) at 1.4.184 — an MIT-licensed Electron ADE for running a fleet of coding agents (Codex, Claude Code, OpenCode, Pi) in parallel git worktrees. Category: **AI Coding Agents**.

Packaged from the upstream `.deb`, following `packages/zcode`. Building from source is not viable: it is a pnpm workspace driving `electron-vite` + `electron-builder`, with native Swift helpers (`computer-use-macos`, `notification-status-macos`, `keyboard-layout-macos`), a native Windows launcher, `sherpa-onnx` platform subpackages, and `node-pty`/`@parcel/watcher` rebuilds. Hence `sourceProvenance = [ binaryNativeCode ]`.

Two binaries land on PATH:

- `orca-ide` — the Electron GUI. Upstream deliberately avoids the name `orca` for the Linux executable because Ubuntu ships GNOME Orca at `/usr/bin/orca`; the desktop entry and `mainProgram` follow that.
- `orca` — the bundled CLI (`resources/bin/orca-ide`, which re-execs Electron under `ELECTRON_RUN_AS_NODE` on the unpacked asar entrypoint). Upstream's `after-install.sh` symlinks this onto PATH; the wrapper replaces that.

Packaging notes:

- `chrome-sandbox` is removed — it needs setuid root, which a store path cannot have. Electron falls back to user namespaces, same as the other prebuilt Electron packages here.
- `libglvnd` goes on the wrapper's `LD_LIBRARY_PATH` rather than `runtimeDependencies`. ANGLE's bundled `libEGL.so` `dlopen()`s the native `libEGL.so.1` with no `DT_NEEDED` entry, so RUNPATH on that object does not survive fixup; without this Chromium falls back to SwiftShader and the WebGL terminal renderer runs on the CPU. Verified: the EGL `dlopen` failures are gone from the startup log.
- `git`, `xdg-utils`, `xdotool`, `xclip`, and `xvfb-run` are on both wrappers' PATH — the deb declares the latter three as `Depends` for the computer-use surface and headless `orca serve`.
- `startupWMClass = "orca"` (not `orca-ide`) — Electron reports `WM_CLASS=orca`, and docks need the exact value to group the window.
- Declarative `passthru.updater` (`kind = "platform"`) with a `github` `versionSource`. Upstream tags `-rc.N` prereleases roughly daily; `/releases/latest` skips them, so the updater only follows stable tags.

Linux only for now, matching every prebuilt-Electron precedent in this repo (`zcode`, `chatgpt`, `claude-desktop`, `vessel-browser`). macOS is a clean follow-up — upstream ships `Orca-<ver>-arm64-mac.zip`, so it needs `aarch64-darwin = "arm64-mac"` in the `platformSource` map plus a zip → `$out/Applications` install branch. I have no darwin machine to verify it on, so I left it out rather than ship it untested.

Also adds `andreszb` to `lib/default.nix` maintainers.

## Test plan

- [x] `nix build .#orca` succeeds (`x86_64-linux`)
- [x] Package updates via a declarative `passthru.updater` — round-tripped: downgraded `hashes.json` to 1.4.183 with dummy hashes, ran `nix run .#orca.updateScript`, and it restored 1.4.184 with both platform hashes correct
- [x] `./result/bin/orca --help` prints the full CLI help
- [x] `./result/bin/orca-ide` launches; queried from the CLI against the running instance:
  ```
  appRunning: true
  desktopWindowStatus: available
  runtimeState: ready
  runtimeReachable: true
  graphState: ready
  ```
- [x] `nix fmt` clean; `checks.x86_64-linux.{treefmt,meta-completeness,meta-maintainers,updater-tests,pkgs-orca}` all pass
- [ ] `aarch64-linux` not built — no emulation or aarch64 builder available here. The URL and hash do resolve (`nix store prefetch-file` on `orca-ide_1.4.184_arm64.deb` matches the committed hash, and `nix eval .#packages.aarch64-linux.orca.drvPath` evaluates), but the build itself is unverified and needs CI.
