### PR TITLE
oh-my-codex: refresh src hash after upstream retag of v0.20.5

### DIFF
--- a/packages/oh-my-codex/hashes.json
+++ b/packages/oh-my-codex/hashes.json
@@ -1,6 +1,6 @@
 {
   "version": "0.20.5",
-  "hash": "sha256-r2sj80vU3hBqbo5z6spy0ByYB2fvnFrgQwrb6MY8sdM=",
+  "hash": "sha256-k5K6cZ3eSSmxfyi2VaUGXNNNNFOIQwdP4GpNpR+Xksc=",
   "cargoHash": "sha256-4YFq9aBUS2ZsBQR04wRGKTSvmv/ZAgEr2PS3X3witVc=",
   "npmDepsHash": "sha256-LdTyiZuRIAzA4QdAKCXkyVX+N3kVft8XDdI6BWskHxM="
 }


### PR DESCRIPTION
## Problem

`packages/oh-my-codex/hashes.json` pins a source hash that no longer resolves:

```
error: hash mismatch in fixed-output derivation '/nix/store/4ph7535pqw4jbccdr83n3abi4fq380i8-source.drv':
  specified: sha256-r2sj80vU3hBqbo5z6spy0ByYB2fvnFrgQwrb6MY8sdM=
     got:    sha256-k5K6cZ3eSSmxfyi2VaUGXNNNNFOIQwdP4GpNpR+Xksc=
```

`Yeachan-Heo/oh-my-codex` re-pushed the `v0.20.5` tag after the bump in
1ef0359a landed, so the tarball behind
`archive/refs/tags/v0.20.5.tar.gz` now hashes differently.

CI was green on #7786 because the hash was correct at merge time, and nothing
re-validates a merged pin afterwards. The stale FOD output
(`fb1jc4r4nx9p7cz4ldyiawvvfb24h5wq-source`) is a 404 on both
`cache.numtide.com` and `cache.nixos.org`, so anyone evaluating fresh hits the
mismatch — it is not masked by a cache hit.

This breaks *evaluation*, not just the build, for downstreams that read out of
`oh-my-codex.src` (e.g. `templates/AGENTS.md`), so it takes the whole flake
down rather than just this package.

## Fix

Refresh `hash` to the current tag content. Only `hash` was stale —
`cargoHash` and `npmDepsHash` still match, so no other field changes.

## Verification

Built against the corrected hash on `x86_64-linux`:

```
/nix/store/36xic2n4kcia77608xh68vnisikgpzfx-oh-my-codex-0.20.5
```

Both the `rustPlatform` sub-builds (`omx-explore-harness`, `omx-sparkshell`)
and the `buildNpmPackage` output build clean, confirming the existing
`cargoHash`/`npmDepsHash` are still valid for the retagged source.

Same class as #4128 (zeroclaw retag) and #3449 (picoclaw retag).
