### PR TITLE
git-ai: ignore prerelease tags in auto-update

### DIFF
--- a/packages/git-ai/nix-update-args
+++ b/packages/git-ai/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$


### PR DESCRIPTION
## Summary

add `nix-update-args` so nix-updater follows stable release tags. 

#8225

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
