### PR TITLE
git-ai: init at 1.6.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1436,6 +1436,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>git-ai</strong> - Git extension for tracking AI-generated code in repositories</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/git-ai-project/git-ai
+- **Usage**: `nix run github:numtide/llm-agents.nix#git-ai -- --help`
+- **Nix**: [packages/git-ai/package.nix](packages/git-ai/package.nix)
+
+</details>
+<details>
 <summary><strong>git-surgeon</strong> - Git primitives for autonomous coding agents</summary>
 
 - **Source**: source

--- a/packages/git-ai/package.nix
+++ b/packages/git-ai/package.nix
@@ -7,7 +7,6 @@
   perl,
   versionCheckHook,
   versionCheckHomeHook,
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -52,10 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
   versionCheckProgramArg = "version";
 
-  passthru = {
-    updateScript = nix-update-script { };
-    category = "Utilities";
-  };
+  passthru.category = "Utilities";
 
   meta = with lib; {
     description = "Git extension for tracking AI-generated code in repositories";

--- a/packages/git-ai/package.nix
+++ b/packages/git-ai/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  flake,
+  rustPlatform,
+  fetchFromGitHub,
+  git,
+  perl,
+  versionCheckHook,
+  versionCheckHomeHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-ai";
+  version = "1.6.23";
+
+  src = fetchFromGitHub {
+    owner = "git-ai-project";
+    repo = "git-ai";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7AfONKrkmgnoUHsBIfl5fj9OJGFZg1X1ExCPnGR+e6I=";
+  };
+
+  cargoHash = "sha256-h9T+1UJgXLiGFbphJSc+DGNIAV1XLUbm/MiDwc7p8vQ=";
+
+  nativeBuildInputs = [ perl ];
+
+  postPatch = ''
+    substituteInPlace src/config.rs \
+      --replace-fail '"/usr/bin/git"' '"${git}/bin/git"'
+    substituteInPlace src/authorship/virtual_attribution.rs \
+      --replace-fail 'Command::new("git")' 'Command::new("${git}/bin/git")'
+  '';
+
+  cargoBuildFlags = [
+    "--bin"
+    "git-ai"
+  ];
+
+  # Upstream's full test suite manages per-test daemons and test-only binaries,
+  # and the full library suite exits abnormally in the Nix sandbox.  Run a pure
+  # unit-test subset that does not require daemon/socket orchestration.
+  cargoTestFlags = [
+    "--lib"
+    "uuid::"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+    category = "Utilities";
+  };
+
+  meta = with lib; {
+    description = "Git extension for tracking AI-generated code in repositories";
+    homepage = "https://github.com/git-ai-project/git-ai";
+    changelog = "https://github.com/git-ai-project/git-ai/releases/tag/v${finalAttrs.version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ mulatta ];
+    mainProgram = "git-ai";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Summary

init git-ai at 1.6.23

Patch the packaged binary to resolve git from the Nix store because git-ai shells out to git during normal operation and must keep working in minimal runtime environments.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
