### PR TITLE
copilot-cli: remove SSL certificate workaround

### DIFF
--- a/packages/copilot-cli/package.nix
+++ b/packages/copilot-cli/package.nix
@@ -6,7 +6,6 @@
   platformSource,
   makeWrapper,
   patchelf,
-  cacert,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -65,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + ''
       makeWrapper "$bin" $out/bin/copilot \
-        --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
         --set-default COPILOT_AUTO_UPDATE false \
         ${lib.optionalString stdenv.hostPlatform.isLinux ''--prefix LD_LIBRARY_PATH : "${libPath}"''}
 


### PR DESCRIPTION
## Summary

In 1e2f7e281 (copilot-cli: fix OpenSSL certificate directory warning, 2026-02-06), we started wrapping the GitHub Copilot CLI executable to give it a definition of SSL_CERT_DIR, apparently because Node.js wasn't managing to find certificates.

At least for me, this value is causing some Python commands run within the Copilot session to fail due to not being able to find SSL certificate.  I'd been working around this by including an instruction to set `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` on every call if it saw a "CERTIFICATE_VERIFY_FAILED" error.

Avoid the need for this workaround by no longer setting SSL_CERT_DIR in the copilot wrapper.  This no longer produces OpenSSL errors when launching copilot, and means Python tools that make HTTPS requests work without needing to set the certificate path manually every time.

Fixes #8175

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
    -   *Both `nix run nixpkgs#nix-update -- --flake copilot-cli` and `nix run .#copilot-cli.passthru.updateScript` work, at least as far as confirming there is no current update available.  `nix run nixpkgs#nix-update -- --flake --use-update-script copilot-cli` **does not** work, because `updateScript` doesn't resolve to a script but a package with the script in the `bin` subdirectory.*

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
