### PR TITLE
dsh: fix hardcoded /bin/bash in terminal backend

### DIFF
--- a/packages/dsh/package.nix
+++ b/packages/dsh/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  bashInteractive,
   buildNpmPackage,
   fetchurl,
   flake,
@@ -38,6 +39,11 @@ buildNpmPackage {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
+    # /bin/bash does not exist on NixOS (issue #8086)
+    substituteInPlace \
+      $out/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-terminal-bash/lib/index.js \
+      --replace-fail '"/bin/bash"' '"${lib.getExe bashInteractive}"'
+
     rm $out/bin/dsh
     makeWrapper ${lib.getExe nodejs} $out/bin/dsh \
       --argv0 dsh \


### PR DESCRIPTION
The bundled `dsh-terminal-bash` plugin defaults `shellPath` to `/bin/bash`, which does not exist on NixOS outside an FHS environment, so the bash tool was unusable. Substitute the store path of `bashInteractive` instead (the shell is started with `-i`).

This is the only `/bin/bash` reference in the shipped bundle that runs locally; the e2b subprocess paths execute inside remote E2B sandboxes.

Fixes #8086