### PR TITLE
herdr: install agent integration assets

### DIFF
--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -81,12 +81,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # sandbox.
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd herdr \
-      --bash <("$out/bin/herdr" completion bash) \
-      --fish <("$out/bin/herdr" completion fish) \
-      --zsh <("$out/bin/herdr" completion zsh)
-  '';
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd herdr \
+        --bash <("$out/bin/herdr" completion bash) \
+        --fish <("$out/bin/herdr" completion fish) \
+        --zsh <("$out/bin/herdr" completion zsh)
+    ''
+    + ''
+      install -d "$out/share/herdr"
+      cp -r --no-preserve=mode ${finalAttrs.src}/src/integration/assets "$out/share/herdr/integrations"
+      find "$out/share/herdr/integrations" -name '*.test.ts' -delete
+    '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [

--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -88,9 +88,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
         --fish <("$out/bin/herdr" completion fish) \
         --zsh <("$out/bin/herdr" completion zsh)
     ''
+    # Ship the per-agent hook/plugin sources so users can wire them up
+    # declaratively (e.g. home-manager) instead of running `herdr integrate`.
     + ''
       install -d "$out/share/herdr"
-      cp -r --no-preserve=mode ${finalAttrs.src}/src/integration/assets "$out/share/herdr/integrations"
+      cp -r src/integration/assets "$out/share/herdr/integrations"
       find "$out/share/herdr/integrations" -name '*.test.ts' -delete
     '';
 


### PR DESCRIPTION
## Summary

Copy Herdr's upstream integration assets from `src/integration/assets` to `$out/share/herdr/integrations`. Preserve the per-integration layout, include the Unix and Windows variants, and omit the TypeScript tests.

The package installs this tree:

```text
share/herdr/integrations/
├── antigravity_cli/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── claude/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── codex/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── copilot/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── cursor/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── devin/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── droid/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── grok/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── hermes/
│   ├── __init__.py
│   └── plugin.yaml
├── kilo/
│   └── herdr-agent-state.js
├── kimi/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── mastracode/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
├── omp/
│   └── herdr-agent-state.ts
├── opencode/
│   ├── herdr-agent-state.js
│   └── herdr-tui-session.js
├── pi/
│   └── herdr-agent-state.ts
├── qodercli/
│   ├── herdr-agent-state.ps1
│   └── herdr-agent-state.sh
└── qwen/
    ├── herdr-agent-session.ps1
    └── herdr-agent-session.sh
```

Consumers can select the hooks and plugins they need. For example, Home Manager can install the Claude hook directly from the package output:

```nix
home.file.".claude/hooks/herdr-agent-state.sh".source =
  "${pkgs.llm-agents.herdr}/share/herdr/integrations/claude/herdr-agent-state.sh";
```

The install phase only copies source files, so cross builds also include the integration assets without executing Herdr.

Package update handling is unchanged. The version and hashes remain inline in `package.nix`.

## Test plan

- [x] `nix fmt`
- [x] `nix build --accept-flake-config .#herdr`
- [x] Confirm the output contains 31 runtime assets and no `*.test.ts` files
- [x] Confirm every packaged asset is byte-identical to its upstream source
