### PR TITLE
bb-app: build with Node 22 to fix host daemon crash

### DIFF
--- a/packages/bb-app/package.nix
+++ b/packages/bb-app/package.nix
@@ -6,7 +6,7 @@
   jq,
   lib,
   makeWrapper,
-  nodejs,
+  nodejs_22,
   python3,
   runCommand,
   stdenv,
@@ -32,6 +32,11 @@ let
   '';
 in
 buildNpmPackage {
+  # better-sqlite3's Statement destructor trips Node 24's
+  # RemoveEnvironmentCleanupHook assertion when the host daemon's worker
+  # thread shuts down, crashing `bb-app start`. Node 22 is unaffected and
+  # within upstream's supported engine range.
+  nodejs = nodejs_22;
   npmDepsFetcherVersion = 2;
   pname = "bb-app";
   inherit version;
@@ -90,7 +95,7 @@ buildNpmPackage {
 
     # The native modules rebuilt in preBuild must load with Nix's Node.js.
     export NODE_PATH=$out/lib/node_modules/bb-app/node_modules
-    ${lib.getExe nodejs} -e \
+    ${lib.getExe nodejs_22} -e \
       "require('@parcel/watcher'); require('better-sqlite3'); require('node-pty')"
 
     runHook postInstallCheck


### PR DESCRIPTION
better-sqlite3's `Statement` destructor trips Node 24's `RemoveEnvironmentCleanupHook` assertion (`(env) != nullptr`) when the host daemon's worker thread shuts down, so `bb-app start` crashed right after startup. Node 22 is unaffected and within upstream's supported engine range (`^22.19.0 || ^24.0.0 || ^26.0.0`).

Verified: built and ran `bb-app start` on x86_64-linux; server and host daemon now start and plugins load.

Fixes #8112
Follow-up investigation tracked in #8217