### PR TITLE
luvus: init at 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>luvus</strong> - Mission control for your AI coding agents</summary>
+
+- **Source**: source
+- **License**: AGPL-3.0-or-later
+- **Homepage**: https://luvus.dev
+- **Usage**: `nix run github:numtide/llm-agents.nix#luvus -- --help`
+- **Nix**: [packages/luvus/package.nix](packages/luvus/package.nix)
+
+</details>
+<details>
 <summary><strong>mardi-gras</strong> - Terminal UI for Beads issue tracking with a parade-inspired workflow view</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -194,6 +194,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 66107;
         name = "Daniel Poelzleithner";
       };
+      r17x = {
+        github = "r17x";
+        githubId = 16365952;
+        name = "RiN";
+      };
       selmison = {
         github = "selmison";
         githubId = 24687232;

--- a/packages/luvus/package.nix
+++ b/packages/luvus/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   rustPlatform,
   makeWrapper,
+  curl,
   git,
   gh,
   openssh,
@@ -43,7 +44,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  doCheck = false;
+  # needs git worktrees and curl for a file:// fetch
+  nativeCheckInputs = [
+    curl
+    git
+  ];
 
   postFixup = ''
     wrapProgram $out/bin/luvus \

--- a/packages/luvus/package.nix
+++ b/packages/luvus/package.nix
@@ -50,6 +50,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     git
   ];
 
+  # flaky: spawn real PTYs/processes and race under load
+  checkFlags = [
+    "--skip=app::tests::clicking_a_pane_title_shows_the_real_command"
+    "--skip=app::tests::keyboard_copy_mode_yanks_history_and_cancel_restores_its_viewport"
+    "--skip=app::tests::resize_yields_to_pane_title_and_zoom_but_still_grabs_the_seam"
+    "--skip=app::tests::resume_session_opens_pane"
+    "--skip=platform::tests::process_tree_finds_this_process_and_its_children"
+  ];
+
   postFixup = ''
     wrapProgram $out/bin/luvus \
       --prefix PATH : ${lib.makeBinPath runtimeTools}

--- a/packages/luvus/package.nix
+++ b/packages/luvus/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  flake,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  git,
+  gh,
+  openssh,
+  bashInteractive,
+  coreutils,
+  procps,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  runtimeTools = [
+    git
+    gh
+    openssh
+    bashInteractive
+    coreutils
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    procps
+  ];
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "luvus";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "RizRiyz";
+    repo = "luvus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aKL/5N0E91IVIG7drMwKozNQy/bzy/78VdNCl67Dunc=";
+  };
+
+  cargoHash = "sha256-CqRDKuHC5kwIdGXLdpehBRoV1kE+Vj2Mj7xix3anz9k=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/luvus \
+      --prefix PATH : ${lib.makeBinPath runtimeTools}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "Workflow & Project Management";
+
+  meta = {
+    description = "Mission control for your AI coding agents";
+    homepage = "https://luvus.dev";
+    changelog = "https://github.com/RizRiyz/luvus/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = with flake.lib.maintainers; [ r17x ];
+    mainProgram = "luvus";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Summary
- Add [luvus](https://luvus.dev) — mission control for AI coding agents
- Version 0.11.0, built from source with `rustPlatform.buildRustPackage`
- Category: Workflow & Project Management
- Platforms: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`
- Runtime PATH wrapping for `git`, `gh`, `openssh`, `bashInteractive`, `coreutils` (+ `procps` on Linux)

## Test plan
- [x] `nix build .#luvus` succeeds on `aarch64-darwin`
- [x] `luvus --version` reports `0.11.0` (via `versionCheckHook`)
- [x] `nix fmt` passes
- [x] `nix flake check` passes