### PR TITLE
t3code: split provider wrapper from unwrapped package

### DIFF
--- a/checks/t3code-packaging.nix
+++ b/checks/t3code-packaging.nix
@@ -9,21 +9,27 @@ let
   packages = flake.packages.${system};
   t3code = packages.t3code;
   desktop = packages.t3code-desktop;
+  t3codeWithoutProviders = t3code.override { providerPackages = [ ]; };
 in
 assert t3code.meta.mainProgram == "t3";
 assert desktop.meta.mainProgram == "t3code-desktop";
 assert !(desktop ? version);
 assert t3code.passthru ? resourceMonitor;
+assert t3code.unwrapped ? override;
+assert t3code.pnpmDeps == t3code.unwrapped.pnpmDeps;
+assert t3code.unwrapped.drvPath == t3codeWithoutProviders.unwrapped.drvPath;
+assert t3code.drvPath != t3codeWithoutProviders.drvPath;
+assert t3code.desktop.drvPath != t3codeWithoutProviders.desktop.drvPath;
 assert pkgs.lib.hasInfix "package.json').dependencies.electron" (
-  builtins.readFile ../packages/t3code/package.nix
+  builtins.readFile ../packages/t3code/unwrapped.nix
 );
 assert
   map pkgs.lib.getName t3code.passthru.providerPackages == [
-    "grok"
-    "claude-code"
     "codex"
-    "opencode"
+    "claude-code"
     "cursor-agent"
+    "grok"
+    "opencode"
   ];
 pkgs.runCommand "t3code-packaging-check" { } ''
   touch $out

--- a/packages/t3code/nix-update-args
+++ b/packages/t3code/nix-update-args
@@ -1,5 +1,7 @@
 --use-github-releases
 --version-regex
 ^v([0-9]+\.[0-9]+\.[0-9]+)$
+--override-filename
+packages/t3code/unwrapped.nix
 --subpackage
 resourceMonitor

--- a/packages/t3code/package.nix
+++ b/packages/t3code/package.nix
@@ -1,258 +1,74 @@
 {
   lib,
-  flake,
-  stdenv,
-  fetchFromGitHub,
-  fetchPnpmDeps,
-  pnpm_11,
-  pnpmConfigHook,
-  pnpmBuildHook,
-  nodejs_24,
-  node-gyp,
-  python3,
-  grok,
-  claude-code,
-  codex,
-  opencode,
-  cursor-agent,
-  cacert,
-  electron_41,
+  callPackage,
+  stdenvNoCC,
   makeBinaryWrapper,
-  installShellFiles,
-  makeDesktopItem,
-  rustPlatform,
-  versionCheckHook,
-  versionCheckHomeHook,
-  cctools,
-  libicns,
-  writeDarwinBundle,
-  xcbuild,
+  t3code-unwrapped ? callPackage ./unwrapped.nix { },
+  codex,
+  claude-code,
+  cursor-agent,
+  grok,
+  opencode,
+  providerPackages ? [
+    codex
+    claude-code
+    cursor-agent
+    grok
+    opencode
+  ],
 }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "t3code";
-  version = "0.0.33";
-  pnpm = pnpm_11;
-
-  src = fetchFromGitHub {
-    owner = "pingdotgg";
-    repo = "t3code";
-    tag = "v${version}";
-    hash = "sha256-qZi9hMGzqpmnpqvvVtsQvkZIiVqTgOMWv1y15MiSAYg=";
-  };
-
-  resourceMonitor = rustPlatform.buildRustPackage {
-    pname = "t3code-resource-monitor";
-    inherit version src;
-
-    sourceRoot = "${src.name}/native/resource-monitor";
-    cargoHash = "sha256-5cmG2daM1bVOA23gjjoalbx0fEL1hmqV6WZov0sUZp8=";
-  };
-
-  platformKey =
-    {
-      x86_64-linux = "linux-x64";
-      aarch64-linux = "linux-arm64";
-      aarch64-darwin = "darwin-arm64";
-    }
-    .${stdenv.hostPlatform.system};
-
-  pnpmWorkspaces = [
-    "@t3tools/monorepo"
-    "t3..."
-    "@t3tools/desktop..."
-    "@t3tools/scripts..."
-  ];
-
-  providerPackages = [
-    grok
-    claude-code
-    codex
-    opencode
-    cursor-agent
-  ];
-
-  appName = "T3 Code (Alpha)";
-  desktopIcon =
-    if stdenv.hostPlatform.isDarwin then
-      "assets/prod/black-macos-1024.png"
-    else
-      "assets/prod/black-universal-1024.png";
-
-  desktopItem = makeDesktopItem {
-    name = "t3code";
-    desktopName = appName;
-    comment = "Control surface for coding agents";
-    exec = "t3code-desktop %U";
-    icon = "t3code";
-    categories = [ "Development" ];
-    startupWMClass = "t3code";
-  };
-in
-stdenv.mkDerivation {
-  inherit
-    pname
-    version
-    src
-    pnpmWorkspaces
-    ;
+  inherit (t3code-unwrapped) version;
 
   outputs = [
     "out"
     "desktop"
   ];
 
+  dontUnpack = true;
   strictDeps = true;
-  __structuredAttrs = true;
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit
-      pnpm
-      pname
-      version
-      src
-      pnpmWorkspaces
-      ;
-    fetcherVersion = 4;
-    hash = "sha256-i/K5bj7CS7PGIX5hfayxAJ7ngNib92w3SDKGXTVWccA=";
-  };
-
-  nativeBuildInputs = [
-    cacert
-    installShellFiles
-    makeBinaryWrapper
-    node-gyp
-    nodejs_24
-    pnpm
-    pnpmBuildHook
-    pnpmConfigHook
-    python3
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools.libtool
-    libicns
-    writeDarwinBundle
-    xcbuild
-  ];
-
-  preBuild = ''
-    export pnpm_config_verify_deps_before_run=false
-
-    node scripts/update-release-package-versions.ts ${version}
-
-    upstream_electron=$(node -p "require('./apps/desktop/package.json').dependencies.electron")
-    upstream_major=''${upstream_electron#^}
-    upstream_major=''${upstream_major%%.*}
-    nix_major=${lib.versions.major electron_41.version}
-    if (( upstream_major > nix_major )); then
-      echo "error: upstream expects Electron $upstream_electron but nixpkgs provides ${electron_41.version}" >&2
-      exit 1
-    fi
-
-    export npm_config_nodedir=${nodejs_24}
-    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
-    pnpm rebuild --pending "''${pnpmInstallFlags[@]}" \
-      --filter '!@t3tools/monorepo'
-  '';
-
-  pnpmBuildScript = "build:desktop";
-
-  # Dependencies include prebuilt artifacts for foreign systems and statically
-  # linked executables, which must not be patched or audited as host binaries.
-  dontPatchELF = true;
-  noAuditTmpdir = true;
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/libexec/t3code/apps/server"
-    cp -r --no-preserve=mode node_modules "$out/libexec/t3code/"
-    cp -r --no-preserve=mode apps/server/{node_modules,dist} "$out/libexec/t3code/apps/server/"
+    mkdir -p "$out/bin" "$desktop/bin"
 
-    mkdir -p "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}"
-    install -Dm755 ${resourceMonitor}/bin/t3-resource-monitor \
-      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor"
+    makeWrapper ${t3code-unwrapped}/bin/t3 "$out/bin/t3" \
+      --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath providerPackages)}
+    ln -s ${t3code-unwrapped}/share "$out/share"
 
-    mkdir -p "$out/bin"
-    makeWrapper ${lib.getExe nodejs_24} "$out/bin/t3" \
-      --add-flags "$out/libexec/t3code/apps/server/dist/bin.mjs" \
-      --prefix PATH : ${lib.makeBinPath providerPackages}
-
-    mkdir -p "$desktop/libexec/t3code/apps/desktop"
-    cp -r --no-preserve=mode \
-      apps/desktop/{package.json,node_modules,dist-electron} \
-      "$desktop/libexec/t3code/apps/desktop/"
-    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources"
-    install -Dm444 ${desktopIcon} \
-      "$desktop/libexec/t3code/apps/desktop/prod-resources/icon.png"
-
-    ln -s "$out/libexec/t3code/node_modules" "$desktop/libexec/t3code/node_modules"
-    ln -s "$out/libexec/t3code/apps/server" "$desktop/libexec/t3code/apps/server"
-
-    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor"
-    ln -s \
-      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor" \
-      "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor/t3-resource-monitor"
-
-    find "$out/libexec/t3code" "$desktop/libexec/t3code" -xtype l -delete
-
-    mkdir -p "$desktop/bin"
-    makeWrapper ${lib.getExe electron_41} "$desktop/bin/t3code-desktop" \
-      --add-flags "$desktop/libexec/t3code/apps/desktop" \
-      --prefix PATH : ${lib.makeBinPath providerPackages} \
+    makeWrapper ${t3code-unwrapped.desktop}/bin/t3code-desktop \
+      "$desktop/bin/t3code-desktop" \
+      --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath providerPackages)} \
       --inherit-argv0
+    ln -s ${t3code-unwrapped.desktop}/share "$desktop/share"
 
-    mkdir -p "$desktop/share/icons/hicolor/scalable/apps"
-    install -Dm444 ${desktopIcon} "$desktop/share/icons/t3code.png"
-    install -Dm444 assets/prod/logo.svg "$desktop/share/icons/hicolor/scalable/apps/t3code.svg"
-    cp -r ${desktopItem}/share/applications "$desktop/share/"
-
-    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-      find "$desktop/libexec/t3code" \
-        -path '*/node-pty/prebuilds/darwin-*/spawn-helper' \
-        -exec chmod 755 {} +
-
-      mkdir -p "$desktop/Applications/${appName}.app/Contents/"{MacOS,Resources}
-      png2icns \
-        "$desktop/Applications/${appName}.app/Contents/Resources/t3code.icns" \
-        ${desktopIcon}
-      ${stdenv.shell} ${lib.getExe writeDarwinBundle} \
-        "$desktop" "${appName}" t3code-desktop t3code
+    ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      sourceApp=${lib.escapeShellArg "${t3code-unwrapped.desktop}/Applications/${t3code-unwrapped.appName}.app"}
+      targetApp="$desktop/Applications/${t3code-unwrapped.appName}.app"
+      mkdir -p "$targetApp/Contents/MacOS"
+      ln -s "$sourceApp/Contents/Info.plist" "$targetApp/Contents/Info.plist"
+      ln -s "$sourceApp/Contents/Resources" "$targetApp/Contents/Resources"
+      ln -s ../../../../bin/t3code-desktop \
+        "$targetApp/Contents/MacOS/${t3code-unwrapped.appName}"
     ''}
 
     runHook postInstall
   '';
 
-  postInstall = ''
-    for shell in bash fish zsh; do
-      installShellCompletion --cmd t3 --"$shell" <("$out/bin/t3" --completions "$shell")
-    done
-  '';
-
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [
-    versionCheckHook
-    versionCheckHomeHook
-  ];
-  versionCheckProgramArg = [ "--version" ];
-
   passthru = {
     category = "AI Coding Agents";
-    inherit providerPackages resourceMonitor;
+    inherit providerPackages;
+    # Keep the existing t3code updater targeting the unwrapped build inputs.
+    inherit (t3code-unwrapped) pnpmDeps resourceMonitor src;
+    unwrapped = t3code-unwrapped;
   };
 
-  meta = {
+  meta = t3code-unwrapped.meta // {
     description = "Control surface for coding agents";
-    homepage = "https://t3.codes";
-    changelog = "https://github.com/pingdotgg/t3code/releases/tag/v${version}";
-    license = lib.licenses.mit;
-    sourceProvenance = with lib.sourceTypes; [ fromSource ];
-    maintainers = with flake.lib.maintainers; [ dancodes ];
-    mainProgram = "t3";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
   };
 }

--- a/packages/t3code/unwrapped.nix
+++ b/packages/t3code/unwrapped.nix
@@ -1,0 +1,243 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_11,
+  pnpmConfigHook,
+  pnpmBuildHook,
+  nodejs_24,
+  node-gyp,
+  python3,
+  cacert,
+  electron_41,
+  makeBinaryWrapper,
+  installShellFiles,
+  makeDesktopItem,
+  rustPlatform,
+  versionCheckHook,
+  versionCheckHomeHook,
+  cctools,
+  libicns,
+  writeDarwinBundle,
+  xcbuild,
+}:
+
+let
+  pname = "t3code";
+  version = "0.0.33";
+  pnpm = pnpm_11;
+
+  src = fetchFromGitHub {
+    owner = "pingdotgg";
+    repo = "t3code";
+    tag = "v${version}";
+    hash = "sha256-qZi9hMGzqpmnpqvvVtsQvkZIiVqTgOMWv1y15MiSAYg=";
+  };
+
+  resourceMonitor = rustPlatform.buildRustPackage {
+    pname = "t3code-resource-monitor";
+    inherit version src;
+
+    sourceRoot = "${src.name}/native/resource-monitor";
+    cargoHash = "sha256-5cmG2daM1bVOA23gjjoalbx0fEL1hmqV6WZov0sUZp8=";
+  };
+
+  platformKey =
+    {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    }
+    .${stdenv.hostPlatform.system};
+
+  pnpmWorkspaces = [
+    "@t3tools/monorepo"
+    "t3..."
+    "@t3tools/desktop..."
+    "@t3tools/scripts..."
+  ];
+
+  appName = "T3 Code (Alpha)";
+  desktopIcon =
+    if stdenv.hostPlatform.isDarwin then
+      "assets/prod/black-macos-1024.png"
+    else
+      "assets/prod/black-universal-1024.png";
+
+  desktopItem = makeDesktopItem {
+    name = "t3code";
+    desktopName = appName;
+    comment = "Control surface for coding agents";
+    exec = "t3code-desktop %U";
+    icon = "t3code";
+    categories = [ "Development" ];
+    startupWMClass = "t3code";
+  };
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    pnpmWorkspaces
+    ;
+
+  outputs = [
+    "out"
+    "desktop"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit
+      pnpm
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    fetcherVersion = 4;
+    hash = "sha256-i/K5bj7CS7PGIX5hfayxAJ7ngNib92w3SDKGXTVWccA=";
+  };
+
+  nativeBuildInputs = [
+    cacert
+    installShellFiles
+    makeBinaryWrapper
+    node-gyp
+    nodejs_24
+    pnpm
+    pnpmBuildHook
+    pnpmConfigHook
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+    libicns
+    writeDarwinBundle
+    xcbuild
+  ];
+
+  preBuild = ''
+    export pnpm_config_verify_deps_before_run=false
+
+    node scripts/update-release-package-versions.ts ${version}
+
+    upstream_electron=$(node -p "require('./apps/desktop/package.json').dependencies.electron")
+    upstream_major=''${upstream_electron#^}
+    upstream_major=''${upstream_major%%.*}
+    nix_major=${lib.versions.major electron_41.version}
+    if (( upstream_major > nix_major )); then
+      echo "error: upstream expects Electron $upstream_electron but nixpkgs provides ${electron_41.version}" >&2
+      exit 1
+    fi
+
+    export npm_config_nodedir=${nodejs_24}
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+    pnpm rebuild --pending "''${pnpmInstallFlags[@]}" \
+      --filter '!@t3tools/monorepo'
+  '';
+
+  pnpmBuildScript = "build:desktop";
+
+  # Dependencies include prebuilt artifacts for foreign systems and statically
+  # linked executables, which must not be patched or audited as host binaries.
+  dontPatchELF = true;
+  noAuditTmpdir = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/libexec/t3code/apps/server"
+    cp -r --no-preserve=mode node_modules "$out/libexec/t3code/"
+    cp -r --no-preserve=mode apps/server/{node_modules,dist} "$out/libexec/t3code/apps/server/"
+
+    mkdir -p "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}"
+    install -Dm755 ${resourceMonitor}/bin/t3-resource-monitor \
+      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor"
+
+    mkdir -p "$out/bin"
+    makeWrapper ${lib.getExe nodejs_24} "$out/bin/t3" \
+      --add-flags "$out/libexec/t3code/apps/server/dist/bin.mjs"
+
+    mkdir -p "$desktop/libexec/t3code/apps/desktop"
+    cp -r --no-preserve=mode \
+      apps/desktop/{package.json,node_modules,dist-electron} \
+      "$desktop/libexec/t3code/apps/desktop/"
+    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources"
+    install -Dm444 ${desktopIcon} \
+      "$desktop/libexec/t3code/apps/desktop/prod-resources/icon.png"
+
+    ln -s "$out/libexec/t3code/node_modules" "$desktop/libexec/t3code/node_modules"
+    ln -s "$out/libexec/t3code/apps/server" "$desktop/libexec/t3code/apps/server"
+
+    mkdir -p "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor"
+    ln -s \
+      "$out/libexec/t3code/apps/server/dist/resource-monitor/${platformKey}/t3-resource-monitor" \
+      "$desktop/libexec/t3code/apps/desktop/prod-resources/resource-monitor/t3-resource-monitor"
+
+    find "$out/libexec/t3code" "$desktop/libexec/t3code" -xtype l -delete
+
+    mkdir -p "$desktop/bin"
+    makeWrapper ${lib.getExe electron_41} "$desktop/bin/t3code-desktop" \
+      --add-flags "$desktop/libexec/t3code/apps/desktop" \
+      --inherit-argv0
+
+    mkdir -p "$desktop/share/icons/hicolor/scalable/apps"
+    install -Dm444 ${desktopIcon} "$desktop/share/icons/t3code.png"
+    install -Dm444 assets/prod/logo.svg "$desktop/share/icons/hicolor/scalable/apps/t3code.svg"
+    cp -r ${desktopItem}/share/applications "$desktop/share/"
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      find "$desktop/libexec/t3code" \
+        -path '*/node-pty/prebuilds/darwin-*/spawn-helper' \
+        -exec chmod 755 {} +
+
+      mkdir -p "$desktop/Applications/${appName}.app/Contents/"{MacOS,Resources}
+      png2icns \
+        "$desktop/Applications/${appName}.app/Contents/Resources/t3code.icns" \
+        ${desktopIcon}
+      ${stdenv.shell} ${lib.getExe writeDarwinBundle} \
+        "$desktop" "${appName}" t3code-desktop t3code
+    ''}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      installShellCompletion --cmd t3 --"$shell" <("$out/bin/t3" --completions "$shell")
+    done
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    category = "AI Coding Agents";
+    inherit appName resourceMonitor;
+  };
+
+  meta = {
+    description = "Control surface for coding agents";
+    homepage = "https://t3.codes";
+    changelog = "https://github.com/pingdotgg/t3code/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ dancodes ];
+    mainProgram = "t3";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Move the heavyweight t3code source build into a private `unwrapped.nix` derivation.
- Make `t3code` a lightweight wrapper that adds `providerPackages` to `PATH`.
- Allow users to override the default provider list with `t3code.override { providerPackages = [ ... ]; }`.
- Preserve the existing public interfaces: `t3code` provides `t3`, while `t3code-desktop` provides the desktop application.
- Point `nix-update` at `unwrapped.nix` and extend the packaging checks for wrapper overrides.

This decouples provider updates from the roughly 1 GiB t3code build. Updating packages such as `claude-code`, `codex`, or `opencode` now only rebuilds the small wrapper instead of downloading and rebuilding t3code itself.

## Test plan

- [x] `nix fmt`
- [x] `nix flake check --accept-flake-config --no-build path:.`
- [x] `nix build --accept-flake-config path:.#t3code path:.#t3code-desktop`
- [x] `nix build --accept-flake-config path:.#checks.x86_64-linux.t3code-packaging`
- [x] Verified that overriding `providerPackages` reuses the same unwrapped derivation and only changes the wrapper derivations.
- [x] Temporarily downgraded t3code from 0.0.33 to 0.0.32 and verified that the updater restored 0.0.33 with the correct source, Cargo, and pnpm dependency hashes.

## Discloure

This PR is assisted by OpenAI Codex with manual smoke tests.