### PR TITLE
agentsview: install the finding-history skill

### DIFF
--- a/packages/agentsview/package.nix
+++ b/packages/agentsview/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   flake,
   buildGoModule,
   buildNpmPackage,
@@ -116,7 +117,8 @@ buildGoModule {
   postInstall = ''
     wrapProgram $out/bin/agentsview \
       --set AGENTSVIEW_TELEMETRY_ENABLED 0
-
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # The source tree has the skill only as a Go template. `agentsview skills
     # install` renders it per harness and adds a header recording a hash of
     # the body, which `agentsview skills list` compares against a fresh render

--- a/packages/agentsview/package.nix
+++ b/packages/agentsview/package.nix
@@ -116,6 +116,34 @@ buildGoModule {
   postInstall = ''
     wrapProgram $out/bin/agentsview \
       --set AGENTSVIEW_TELEMETRY_ENABLED 0
+
+    # The source tree has the skill only as a Go template. `agentsview skills
+    # install` renders it per harness and adds a header recording a hash of
+    # the body, which `agentsview skills list` compares against a fresh render
+    # to detect a stale or edited file. A copy taken from the source tree
+    # would have neither the harness-specific text nor that header, so only
+    # the binary can produce a usable file. The installer writes under $HOME
+    # and accepts no other destination, hence the staging home.
+    #
+    # `skills list` reports one row per harness, with the columns HARNESS,
+    # LEVEL, STATE and PATH, so a harness added upstream needs no change here.
+    (
+      export HOME="$NIX_BUILD_TOP/agentsview-skills-home"
+
+      "$out/bin/agentsview" skills install
+
+      "$out/bin/agentsview" skills list \
+        | awk 'NR > 1 { print $1, $4 }' \
+        | while read -r harness path; do
+            mkdir -p "$out/share/agentsview/skills/$harness"
+            cp -r "$(dirname "$path")" "$out/share/agentsview/skills/$harness/"
+          done
+
+      if [ ! -d "$out/share/agentsview/skills" ]; then
+        echo "agentsview: no skills were installed; has 'skills list' changed?" >&2
+        exit 1
+      fi
+    )
   '';
 
   passthru.category = "Usage Analytics";


### PR DESCRIPTION
AgentsView ships a skill that teaches a coding agent to search recorded
sessions, but a consumer cannot obtain the file without running
`agentsview skills install`. The source tree has only a Go template; the
binary renders it per harness and adds a header recording a hash of the
body. The installer writes the result into the harness's own
configuration directory under `$HOME` and accepts no other destination.
home-manager, for one, fills those directories with read-only symlinks
into the store, so the installer cannot write there at all.

This renders the skill during `postInstall` with `HOME` set to a staging
directory and copies the result to
`$out/share/agentsview/skills/<harness>/`, so the file can be installed
like any other package output. The header is copied with the file, so
`agentsview skills list` reports an installed copy as `current` rather
than `foreign`.

The harnesses come from `agentsview skills list` rather than a hard-coded
list, so a harness added upstream needs no change here. The build fails
if that listing stops yielding paths.

Running the built binary is not a new requirement for this package: it
already does so for `versionCheckHook`.

## Testing

`nix fmt` reports no changes. `nix build .#agentsview` on
aarch64-darwin produces both variants:

```console
$ find result/share -type f
result/share/agentsview/skills/claude/agentsview-finding-history/SKILL.md
result/share/agentsview/skills/agents/agentsview-finding-history/SKILL.md

$ diff result/share/agentsview/skills/{claude,agents}/agentsview-finding-history/SKILL.md
2c2
< # generated-by: agentsview 0.41.1 hash:447be3b08cea96ff9beadc3ff0182bc0eddf527df6135d6cb51495dab29fed17 — do not edit; re-run `agentsview skills install`
---
> # generated-by: agentsview 0.41.1 hash:a7eb82c53ab771405a1e0d0f7adf74efb8222541fc26ca6699c02b441260f13c — do not edit; re-run `agentsview skills install`
15c15
< Dispatch a search subagent (e.g. the Task/Agent tool). The coordinator decides what evidence it wants, delegates
---
> Delegate to a search subagent if your harness supports one; otherwise run the bounded probes yourself in order. The coordinator decides what evidence it wants, delegates
```

I have not run `nix flake check`, which builds every package in the
repository.