### PR TITLE
chatgpt: split runtime wrapper

### DIFF
--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -1,195 +1,36 @@
 {
   lib,
-  flake,
-  stdenv,
-  fetchurl,
-  coreutils,
-  dpkg,
-  formatelf,
-  makeWrapper,
-  python3,
-  wrapGAppsHook3,
-  alsa-lib,
-  at-spi2-atk,
-  at-spi2-core,
-  atk,
-  cairo,
-  cups,
-  dbus,
-  expat,
-  fontconfig,
-  freetype,
-  gdk-pixbuf,
-  glib,
-  gtk3,
-  libGL,
-  libdrm,
-  libgbm,
-  libnotify,
-  libpulseaudio,
-  libsecret,
-  libusb1,
-  libxkbcommon,
-  nspr,
-  nss,
-  pango,
-  pipewire,
-  qt5,
-  qt6,
-  systemd,
-  wayland,
-  xdg-utils,
-  libx11,
-  libxcomposite,
-  libxdamage,
-  libxext,
-  libxfixes,
-  libxrandr,
-  libxcb,
+  callPackage,
+  stdenvNoCC,
+  makeShellWrapper,
+  chatgpt-unwrapped ? callPackage ./unwrapped.nix { },
   commandLineArgs ? "",
 }:
 
-let
-  sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  platform = stdenv.hostPlatform.system;
-  source = sourceData.sources.${platform} or (throw "Unsupported system: ${platform}");
-in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "chatgpt";
-  inherit (source) version;
+  inherit (chatgpt-unwrapped) version;
 
-  src = fetchurl {
-    inherit (source) url hash;
-  };
+  dontUnpack = true;
 
-  dontStrip = true;
-  dontWrapGApps = true;
-
-  nativeBuildInputs = [
-    formatelf
-    dpkg
-    makeWrapper
-    python3
-    wrapGAppsHook3
-  ];
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    libGL
-    libdrm
-    libgbm
-    libnotify
-    libpulseaudio
-    libusb1
-    libxkbcommon
-    nspr
-    nss
-    pango
-    pipewire
-    stdenv.cc.cc.lib
-    systemd
-    wayland
-    libx11
-    libxcomposite
-    libxdamage
-    libxext
-    libxfixes
-    libxrandr
-    libxcb
-  ];
-
-  # Electron loads these at runtime rather than linking them directly. Put
-  # them on each ELF object's RPATH without leaking a broad LD_LIBRARY_PATH
-  # into Electron's Node and Chromium children.
-  runtimeDependencies = [
-    libGL
-    libgbm
-    libsecret
-    pipewire
-    wayland
-  ];
-
-  # The archive includes musl, glibc, and Android prebuilds for a few Node
-  # modules. NixOS uses the glibc variants, so the other runtimes are
-  # intentionally absent.
-  # The Qt shims are optional and selected dynamically, so autoPatchelf cannot
-  # resolve both of their runtimes during its direct dependency pass. Their
-  # version-specific RPATHs are added in postFixup below.
-  autoPatchelfIgnoreMissingDeps = [
-    "libc++_shared.so"
-    "libc.musl-x86_64.so.1"
-    "liblog.so"
-    "libQt5Core.so.5"
-    "libQt5Gui.so.5"
-    "libQt5Widgets.so.5"
-    "libQt6Core.so.6"
-    "libQt6Gui.so.6"
-    "libQt6Widgets.so.6"
-  ];
-
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x "$src" .
-    runHook postUnpack
-  '';
+  nativeBuildInputs = [ makeShellWrapper ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin" "$out/lib" "$out/share"
-    cp -r usr/lib/chatgpt "$out/lib/"
-    cp -r usr/share/applications usr/share/pixmaps "$out/share/"
-    ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
-
-    # See patch-asar.py for the NixOS-specific source patches.
-    python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
-
-    wrapProgram "$out/lib/chatgpt/ChatGPT" \
-      "''${gappsWrapperArgs[@]}" \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          coreutils
-          xdg-utils
-        ]
-      } \
+    mkdir -p "$out/bin"
+    makeShellWrapper ${chatgpt-unwrapped}/bin/chatgpt "$out/bin/chatgpt" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
+    ln -s ${chatgpt-unwrapped}/share "$out/share"
 
     runHook postInstall
   '';
 
-  postFixup = ''
-    patchelf --add-rpath ${lib.makeLibraryPath [ qt5.qtbase ]} \
-      "$out/lib/chatgpt/libqt5_shim.so"
-    patchelf --add-rpath ${lib.makeLibraryPath [ qt6.qtbase ]} \
-      "$out/lib/chatgpt/libqt6_shim.so"
-  '';
-
-  passthru.category = "AI Coding Agents";
-
-  meta = with lib; {
-    description = "Desktop application for ChatGPT and Codex";
-    homepage = "https://developers.openai.com/codex/app";
-    changelog = "https://learn.chatgpt.com/docs/changelog";
-    license = flake.lib.licenses.unfree;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with flake.lib.maintainers; [ whazor ];
-    mainProgram = "chatgpt";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+  passthru = {
+    category = "AI Coding Agents";
+    unwrapped = chatgpt-unwrapped;
   };
+
+  inherit (chatgpt-unwrapped) meta;
 }

--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -1,0 +1,190 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  coreutils,
+  dpkg,
+  formatelf,
+  makeWrapper,
+  python3,
+  wrapGAppsHook3,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libGL,
+  libdrm,
+  libgbm,
+  libnotify,
+  libpulseaudio,
+  libsecret,
+  libusb1,
+  libxkbcommon,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  qt5,
+  qt6,
+  systemd,
+  wayland,
+  xdg-utils,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
+}:
+
+let
+  sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  platform = stdenv.hostPlatform.system;
+  source = sourceData.sources.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "chatgpt-unwrapped";
+  inherit (source) version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  dontStrip = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    formatelf
+    dpkg
+    makeWrapper
+    python3
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libGL
+    libdrm
+    libgbm
+    libnotify
+    libpulseaudio
+    libusb1
+    libxkbcommon
+    nspr
+    nss
+    pango
+    pipewire
+    stdenv.cc.cc.lib
+    systemd
+    wayland
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxcb
+  ];
+
+  # Electron loads these at runtime rather than linking them directly. Put
+  # them on each ELF object's RPATH without leaking a broad LD_LIBRARY_PATH
+  # into Electron's Node and Chromium children.
+  runtimeDependencies = [
+    libGL
+    libgbm
+    libsecret
+    pipewire
+    wayland
+  ];
+
+  # The archive includes musl, glibc, and Android prebuilds for a few Node
+  # modules. NixOS uses the glibc variants, so the other runtimes are
+  # intentionally absent.
+  # The Qt shims are optional and selected dynamically, so autoPatchelf cannot
+  # resolve both of their runtimes during its direct dependency pass. Their
+  # version-specific RPATHs are added in postFixup below.
+  autoPatchelfIgnoreMissingDeps = [
+    "libc++_shared.so"
+    "libc.musl-x86_64.so.1"
+    "liblog.so"
+    "libQt5Core.so.5"
+    "libQt5Gui.so.5"
+    "libQt5Widgets.so.5"
+    "libQt6Core.so.6"
+    "libQt6Gui.so.6"
+    "libQt6Widgets.so.6"
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib" "$out/share"
+    cp -r usr/lib/chatgpt "$out/lib/"
+    cp -r usr/share/applications usr/share/pixmaps "$out/share/"
+    ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
+
+    # See patch-asar.py for the NixOS-specific source patches.
+    python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
+
+    wrapProgram "$out/lib/chatgpt/ChatGPT" \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          xdg-utils
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchelf --add-rpath ${lib.makeLibraryPath [ qt5.qtbase ]} \
+      "$out/lib/chatgpt/libqt5_shim.so"
+    patchelf --add-rpath ${lib.makeLibraryPath [ qt6.qtbase ]} \
+      "$out/lib/chatgpt/libqt6_shim.so"
+  '';
+
+  meta = with lib; {
+    description = "Desktop application for ChatGPT and Codex";
+    homepage = "https://developers.openai.com/codex/app";
+    changelog = "https://learn.chatgpt.com/docs/changelog";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ whazor ];
+    mainProgram = "chatgpt";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- move the patched ChatGPT application into a separately overridable `chatgpt-unwrapped` derivation
- add a lightweight shell wrapper that evaluates `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` when the application starts
- keep `commandLineArgs` changes wrapper-only and expose the inner package as `passthru.unwrapped`

## Root cause

This follows up on #8061. That change added the correct Ozone condition, but placed it in the existing `wrapProgram` call used for the application.

`wrapGAppsHook3` selects `makeBinaryWrapper`'s `wrapProgram`, which produces a compiled wrapper. Its `--add-flags` option can append fixed arguments, but it cannot evaluate shell parameter expansion when the application starts. The expression checking `NIXOS_OZONE_WL` and `WAYLAND_DISPLAY` was consequently embedded as a literal argument, so `--ozone-platform=wayland` never reached Electron.

The inner compiled wrapper remains useful for the GApps environment and runtime `PATH`. This change adds a separate shell wrapper around the finished application, where the Wayland condition can be evaluated at launch time.

Separating the wrapper also means changing `commandLineArgs` no longer repacks the application. Downstream users can customize the inner derivation and feed it back into the wrapper:

```nix
chatgpt.override {
  chatgpt-unwrapped = chatgpt.unwrapped.overrideAttrs (_: {
    # Inner package changes.
  });
}
```

The outer package continues to expose the inner desktop files through `share`; `Exec=chatgpt` resolves to the outer wrapper when the package is installed in a profile.

## Test plan

- [x] `nix fmt packages/chatgpt/package.nix packages/chatgpt/unwrapped.nix`
- [x] `git diff --check`
- [x] `nix flake check --accept-flake-config --no-build path:.`
- [x] `nix build --accept-flake-config path:.#checks.x86_64-linux.pkgs-chatgpt`
- [x] rebuild an overridden `chatgpt.unwrapped` and verify the outer output references it
- [x] switch a NixOS system with this checkout as the `llm-agents` input and verify native Wayland from both the wrapper and desktop entry

## LLM disclosure

This change, commit message, and pull request description were prepared with assistance from OpenAI Codex (GPT-5).
