### PR TITLE
chatgpt: bundle primary runtime dependencies

### DIFF
--- a/checks/chatgpt-packaging.nix
+++ b/checks/chatgpt-packaging.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+  flake,
+  system,
+}:
+
+let
+  chatgpt = flake.packages.${system}.chatgpt or null;
+  chatgptWithPrimaryRuntime =
+    if chatgpt != null then
+      chatgpt.override {
+        withPrimaryRuntime = true;
+      }
+    else
+      null;
+in
+assert
+  chatgpt == null
+  || (
+    !chatgpt.withPrimaryRuntime
+    && chatgpt.primaryRuntime == null
+    && chatgpt.runtimePython == null
+    && (
+      system != "x86_64-linux"
+      || (
+        chatgptWithPrimaryRuntime.withPrimaryRuntime
+        && chatgptWithPrimaryRuntime.primaryRuntime != null
+        && chatgptWithPrimaryRuntime.runtimePython != null
+        && chatgptWithPrimaryRuntime.drvPath != chatgpt.drvPath
+      )
+    )
+  );
+pkgs.runCommand "chatgpt-packaging-check" { } ''
+  touch $out
+''

--- a/packages/chatgpt/hashes.json
+++ b/packages/chatgpt/hashes.json
@@ -10,5 +10,14 @@
       "url": "https://persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.818.31338_amd64.deb",
       "hash": "sha256-Q4J4SKdHJLVyvn+NyVRpirLMCRb3+dWZGg7oKJlE+Vs="
     }
+  },
+  "runtimeSources": {
+    "x86_64-linux": {
+      "version": "26.819.11345",
+      "pythonVersion": "3.12.13",
+      "nodeVersion": "v24.19.0",
+      "url": "https://persistent.oaistatic.com/codex-primary-runtime/26.819.11345/codex-primary-runtime-linux-x64-26.819.11345.tar.xz",
+      "hash": "sha256-XBJSS/Y2yX1pJrz0gtb78X4e9ZM1+lTopTruaJggSq8="
+    }
   }
 }

--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -3,7 +3,13 @@
   callPackage,
   stdenvNoCC,
   makeShellWrapper,
+  nodejs_24,
   chatgpt-unwrapped ? callPackage ./unwrapped.nix { },
+  chatgpt-runtime-python ?
+    if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
+      callPackage ./runtime-python.nix { }
+    else
+      null,
   commandLineArgs ? "",
 }:
 
@@ -20,6 +26,12 @@ stdenvNoCC.mkDerivation {
 
     mkdir -p "$out/bin"
     makeShellWrapper ${chatgpt-unwrapped}/bin/chatgpt "$out/bin/chatgpt" \
+      --set CODEX_MCP_NODE_PATH ${lib.getExe nodejs_24} \
+      ${
+        lib.optionalString (
+          chatgpt-runtime-python != null
+        ) "--set PYTHON ${lib.getExe chatgpt-runtime-python}"
+      } \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
     ln -s ${chatgpt-unwrapped}/share "$out/share"
@@ -29,6 +41,7 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     category = "AI Coding Agents";
+    runtimePython = chatgpt-runtime-python;
     unwrapped = chatgpt-unwrapped;
   };
 

--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -3,7 +3,8 @@
   callPackage,
   stdenvNoCC,
   makeShellWrapper,
-  nodejs_24,
+  nodejs,
+  bubblewrap,
   chatgpt-unwrapped ? callPackage ./unwrapped.nix { },
   chatgpt-runtime-python ?
     if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
@@ -26,7 +27,13 @@ stdenvNoCC.mkDerivation {
 
     mkdir -p "$out/bin"
     makeShellWrapper ${chatgpt-unwrapped}/bin/chatgpt "$out/bin/chatgpt" \
-      --set CODEX_MCP_NODE_PATH ${lib.getExe nodejs_24} \
+      --set CODEX_MCP_NODE_PATH ${lib.getExe nodejs} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bubblewrap
+          nodejs
+        ]
+      } \
       ${
         lib.optionalString (
           chatgpt-runtime-python != null

--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -6,9 +6,14 @@
   nodejs,
   bubblewrap,
   chatgpt-unwrapped ? callPackage ./unwrapped.nix { },
-  chatgpt-runtime-python ?
-    if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
-      callPackage ./runtime-python.nix { }
+  # Keep proprietary runtime contents out of the default package and CI closure.
+  withPrimaryRuntime ? false,
+  chatgpt-runtime-python ? if withPrimaryRuntime then callPackage ./runtime-python.nix { } else null,
+  chatgpt-primary-runtime ?
+    if withPrimaryRuntime then
+      callPackage ./runtime.nix {
+        inherit chatgpt-runtime-python;
+      }
     else
       null,
   commandLineArgs ? "",
@@ -39,6 +44,11 @@ stdenvNoCC.mkDerivation {
           chatgpt-runtime-python != null
         ) "--set PYTHON ${lib.getExe chatgpt-runtime-python}"
       } \
+      ${
+        lib.optionalString (
+          chatgpt-primary-runtime != null
+        ) "--set CODEX_PRIMARY_RUNTIME_PATH ${chatgpt-primary-runtime}"
+      } \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
     ln -s ${chatgpt-unwrapped}/share "$out/share"
@@ -48,8 +58,10 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     category = "AI Coding Agents";
+    primaryRuntime = chatgpt-primary-runtime;
     runtimePython = chatgpt-runtime-python;
     unwrapped = chatgpt-unwrapped;
+    inherit withPrimaryRuntime;
   };
 
   inherit (chatgpt-unwrapped) meta;

--- a/packages/chatgpt/patch-asar.py
+++ b/packages/chatgpt/patch-asar.py
@@ -5,6 +5,7 @@ The asar header records file offsets, so every replacement is padded with
 spaces to the original's exact byte length instead of re-packing the archive.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -24,17 +25,106 @@ COPY_PLUGINS_WRITABLE = (
     b'async function Kne(e,t){let r=S.default.platform;if(r===`darwin`){await Cne(`/usr/bin/ditto`,[`--noqtn`,e,t]);return}if(r!==`win32`){await Cne(`cp`,[`-r`,e+`/.`,t]);await Cne(`chmod`,[`-R`,`u+w`,t]);return}let{copyDirectoryAllowDecryptedDestinationOnEncryptionFailure:n}=await Promise.resolve().then(()=>require("./windows-file-copy-Bw9CB6bJ.js"));await n({copy:()=>y.default.cp(e,t,{recursive:!0,verbatimSymlinks:!0}),destination:t,source:e})}',
 )
 
+# Resolve the immutable primary runtime facade directly. The compact fallbacks
+# preserve the normal Linux cache location when the opt-in wrapper variable is
+# absent; Windows-only framework-path handling is irrelevant to this package.
+PRIMARY_RUNTIME_ROOTS = (
+    (
+        b"function FR(e){return e==null&&IL!=null?IL:i.default.join(e??i.default.join(r.default.homedir(),`.cache`,`codex-runtimes`),jL)}",
+        b"function FR(e){return process.env.CODEX_PRIMARY_RUNTIME_PATH||(e||r.default.homedir()+`/.cache/codex-runtimes`)+`/`+jL}",
+    ),
+    (
+        b"function jY(e){return e==null&&DY!=null?DY:E.default.join(e??E.default.join(T.default.homedir(),`.cache`,`codex-runtimes`),EY)}",
+        b"function jY(e){return process.env.CODEX_PRIMARY_RUNTIME_PATH||(e||T.default.homedir()+`/.cache/codex-runtimes`)+`/`+EY}",
+    ),
+)
+
+PRIMARY_RUNTIME_STATUS = re.compile(
+    rb"async function iR\(.*?(?=async function aR\()",
+    re.DOTALL,
+)
+
+PRIMARY_RUNTIME_INSTALL = re.compile(
+    rb"async function sR\(.*?(?=async function cR\()",
+    re.DOTALL,
+)
+
+PRIMARY_RUNTIME_STATUS_WRAPPER = (
+    b"async function iR(e){let t=process.env.CODEX_PRIMARY_RUNTIME_PATH;"
+    b"if(t){let e=(await NR(t))?.bundleVersion??null;return{desiredBundleVersion:e,"
+    b"installedBundleVersion:e,status:e?`current`:`missing`}}return iR0(e)}"
+)
+
+PRIMARY_RUNTIME_INSTALL_WRAPPER = (
+    b"async function sR(e,t,n=`latest`,r={}){let i=process.env."
+    b"CODEX_PRIMARY_RUNTIME_PATH;if(i){let t=await HR(i);return{bundleVersion:"
+    b"t.bundleVersion??null,paths:await BR({bundleFormatVersion:"
+    b"t.bundleFormatVersion??1,runtimeRoot:i,targetPlatform:yR(e.platform)}),"
+    b"status:`already-current`}}return cR(e,t,n,r)}"
+)
+
+
+def replace_exact(
+    data: bytes, original: bytes, replacement: bytes, label: str
+) -> bytes:
+    """Replace one exact pattern without changing the archive length."""
+    count = data.count(original)
+    if count != 1:
+        sys.exit(f"expected one {label} pattern, found {count}")
+    if len(replacement) > len(original):
+        sys.exit(f"replacement longer than original for {label}")
+    return data.replace(original, replacement.ljust(len(original), b" "))
+
+
+def replace_regex(
+    data: bytes,
+    pattern: re.Pattern[bytes],
+    replacement: bytes,
+    label: str,
+) -> bytes:
+    """Replace one regex match without changing the archive length."""
+    matches = list(pattern.finditer(data))
+    if len(matches) != 1:
+        sys.exit(f"expected one {label} function, found {len(matches)}")
+    match = matches[0]
+    if len(replacement) > len(match.group()):
+        sys.exit(f"replacement longer than original for {label}")
+    padded = replacement.ljust(len(match.group()), b" ")
+    return data[: match.start()] + padded + data[match.end() :]
+
 
 def main() -> None:
     """Patch the asar archive given as the only argument."""
     asar = Path(sys.argv[1])
     data = asar.read_bytes()
     for original, replacement in (SKIP_PROCESS_REPORT, COPY_PLUGINS_WRITABLE):
-        if len(replacement) > len(original):
-            sys.exit(f"replacement longer than original: {replacement[:60]!r}...")
-        if original not in data:
-            sys.exit(f"pattern not found in {asar}: {original[:60]!r}...")
-        data = data.replace(original, replacement.ljust(len(original), b" "))
+        data = replace_exact(data, original, replacement, repr(original[:40]))
+
+    for original, replacement in PRIMARY_RUNTIME_ROOTS:
+        data = replace_exact(data, original, replacement, "primary-runtime root")
+
+    status_match = PRIMARY_RUNTIME_STATUS.search(data)
+    if status_match is None:
+        sys.exit("primary-runtime status function not found")
+    renamed_status = (
+        status_match.group()
+        .replace(b"async function iR(", b"async function iR0(", 1)
+        .replace(b"preferWindowsFramework:o=!1", b"preferWindowsFramework:o=0", 1)
+    )
+    if len(renamed_status) != len(status_match.group()):
+        sys.exit("renamed primary-runtime status function changed byte length")
+    data = replace_regex(
+        data,
+        PRIMARY_RUNTIME_STATUS,
+        renamed_status,
+        "primary-runtime status",
+    )
+    data = replace_regex(
+        data,
+        PRIMARY_RUNTIME_INSTALL,
+        PRIMARY_RUNTIME_STATUS_WRAPPER + PRIMARY_RUNTIME_INSTALL_WRAPPER,
+        "primary-runtime installer",
+    )
     asar.write_bytes(data)
 
 

--- a/packages/chatgpt/runtime-python.nix
+++ b/packages/chatgpt/runtime-python.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchurl,
+  libxcrypt-legacy,
+  makeWrapper,
+  wrapBuddy,
+  zlib,
+}:
+
+let
+  sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  platform = stdenv.hostPlatform.system;
+  source =
+    sourceData.runtimeSources.${platform}
+      or (throw "Unsupported ChatGPT primary runtime platform: ${platform}");
+  runtimeLibraryPath = lib.makeLibraryPath [
+    libxcrypt-legacy
+    zlib
+    stdenv.cc.cc.lib
+  ];
+in
+stdenv.mkDerivation {
+  pname = "chatgpt-primary-runtime-python";
+  inherit (source) version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  sourceRoot = "codex-primary-runtime/dependencies/python";
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapBuddy
+  ];
+
+  buildInputs = [
+    libxcrypt-legacy
+    zlib
+    stdenv.cc.cc.lib
+  ];
+
+  # The runtime contains a Bun executable whose embedded payload is corrupted by
+  # patchelf and strip. wrapBuddy supplies a compatible ELF loader without
+  # modifying the executable itself.
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -a . "$out/"
+
+    # Upstream's archive contains absolute symlinks into its temporary assembly
+    # directory. Retarget them to the immutable runtime installed here.
+    while IFS= read -r -d "" link; do
+      target="$(readlink "$link")"
+      case "$target" in
+        /tmp/codex-primary-runtime-*/python-download/python/*)
+          relative="''${target#*/python-download/python/}"
+          ln -sfn "$out/$relative" "$link"
+          ;;
+        *)
+          echo "unexpected dangling symlink in primary runtime: $link -> $target" >&2
+          exit 1
+          ;;
+      esac
+    done < <(find "$out" -xtype l -print0)
+
+    # This malformed linker stub is unused by the bundled interpreter and
+    # extensions; libpython3.12.so is the functional development symlink.
+    rm "$out/lib/libpython3.so"
+
+    wrapProgram "$out/bin/python3.12" \
+      --prefix LD_LIBRARY_PATH : "$out/lib:${runtimeLibraryPath}"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/python3" - <<'PY'
+    import sys
+    from pathlib import Path
+
+    assert sys.version.startswith("${source.pythonVersion}")
+
+    import artifact_tool_v2
+    import cryptography
+    import lxml.etree
+    import numpy
+    import pandas
+    import PIL.Image
+    import pydantic_core
+    import pypdfium2
+    import reportlab
+
+    from artifact_tool_v2.rpc.daemon import start_daemon
+
+    socket_path = start_daemon()
+    assert Path(socket_path).exists()
+    PY
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "Python environment bundled with ChatGPT's primary workspace runtime";
+    homepage = "https://chatgpt.com";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames sourceData.runtimeSources;
+    mainProgram = "python3";
+  };
+}

--- a/packages/chatgpt/runtime-python.nix
+++ b/packages/chatgpt/runtime-python.nix
@@ -2,80 +2,75 @@
   lib,
   flake,
   stdenv,
-  fetchurl,
+  stdenvNoCC,
+  callPackage,
   libxcrypt-legacy,
   makeWrapper,
+  python312,
   wrapBuddy,
   zlib,
+  chatgpt-runtime-source ? callPackage ./runtime-source.nix { },
 }:
 
 let
-  sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  platform = stdenv.hostPlatform.system;
-  source =
-    sourceData.runtimeSources.${platform}
-      or (throw "Unsupported ChatGPT primary runtime platform: ${platform}");
+  runtimeMetadata = chatgpt-runtime-source.runtimeMetadata;
   runtimeLibraryPath = lib.makeLibraryPath [
     libxcrypt-legacy
     zlib
     stdenv.cc.cc.lib
   ];
+
+  runtimePythonPackages = python312.pkgs.toPythonModule (
+    stdenv.mkDerivation {
+      pname = "chatgpt-primary-runtime-python-packages";
+      inherit (runtimeMetadata) version;
+
+      src = chatgpt-runtime-source;
+      sourceRoot = "codex-primary-runtime/dependencies/python/${python312.sitePackages}";
+
+      nativeBuildInputs = [ wrapBuddy ];
+      buildInputs = [
+        libxcrypt-legacy
+        zlib
+        stdenv.cc.cc.lib
+      ];
+
+      # The module tree contains a Bun executable whose embedded payload is
+      # corrupted by patchelf and strip. wrapBuddy supplies a compatible ELF
+      # loader without modifying the executable itself.
+      dontPatchELF = true;
+      dontStrip = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p "$out/${python312.sitePackages}"
+        cp -a . "$out/${python312.sitePackages}/"
+
+        runHook postInstall
+      '';
+    }
+  );
+
+  pythonEnvironment = python312.withPackages (_: [ runtimePythonPackages ]);
 in
-stdenv.mkDerivation {
+assert
+  lib.versions.majorMinor python312.version == lib.versions.majorMinor runtimeMetadata.pythonVersion;
+stdenvNoCC.mkDerivation {
   pname = "chatgpt-primary-runtime-python";
-  inherit (source) version;
+  inherit (runtimeMetadata) version;
 
-  src = fetchurl {
-    inherit (source) url hash;
-  };
-
-  sourceRoot = "codex-primary-runtime/dependencies/python";
-
-  nativeBuildInputs = [
-    makeWrapper
-    wrapBuddy
-  ];
-
-  buildInputs = [
-    libxcrypt-legacy
-    zlib
-    stdenv.cc.cc.lib
-  ];
-
-  # The runtime contains a Bun executable whose embedded payload is corrupted by
-  # patchelf and strip. wrapBuddy supplies a compatible ELF loader without
-  # modifying the executable itself.
-  dontPatchELF = true;
-  dontStrip = true;
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out"
-    cp -a . "$out/"
-
-    # Upstream's archive contains absolute symlinks into its temporary assembly
-    # directory. Retarget them to the immutable runtime installed here.
-    while IFS= read -r -d "" link; do
-      target="$(readlink "$link")"
-      case "$target" in
-        /tmp/codex-primary-runtime-*/python-download/python/*)
-          relative="''${target#*/python-download/python/}"
-          ln -sfn "$out/$relative" "$link"
-          ;;
-        *)
-          echo "unexpected dangling symlink in primary runtime: $link -> $target" >&2
-          exit 1
-          ;;
-      esac
-    done < <(find "$out" -xtype l -print0)
-
-    # This malformed linker stub is unused by the bundled interpreter and
-    # extensions; libpython3.12.so is the functional development symlink.
-    rm "$out/lib/libpython3.so"
-
-    wrapProgram "$out/bin/python3.12" \
-      --prefix LD_LIBRARY_PATH : "$out/lib:${runtimeLibraryPath}"
+    mkdir -p "$out/bin"
+    makeWrapper ${pythonEnvironment}/bin/python3 "$out/bin/python3" \
+      --prefix LD_LIBRARY_PATH : ${lib.escapeShellArg runtimeLibraryPath}
+    ln -s python3 "$out/bin/python"
+    ln -s python3 "$out/bin/python3.12"
 
     runHook postInstall
   '';
@@ -84,11 +79,11 @@ stdenv.mkDerivation {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    "$out/bin/python3" - <<'PY'
+    HOME="$TMPDIR" "$out/bin/python3" - <<'PY'
     import sys
     from pathlib import Path
 
-    assert sys.version.startswith("${source.pythonVersion}")
+    assert sys.version.startswith("${lib.versions.majorMinor runtimeMetadata.pythonVersion}")
 
     import artifact_tool_v2
     import cryptography
@@ -109,12 +104,20 @@ stdenv.mkDerivation {
     runHook postInstallCheck
   '';
 
+  allowSubstitutes = false;
+  preferLocalBuild = true;
+
+  passthru = {
+    inherit pythonEnvironment runtimePythonPackages;
+    runtimeSource = chatgpt-runtime-source;
+  };
+
   meta = with lib; {
-    description = "Python environment bundled with ChatGPT's primary workspace runtime";
+    description = "Python environment for ChatGPT's primary workspace runtime";
     homepage = "https://chatgpt.com";
     license = flake.lib.licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = builtins.attrNames sourceData.runtimeSources;
+    platforms = chatgpt-runtime-source.meta.platforms;
     mainProgram = "python3";
   };
 }

--- a/packages/chatgpt/runtime-source.nix
+++ b/packages/chatgpt/runtime-source.nix
@@ -1,0 +1,34 @@
+{
+  flake,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  platform = stdenv.hostPlatform.system;
+  runtimeMetadata =
+    sourceData.runtimeSources.${platform}
+      or (throw "Unsupported ChatGPT primary runtime platform: ${platform}");
+in
+(fetchurl {
+  name = baseNameOf runtimeMetadata.url;
+  inherit (runtimeMetadata) url hash;
+}).overrideAttrs
+  {
+    # The archive contains non-redistributable modules. It is reachable only from
+    # the explicit opt-in runtime graph and is always fetched locally.
+    allowSubstitutes = false;
+    preferLocalBuild = true;
+
+    passthru = {
+      inherit runtimeMetadata;
+    };
+
+    meta = {
+      homepage = "https://chatgpt.com";
+      license = flake.lib.licenses.unfree;
+      sourceProvenance = with flake.lib.sourceTypes; [ binaryNativeCode ];
+      platforms = builtins.attrNames sourceData.runtimeSources;
+    };
+  }

--- a/packages/chatgpt/runtime.nix
+++ b/packages/chatgpt/runtime.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  flake,
+  stdenvNoCC,
+  callPackage,
+  git,
+  jxrlib,
+  libheif,
+  libreoffice,
+  nodejs,
+  pnpm_11,
+  poppler-utils,
+  chatgpt-runtime-source ? callPackage ./runtime-source.nix { },
+  chatgpt-runtime-python ? callPackage ./runtime-python.nix {
+    inherit chatgpt-runtime-source;
+  },
+}:
+
+let
+  runtimeMetadata = chatgpt-runtime-source.runtimeMetadata;
+in
+assert runtimeMetadata.nodeVersion == "v${nodejs.version}";
+stdenvNoCC.mkDerivation {
+  pname = "chatgpt-primary-runtime";
+  inherit (runtimeMetadata) version;
+
+  src = chatgpt-runtime-source;
+  sourceRoot = "codex-primary-runtime";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p \
+      "$out/dependencies/bin/fallback" \
+      "$out/dependencies/bin/override" \
+      "$out/dependencies/node/bin" \
+      "$out/dependencies/python/bin"
+
+    cp runtime.json "$out/runtime.json"
+    cp -a plugins "$out/plugins"
+    cp -a dependencies/node/node_modules "$out/dependencies/node/node_modules"
+
+    ln -s ${lib.getExe nodejs} "$out/dependencies/node/bin/node"
+
+    ln -s ${lib.getExe chatgpt-runtime-python} "$out/dependencies/python/bin/python3"
+    ln -s python3 "$out/dependencies/python/bin/python"
+    ln -s ${chatgpt-runtime-python.runtimePythonPackages}/lib "$out/dependencies/python/lib"
+
+    ln -s ${lib.getExe' jxrlib "JxrDecApp"} "$out/dependencies/bin/override/JxrDecApp"
+    ln -s ${lib.getExe' libheif "heif-dec"} "$out/dependencies/bin/override/heif-convert"
+    ln -s ${lib.getExe' poppler-utils "pdfinfo"} "$out/dependencies/bin/override/pdfinfo"
+    ln -s ${lib.getExe' poppler-utils "pdftoppm"} "$out/dependencies/bin/override/pdftoppm"
+    ln -s ${lib.getExe' libreoffice "libreoffice"} "$out/dependencies/bin/override/soffice"
+
+    ln -s ${lib.getExe git} "$out/dependencies/bin/fallback/git"
+    ln -s ${lib.getExe pnpm_11} "$out/dependencies/bin/fallback/pnpm"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    test -x "$out/dependencies/node/bin/node"
+    test -x "$out/dependencies/python/bin/python3"
+    test -x "$out/dependencies/bin/override/JxrDecApp"
+    test -x "$out/dependencies/bin/override/heif-convert"
+    test -x "$out/dependencies/bin/override/pdfinfo"
+    test -x "$out/dependencies/bin/override/pdftoppm"
+    test -x "$out/dependencies/bin/override/soffice"
+    test -x "$out/dependencies/bin/fallback/git"
+    test -x "$out/dependencies/bin/fallback/pnpm"
+    test -d "$out/plugins/openai-primary-runtime"
+    test ! -e "$out/dependencies/native"
+
+    RUNTIME_ROOT="$out" \
+      NODE_PATH="$out/dependencies/node/node_modules" \
+      "$out/dependencies/node/bin/node" - <<'JS'
+    const assert = require("node:assert");
+    const metadata = require(process.env.RUNTIME_ROOT + "/runtime.json");
+
+    assert.equal(metadata.bundleVersion, "${runtimeMetadata.version}");
+    assert.equal(metadata.bundleFormatVersion, 2);
+    assert.equal(process.version, metadata.nodeVersion);
+
+    for (const moduleName of [
+      "@oai/artifact-tool",
+      "sharp",
+      "@napi-rs/canvas",
+    ]) {
+      require(moduleName);
+    }
+
+    require(
+      process.env.RUNTIME_ROOT
+        + "/dependencies/node/node_modules/@oai/artifact-tool/node_modules/skia-canvas",
+    );
+    JS
+
+    runHook postInstallCheck
+  '';
+
+  allowSubstitutes = false;
+  preferLocalBuild = true;
+
+  passthru = {
+    python = chatgpt-runtime-python;
+    runtimeSource = chatgpt-runtime-source;
+  };
+
+  meta = with lib; {
+    description = "Nix-compatible ChatGPT primary workspace runtime";
+    homepage = "https://chatgpt.com";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    platforms = chatgpt-runtime-source.meta.platforms;
+  };
+}

--- a/packages/chatgpt/update.py
+++ b/packages/chatgpt/update.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#gnupg nixpkgs#python3 --command python3
-"""Update ChatGPT from OpenAI's signed Debian repository."""
+"""Update ChatGPT and its primary runtime from OpenAI's distribution servers."""
 
 import hashlib
+import json
 import subprocess
 import sys
 import tempfile
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -24,19 +26,30 @@ PLATFORMS = {
     "aarch64-linux": "arm64",
     "x86_64-linux": "amd64",
 }
+RUNTIME_MANIFESTS = {
+    "x86_64-linux": (
+        "https://persistent.oaistatic.com/"
+        "codex-primary-runtime/latest/linux-x64/LATEST.json"
+    ),
+}
 USER_AGENT = (
     "llm-agents.nix package updater (+https://github.com/numtide/llm-agents.nix)"
 )
 
 
-def fetch(path: str) -> bytes:
-    """Fetch one path from OpenAI's Debian repository."""
+def fetch_url(url: str) -> bytes:
+    """Fetch one OpenAI URL."""
     request = urllib.request.Request(
-        f"{REPO_BASE}/{path}",
+        url,
         headers={"User-Agent": USER_AGENT},
     )
     with urllib.request.urlopen(request) as response:
         return bytes(response.read())
+
+
+def fetch(path: str) -> bytes:
+    """Fetch one path from OpenAI's Debian repository."""
+    return fetch_url(f"{REPO_BASE}/{path}")
 
 
 def verify_inrelease(inrelease: bytes) -> str:
@@ -178,12 +191,77 @@ def source_from_index(platform: str, architecture: str, release: str) -> dict[st
     }
 
 
+def runtime_source(platform: str, manifest_url: str) -> dict[str, str]:
+    """Return the primary runtime source described by OpenAI's latest manifest."""
+    manifest = json.loads(fetch_url(manifest_url))
+    required_fields = (
+        "archiveSha256",
+        "archiveUrl",
+        "bundleVersion",
+        "format",
+        "nodeVersion",
+        "pythonVersion",
+        "runtimeRootDirectoryName",
+        "targetArch",
+        "targetPlatform",
+    )
+    missing_fields = [field for field in required_fields if field not in manifest]
+    if missing_fields:
+        msg = (
+            f"primary runtime ({platform}) missing fields: {', '.join(missing_fields)}"
+        )
+        raise ValueError(msg)
+
+    expected_architecture = {"x86_64-linux": "x64"}[platform]
+    if (
+        manifest["targetPlatform"] != "linux"
+        or manifest["targetArch"] != expected_architecture
+    ):
+        msg = (
+            f"primary runtime ({platform}) target mismatch: "
+            f"{manifest['targetPlatform']}-{manifest['targetArch']}"
+        )
+        raise ValueError(msg)
+    if manifest["runtimeRootDirectoryName"] != "codex-primary-runtime":
+        msg = f"unexpected primary runtime root for {platform}"
+        raise ValueError(msg)
+    if manifest["format"] != "tar.xz":
+        msg = f"unexpected primary runtime format for {platform}: {manifest['format']}"
+        raise ValueError(msg)
+
+    archive_url = manifest["archiveUrl"]
+    parsed_url = urllib.parse.urlparse(archive_url)
+    if (
+        parsed_url.scheme != "https"
+        or parsed_url.hostname != "persistent.oaistatic.com"
+    ):
+        msg = f"unsafe primary runtime URL for {platform}: {archive_url}"
+        raise ValueError(msg)
+
+    archive_hash = manifest["archiveSha256"]
+    if len(bytes.fromhex(archive_hash)) != hashlib.sha256().digest_size:
+        msg = f"invalid primary runtime SHA256 for {platform}"
+        raise ValueError(msg)
+
+    return {
+        "version": manifest["bundleVersion"],
+        "pythonVersion": manifest["pythonVersion"],
+        "nodeVersion": manifest["nodeVersion"],
+        "url": archive_url,
+        "hash": hex_to_sri(archive_hash),
+    }
+
+
 def main() -> None:
-    """Refresh all sources from OpenAI's signed APT metadata."""
+    """Refresh the desktop package and primary runtime sources."""
     release = verify_inrelease(fetch(INRELEASE_PATH))
     sources = {
         platform: source_from_index(platform, architecture, release)
         for platform, architecture in PLATFORMS.items()
+    }
+    runtime_sources = {
+        platform: runtime_source(platform, manifest_url)
+        for platform, manifest_url in RUNTIME_MANIFESTS.items()
     }
 
     versions = {source["version"] for source in sources.values()}
@@ -206,12 +284,35 @@ def main() -> None:
             )
             raise ValueError(msg)
 
-    if current_sources == sources:
+    current_runtime_sources = current.get("runtimeSources", {})
+    for platform, source in runtime_sources.items():
+        current_version = current_runtime_sources.get(platform, {}).get("version", "")
+        if (
+            current_version
+            and source["version"] != current_version
+            and not should_update(current_version, source["version"])
+        ):
+            msg = (
+                f"refusing to downgrade {platform} primary runtime from "
+                f"{current_version} to {source['version']}"
+            )
+            raise ValueError(msg)
+
+    if current_sources == sources and current_runtime_sources == runtime_sources:
         print("chatgpt: already up to date")
         return
 
-    save_hashes(HASHES_FILE, {"sources": sources})
-    print(f"chatgpt: updated to {versions.pop()}")
+    save_hashes(
+        HASHES_FILE,
+        {
+            "sources": sources,
+            "runtimeSources": runtime_sources,
+        },
+    )
+    print(
+        f"chatgpt: updated to {versions.pop()} "
+        f"(primary runtime {runtime_sources['x86_64-linux']['version']})"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

### Problem

This is primarily related (at least the way I faced it) to Codex Security, both tab and plugin.

First, `codex-security` plugin ships with its MCP, which fails to start with message:
```
MCP client for `codex-security` failed to start: MCP startup failed: handshaking with MCP server failed: connection closed: initialize response
```
Logs (usually in `$CODEX_HOME/logs_2.sqlite`) reveal the true cause:
```
MCP server stderr (./scripts/launch_codex_security_mcp): Could not start dynamically linked executable: <$XDG_CACHE_HOME>/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node NixOS cannot run dynamically linked executables intended for generic linux environments out of the box.
```

Secondly, the same problem appears, when one opens Security tab in Codex (in the ChatGPT desktop app):
```
Could not start dynamically linked executable: <$XDG_CACHE_HOME>/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 NixOS cannot run dynamically linked executables intended for generic linux environments out of the box.
```

### Things done

It seems a good idea to simply bundle `codex-primary-runtime`. The downloader is `usr/lib/chatgpt/resources/app.asar`. It fetches: `https://persistent.oaistatic.com/codex-primary-runtime/latest/linux-x64/LATEST.json`.

`codex-security` already supports the solution cleanly:
- `plugins/cache/openai-curated-remote/codex-security/0.1.21/.mcp.json` forwards PYTHON.
- Its bundled server resolves `process.env.PYTHON` before falling back to `~/.cache/codex-runtimes/.../python3`.

No `app.asar` patch is needed for this particular failure. The package structure is:
1. Add a `codex-primary-runtime-python` derivation.
2. Extend `packages/chatgpt/update.py` and `packages/chatgpt/hashes.json` with the runtime version, URL, and hash.
3. Extract only `codex-primary-runtime/dependencies/python`.
4. Patch it with `wrapBuddy`, not `formatelf`, because `artifact_tool_v2` contains a Bun-compiled daemon.
5. Wrap ChatGPT with:
```sh
--set PYTHON ${codex-primary-runtime-python}/bin/python3
--set CODEX_MCP_NODE_PATH ${nodejs}/bin/node
```
The upstream Python archive also has malformed absolute symlinks into its build-time `/tmp` directory and an unused malformed `libpython3.so` ABI stub. Those need deterministic cleanup during installation.

 I verified:
- Python 3.12.13 starts normally.
- NumPy, pandas, lxml, Pillow, cryptography, pydantic, PDFium, ReportLab, Tkinter, and artifact_tool_v2 import successfully.
- The proprietary artifact RPC daemon starts and creates its Unix socket.
- The Bun payload tail remains byte-for-byte identical after wrapBuddy.
- AArch64 package evaluation; it remains without the Python override because OpenAI currently publishes no Linux ARM64 runtime manifest.

One limitation: this fixes `codex-security` and other components honoring `PYTHON`. ChatGPT’s general `load_workspace_dependencies` mechanism will still advertise the downloaded cache runtime, including its other generic Linux binaries. Packaging and redirecting the entire runtime would be a broader follow-up.


## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
