### PR TITLE
herdr: point notify-send at libnotify store path

### DIFF
--- a/packages/herdr/package.nix
+++ b/packages/herdr/package.nix
@@ -8,6 +8,7 @@
   xcbuild,
   cctools,
   installShellFiles,
+  libnotify,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -67,6 +68,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '.arg("build")' '.arg("build")
           .arg("-Dcpu=baseline")' \
       --replace-fail '.arg(format!("-Dtarget={zig_target}"))' ""
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace src/platform/linux.rs \
+      --replace-fail 'let mut cmd = command("notify-send");' \
+        'let mut cmd = command("${libnotify}/bin/notify-send");'
   '';
 
   preBuild = ''


### PR DESCRIPTION
## Summary

Currently, you need `notify-send` available in your `$PATH` for `ui.toast.delivery = "system"` to work. This change points it to the `libnotify` store path instead.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work