### PR TITLE
fx: init at 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>fx</strong> - Tiny, open, embeddable, native coding agent</summary>
+
+- **Source**: source
+- **License**: Apache-2.0
+- **Homepage**: https://github.com/vercel-labs/fx
+- **Usage**: `nix run github:numtide/llm-agents.nix#fx -- --help`
+- **Nix**: [packages/fx/package.nix](packages/fx/package.nix)
+
+</details>
+<details>
 <summary><strong>gemini-cli</strong> - AI agent that brings the power of Gemini directly into your terminal</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -224,6 +224,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 103114856;
         name = "imxyy_soope_";
       };
+      jossephus = {
+        github = "jossephus";
+        githubId = 46337696;
+        name = "Josseph";
+      };
     };
   }
 )

--- a/packages/fx/package.nix
+++ b/packages/fx/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  flake,
   fetchFromGitHub,
   zig,
   versionCheckHook,
@@ -38,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/vercel-labs/fx/releases/tag/v${finalAttrs.version}";
     license = licenses.asl20;
     sourceProvenance = with sourceTypes; [ fromSource ];
-    maintainers = with maintainers; [ ];
+    maintainers = with flake.lib.maintainers; [ jossephus ];
     mainProgram = "fx";
     platforms = platforms.unix;
   };

--- a/packages/fx/package.nix
+++ b/packages/fx/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fx";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "fx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oKDTCdHWe9kRmgMuty3s0J1urxPv5xutwlf/pWkXjYs=";
+  };
+
+  nativeBuildInputs = [ zig.hook ];
+
+  zigBuildFlags = [ "-Doptimize=ReleaseSafe" ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "Tiny, open, embeddable, native coding agent";
+    homepage = "https://github.com/vercel-labs/fx";
+    changelog = "https://github.com/vercel-labs/fx/releases/tag/v${finalAttrs.version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "fx";
+    platforms = platforms.unix;
+  };
+})

--- a/packages/fx/package.nix
+++ b/packages/fx/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fx";
-  version = "0.0.3";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "vercel-labs";
     repo = "fx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oKDTCdHWe9kRmgMuty3s0J1urxPv5xutwlf/pWkXjYs=";
+    hash = "sha256-Delw7SY6rbvW429yDiszbopCPvQkbliR0TULKuWGXrg=";
   };
 
   nativeBuildInputs = [ zig.hook ];


### PR DESCRIPTION
## Summary

Add vercel's new coding agent https://github.com/vercel-labs/fx 

## Test plan
I built it locall using nix build .#fx and its works fine. 

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
