### PR TITLE
prime-agent: 0.7.2 -> 0.8.1

### DIFF
--- a/packages/prime-agent/package-lock.json
+++ b/packages/prime-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prime-agent",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prime-agent",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "workspaces": [
         "packages/*",
         "packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
         "packages/coding-agent/examples/extensions/sandbox"
       ],
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.7.2",
+        "@earendil-works/pi-coding-agent": "^0.8.0",
         "get-east-asian-width": "^1.6.0"
       },
       "devDependencies": {
@@ -6165,10 +6165,10 @@
     },
     "packages/agent": {
       "name": "@earendil-works/pi-agent-core",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.7.2",
+        "@earendil-works/pi-ai": "^0.8.0",
         "typebox": "^1.3.9"
       },
       "devDependencies": {
@@ -6199,7 +6199,7 @@
     },
     "packages/ai": {
       "name": "@earendil-works/pi-ai",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
@@ -6245,14 +6245,14 @@
     },
     "packages/coding-agent": {
       "name": "@earendil-works/pi-coding-agent",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",
-        "@earendil-works/pi-agent-core": "^0.7.2",
-        "@earendil-works/pi-ai": "^0.7.2",
-        "@earendil-works/pi-tui": "^0.7.2",
+        "@earendil-works/pi-agent-core": "^0.8.0",
+        "@earendil-works/pi-ai": "^0.8.0",
+        "@earendil-works/pi-tui": "^0.8.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
@@ -6391,7 +6391,7 @@
     },
     "packages/tui": {
       "name": "@earendil-works/pi-tui",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^3.0.1",

--- a/packages/prime-agent/package-lock.json
+++ b/packages/prime-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prime-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prime-agent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "workspaces": [
         "packages/*",
         "packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
         "packages/coding-agent/examples/extensions/sandbox"
       ],
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.8.0",
+        "@earendil-works/pi-coding-agent": "^0.8.1",
         "get-east-asian-width": "^1.6.0"
       },
       "devDependencies": {
@@ -6165,10 +6165,10 @@
     },
     "packages/agent": {
       "name": "@earendil-works/pi-agent-core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.8.0",
+        "@earendil-works/pi-ai": "^0.8.1",
         "typebox": "^1.3.9"
       },
       "devDependencies": {
@@ -6199,7 +6199,7 @@
     },
     "packages/ai": {
       "name": "@earendil-works/pi-ai",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
@@ -6245,14 +6245,14 @@
     },
     "packages/coding-agent": {
       "name": "@earendil-works/pi-coding-agent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",
-        "@earendil-works/pi-agent-core": "^0.8.0",
-        "@earendil-works/pi-ai": "^0.8.0",
-        "@earendil-works/pi-tui": "^0.8.0",
+        "@earendil-works/pi-agent-core": "^0.8.1",
+        "@earendil-works/pi-ai": "^0.8.1",
+        "@earendil-works/pi-tui": "^0.8.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
@@ -6391,7 +6391,7 @@
     },
     "packages/tui": {
       "name": "@earendil-works/pi-tui",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^3.0.1",

--- a/packages/prime-agent/package.nix
+++ b/packages/prime-agent/package.nix
@@ -20,17 +20,17 @@
 buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   pname = "prime-agent";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "PrimeIntellect-ai";
     repo = "prime-agent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9XOGeZMjAWeoD1vo/4LkuKHNtBawGri/2kcKIZ99Xms=";
+    hash = "sha256-PdgkayPQ0Bmmr5ojnaXM6drbmB/p47cNvkwOmj93FGc=";
   };
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-DDRh4iMIQ8HGLVPdav2+4ONwxhlMt7kYCXE4h/OGhxQ=";
+  npmDepsHash = "sha256-kv4pZ6HS+2MZThcEcZce8o+I2ceTKAMYt4abhyRTnVs=";
 
   nativeBuildInputs = [
     makeWrapper

--- a/packages/prime-agent/package.nix
+++ b/packages/prime-agent/package.nix
@@ -17,20 +17,108 @@
   versionCheckHomeHook,
 }:
 
+let
+  # prime-agent-runtime 0.8.0 requires mcp>=2,<3 and nixpkgs still ships 1.29.0.
+  # Build the 2.0.0 SDK and its newly split-out mcp-types wire package from the
+  # one upstream tag, behind an overridden Python package set so the runtime,
+  # the bundled skills, and the kernel environment all resolve the same mcp.
+  # Drop this block once nixpkgs carries mcp 2.x.
+  mcpVersion = "2.0.0";
+
+  mcpSrc = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "python-sdk";
+    tag = "v${mcpVersion}";
+    hash = "sha256-baeceVB9PC+f3vQO1AaDHflOJ7oD7u7ylXUkVvusT/o=";
+  };
+
+  python = python3.override {
+    self = python;
+    packageOverrides = final: prev: {
+      mcp-types = prev.buildPythonPackage {
+        pname = "mcp-types";
+        version = mcpVersion;
+        pyproject = true;
+        src = "${mcpSrc}/src/mcp-types";
+
+        # uv-dynamic-versioning reads the version out of git history, which a
+        # source archive does not carry.
+        env.UV_DYNAMIC_VERSIONING_BYPASS = mcpVersion;
+
+        build-system = [
+          prev.hatchling
+          prev.uv-dynamic-versioning
+        ];
+
+        dependencies = [
+          prev.pydantic
+          prev.typing-extensions
+        ];
+
+        pythonImportsCheck = [ "mcp_types" ];
+      };
+
+      mcp = prev.mcp.overridePythonAttrs (old: {
+        version = mcpVersion;
+        src = mcpSrc;
+
+        env = (old.env or { }) // {
+          UV_DYNAMIC_VERSIONING_BYPASS = mcpVersion;
+        };
+
+        # The 1.x darwin flake patch targets a test file 2.0.0 no longer ships.
+        postPatch = "";
+
+        # 2.0.0 dropped pydantic-settings, httpx and httpx-sse for httpx2, and
+        # split its wire types into mcp-types.
+        pythonRelaxDeps = [ ];
+        dependencies = [
+          prev.anyio
+          prev.httpx2
+          prev.jsonschema
+          prev.opentelemetry-api
+          prev.pydantic
+          prev.pyjwt
+          prev.python-multipart
+          prev.sse-starlette
+          prev.starlette
+          prev.typing-extensions
+          prev.typing-inspection
+          prev.uvicorn
+          final.mcp-types
+        ];
+
+        optional-dependencies = {
+          cli = [
+            prev.python-dotenv
+            prev.typer
+          ];
+          rich = [ prev.rich ];
+        };
+
+        # The 1.x disabledTests list is written against a suite 2.0.0 reorganized.
+        doCheck = false;
+        nativeCheckInputs = [ ];
+        disabledTests = [ ];
+      });
+    };
+  };
+in
+
 buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   pname = "prime-agent";
-  version = "0.7.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "PrimeIntellect-ai";
     repo = "prime-agent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rOKFkKoV2Mfg2wHioZ+2Eo3Js6C4489hxTxVu38cgbA=";
+    hash = "sha256-9XOGeZMjAWeoD1vo/4LkuKHNtBawGri/2kcKIZ99Xms=";
   };
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-/pu+a4hlTOCde1qwxTQ4WLVwJEVmojl9B1DBbjoxwRs=";
+  npmDepsHash = "sha256-DDRh4iMIQ8HGLVPdav2+4ONwxhlMt7kYCXE4h/OGhxQ=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -103,14 +191,15 @@ buildNpmPackage (finalAttrs: {
   passthru = {
     category = "AI Coding Agents";
 
-    primeAgentRuntime = python3.pkgs.buildPythonPackage {
+    primeAgentRuntime = python.pkgs.buildPythonPackage {
       pname = "prime-agent-runtime";
       version = "0.1.0";
       src = "${finalAttrs.src}/prime-agent-runtime";
       pyproject = true;
-      build-system = [ python3.pkgs.hatchling ];
-      dependencies = with python3.pkgs; [
+      build-system = [ python.pkgs.hatchling ];
+      dependencies = with python.pkgs; [
         ipykernel
+        mcp
         nest-asyncio
         tyro
       ];
@@ -125,11 +214,11 @@ buildNpmPackage (finalAttrs: {
             pname ? directory,
             dependencies ? [ ],
           }:
-          python3.pkgs.buildPythonPackage {
+          python.pkgs.buildPythonPackage {
             inherit pname version dependencies;
             src = "${finalAttrs.src}/packages/coding-agent/skills/${directory}";
             pyproject = true;
-            build-system = [ python3.pkgs.hatchling ];
+            build-system = [ python.pkgs.hatchling ];
           };
         runtime = finalAttrs.passthru.primeAgentRuntime;
       in
@@ -148,7 +237,7 @@ buildNpmPackage (finalAttrs: {
           directory = "attach-image";
           version = "0.1.0";
           pname = "prime-agent-skill-attach-image";
-          dependencies = with python3.pkgs; [
+          dependencies = with python.pkgs; [
             pillow
             runtime
           ];
@@ -169,7 +258,7 @@ buildNpmPackage (finalAttrs: {
           directory = "linear";
           version = "0.1.0";
           pname = "prime-agent-skill-linear";
-          dependencies = with python3.pkgs; [
+          dependencies = with python.pkgs; [
             httpx
             mcp
             runtime
@@ -179,7 +268,7 @@ buildNpmPackage (finalAttrs: {
           directory = "notion";
           version = "0.1.0";
           pname = "prime-agent-skill-notion";
-          dependencies = with python3.pkgs; [
+          dependencies = with python.pkgs; [
             httpx
             mcp
             runtime
@@ -197,14 +286,14 @@ buildNpmPackage (finalAttrs: {
           directory = "websearch";
           version = "0.1.0";
           pname = "prime-agent-skill-websearch";
-          dependencies = with python3.pkgs; [
+          dependencies = with python.pkgs; [
             httpx
             runtime
           ];
         })
       ];
 
-    pythonRuntime = python3.withPackages (
+    pythonRuntime = python.withPackages (
       ps:
       (with ps; [
         beautifulsoup4

--- a/packages/prime-agent/package.nix
+++ b/packages/prime-agent/package.nix
@@ -17,94 +17,6 @@
   versionCheckHomeHook,
 }:
 
-let
-  # prime-agent-runtime 0.8.0 requires mcp>=2,<3 and nixpkgs still ships 1.29.0.
-  # Build the 2.0.0 SDK and its newly split-out mcp-types wire package from the
-  # one upstream tag, behind an overridden Python package set so the runtime,
-  # the bundled skills, and the kernel environment all resolve the same mcp.
-  # Drop this block once nixpkgs carries mcp 2.x.
-  mcpVersion = "2.0.0";
-
-  mcpSrc = fetchFromGitHub {
-    owner = "modelcontextprotocol";
-    repo = "python-sdk";
-    tag = "v${mcpVersion}";
-    hash = "sha256-baeceVB9PC+f3vQO1AaDHflOJ7oD7u7ylXUkVvusT/o=";
-  };
-
-  python = python3.override {
-    self = python;
-    packageOverrides = final: prev: {
-      mcp-types = prev.buildPythonPackage {
-        pname = "mcp-types";
-        version = mcpVersion;
-        pyproject = true;
-        src = "${mcpSrc}/src/mcp-types";
-
-        # uv-dynamic-versioning reads the version out of git history, which a
-        # source archive does not carry.
-        env.UV_DYNAMIC_VERSIONING_BYPASS = mcpVersion;
-
-        build-system = [
-          prev.hatchling
-          prev.uv-dynamic-versioning
-        ];
-
-        dependencies = [
-          prev.pydantic
-          prev.typing-extensions
-        ];
-
-        pythonImportsCheck = [ "mcp_types" ];
-      };
-
-      mcp = prev.mcp.overridePythonAttrs (old: {
-        version = mcpVersion;
-        src = mcpSrc;
-
-        env = (old.env or { }) // {
-          UV_DYNAMIC_VERSIONING_BYPASS = mcpVersion;
-        };
-
-        # The 1.x darwin flake patch targets a test file 2.0.0 no longer ships.
-        postPatch = "";
-
-        # 2.0.0 dropped pydantic-settings, httpx and httpx-sse for httpx2, and
-        # split its wire types into mcp-types.
-        pythonRelaxDeps = [ ];
-        dependencies = [
-          prev.anyio
-          prev.httpx2
-          prev.jsonschema
-          prev.opentelemetry-api
-          prev.pydantic
-          prev.pyjwt
-          prev.python-multipart
-          prev.sse-starlette
-          prev.starlette
-          prev.typing-extensions
-          prev.typing-inspection
-          prev.uvicorn
-          final.mcp-types
-        ];
-
-        optional-dependencies = {
-          cli = [
-            prev.python-dotenv
-            prev.typer
-          ];
-          rich = [ prev.rich ];
-        };
-
-        # The 1.x disabledTests list is written against a suite 2.0.0 reorganized.
-        doCheck = false;
-        nativeCheckInputs = [ ];
-        disabledTests = [ ];
-      });
-    };
-  };
-in
-
 buildNpmPackage (finalAttrs: {
   npmDepsFetcherVersion = 2;
   pname = "prime-agent";
@@ -191,18 +103,20 @@ buildNpmPackage (finalAttrs: {
   passthru = {
     category = "AI Coding Agents";
 
-    primeAgentRuntime = python.pkgs.buildPythonPackage {
+    primeAgentRuntime = python3.pkgs.buildPythonPackage {
       pname = "prime-agent-runtime";
       version = "0.1.0";
       src = "${finalAttrs.src}/prime-agent-runtime";
       pyproject = true;
-      build-system = [ python.pkgs.hatchling ];
-      dependencies = with python.pkgs; [
+      build-system = [ python3.pkgs.hatchling ];
+      dependencies = with python3.pkgs; [
         ipykernel
         mcp
         nest-asyncio
         tyro
       ];
+      # Pins mcp>=2 but rlm/mcp_base.py explicitly supports the 1.x client API.
+      pythonRelaxDeps = [ "mcp" ];
     };
 
     pythonSkills =
@@ -214,11 +128,11 @@ buildNpmPackage (finalAttrs: {
             pname ? directory,
             dependencies ? [ ],
           }:
-          python.pkgs.buildPythonPackage {
+          python3.pkgs.buildPythonPackage {
             inherit pname version dependencies;
             src = "${finalAttrs.src}/packages/coding-agent/skills/${directory}";
             pyproject = true;
-            build-system = [ python.pkgs.hatchling ];
+            build-system = [ python3.pkgs.hatchling ];
           };
         runtime = finalAttrs.passthru.primeAgentRuntime;
       in
@@ -237,7 +151,7 @@ buildNpmPackage (finalAttrs: {
           directory = "attach-image";
           version = "0.1.0";
           pname = "prime-agent-skill-attach-image";
-          dependencies = with python.pkgs; [
+          dependencies = with python3.pkgs; [
             pillow
             runtime
           ];
@@ -258,7 +172,7 @@ buildNpmPackage (finalAttrs: {
           directory = "linear";
           version = "0.1.0";
           pname = "prime-agent-skill-linear";
-          dependencies = with python.pkgs; [
+          dependencies = with python3.pkgs; [
             httpx
             mcp
             runtime
@@ -268,7 +182,7 @@ buildNpmPackage (finalAttrs: {
           directory = "notion";
           version = "0.1.0";
           pname = "prime-agent-skill-notion";
-          dependencies = with python.pkgs; [
+          dependencies = with python3.pkgs; [
             httpx
             mcp
             runtime
@@ -286,14 +200,14 @@ buildNpmPackage (finalAttrs: {
           directory = "websearch";
           version = "0.1.0";
           pname = "prime-agent-skill-websearch";
-          dependencies = with python.pkgs; [
+          dependencies = with python3.pkgs; [
             httpx
             runtime
           ];
         })
       ];
 
-    pythonRuntime = python.withPackages (
+    pythonRuntime = python3.withPackages (
       ps:
       (with ps; [
         beautifulsoup4


### PR DESCRIPTION
## Summary

Updates prime-agent to [v0.8.0](https://github.com/PrimeIntellect-ai/prime-agent/releases/tag/v0.8.0). The generated npm lockfile metadata, source hash, and npm dependency hash are refreshed.

0.8.0 also moves the MCP client into `prime-agent-runtime`, which now requires `mcp>=2,<3`. nixpkgs still ships mcp 1.29.0, so the runtime fails `pythonRuntimeDepsCheck` with `mcp not installed`. This PR therefore also builds mcp 2.0.0 and its newly split-out `mcp-types` wire package from the one upstream `modelcontextprotocol/python-sdk` tag, behind a `python3.override` so the runtime, the bundled Python skills, and the kernel environment all resolve the same mcp.

Notes on the override:

- 2.0.0 swaps `httpx`/`httpx-sse` for `httpx2` and drops `pydantic-settings`; nixpkgs already carries `httpx2`, `opentelemetry-api` and `typing-inspection`, so only `mcp-types` needed packaging.
- `uv-dynamic-versioning` reads the version from git history, so `UV_DYNAMIC_VERSIONING_BYPASS` is set for both derivations.
- The 2.0.0 test suite was reorganized, so the 1.x `disabledTests` list no longer applies and checks are disabled for the override.
- The whole block is commented for removal once nixpkgs carries mcp 2.x.

## Test plan

- [x] `nix build .#prime-agent --no-link --print-out-paths`
- [x] `nix run .#prime-agent -- --version` reports `0.8.0`
- [x] Kernel env reports `mcp 2.0.0` / `mcp-types 2.0.0`, and `import rlm`, `from mcp import ClientSession, StdioServerParameters`, `mcp.client.stdio`, `mcp.client.streamable_http` all resolve
- [x] `postInstallCheck` imports every bundled skill (`linear`, `notion`, `websearch`, `attach_image`, `rlm`, …) against that env
- [x] Dogfooded through a `home-manager switch` using the fork branch; installed `prime-agent --version` reports `0.8.0`
- [x] Package update generated with `packages/prime-agent/update.py`
- [x] `nix fmt` clean

Release: https://github.com/PrimeIntellect-ai/prime-agent/releases/tag/v0.8.0
