### PR TITLE
fx: use github releases for updates

### DIFF
--- a/packages/fx/nix-update-args
+++ b/packages/fx/nix-update-args
@@ -1,0 +1,1 @@
+--use-github-releases


### PR DESCRIPTION
I noticed that `fx` was stuck on an older version when I wanted to try it out today.
Seems that upstream accidentally published a v0.4.5 that we're stuck on, rather than the latest v0.0.5.
This adds `--use-github-releases` to `nix-update`, so updates will use the latest published release.

After this, the next scheduled update should properly get it set to v0.0.5.