### PR TITLE
ori: init at 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>ori</strong> - OpenRouter CLI for managing agent environments across coding tools</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://openrouter.ai/labs/ori
+- **Usage**: `nix run github:numtide/llm-agents.nix#ori -- --help`
+- **Nix**: [packages/ori/package.nix](packages/ori/package.nix)
+
+</details>
+<details>
 <summary><strong>pi</strong> - A terminal-based coding agent with multi-model support</summary>
 
 - **Source**: bytecode

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -244,6 +244,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 8401799;
         name = "Lukáš Hozda";
       };
+      shzhng = {
+        github = "shzhng";
+        githubId = 8622519;
+        name = "Shuo Zheng";
+      };
     };
   }
 )

--- a/packages/ori/hashes.json
+++ b/packages/ori/hashes.json
@@ -1,0 +1,13 @@
+{
+  "version": "cli-0.10.2-d7b2684",
+  "urls": {
+    "x86_64-linux": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-linux-x64",
+    "aarch64-linux": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-linux-arm64",
+    "aarch64-darwin": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-darwin-arm64"
+  },
+  "hashes": {
+    "x86_64-linux": "sha256-UjhP+/EdAHRjmk3kvLt00BYIe7MSqqys/kg5v0rI6is=",
+    "aarch64-linux": "sha256-I5/IR1sIdaNGzUCXWW0jVdHfmowdCplnQEtSxLxaeCY=",
+    "aarch64-darwin": "sha256-uSHqohd7UMJYcG+7LTo3i+DDinqQIeWtSvMJVzGX9X8="
+  }
+}

--- a/packages/ori/hashes.json
+++ b/packages/ori/hashes.json
@@ -1,10 +1,5 @@
 {
-  "version": "cli-0.10.2-d7b2684",
-  "urls": {
-    "x86_64-linux": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-linux-x64",
-    "aarch64-linux": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-linux-arm64",
-    "aarch64-darwin": "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-0.10.2-d7b2684/ori-darwin-arm64"
-  },
+  "version": "0.10.2-d7b2684",
   "hashes": {
     "x86_64-linux": "sha256-UjhP+/EdAHRjmk3kvLt00BYIe7MSqqys/kg5v0rI6is=",
     "aarch64-linux": "sha256-I5/IR1sIdaNGzUCXWW0jVdHfmowdCplnQEtSxLxaeCY=",

--- a/packages/ori/hashes.json
+++ b/packages/ori/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.10.2-d7b2684",
+  "version": "0.11.0-fe98906",
   "hashes": {
-    "x86_64-linux": "sha256-UjhP+/EdAHRjmk3kvLt00BYIe7MSqqys/kg5v0rI6is=",
-    "aarch64-linux": "sha256-I5/IR1sIdaNGzUCXWW0jVdHfmowdCplnQEtSxLxaeCY=",
-    "aarch64-darwin": "sha256-uSHqohd7UMJYcG+7LTo3i+DDinqQIeWtSvMJVzGX9X8="
+    "aarch64-linux": "sha256-asFbcSDJk+5ytv/IYLiRqBYLtldTszYtNrSKPdk629A=",
+    "aarch64-darwin": "sha256-m9j2lH/BmM5FKjwci/87DTDLmzWzRr2jl935YLDuVZg=",
+    "x86_64-linux": "sha256-VgbmRxfzQ8eHt7EoNra9KvEeAxowNDzqZ/jusJwEPdc="
   }
 }

--- a/packages/ori/package.nix
+++ b/packages/ori/package.nix
@@ -5,6 +5,7 @@
   mkUpdater,
   platformSource,
   wrapBuddy,
+  makeBinaryWrapper,
 }:
 
 let
@@ -25,11 +26,15 @@ stdenv.mkDerivation {
   dontUnpack = true;
   dontStrip = true;
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
 
   installPhase = ''
     runHook preInstall
     install -Dm755 $src $out/bin/ori
+    wrapProgram $out/bin/ori --set-default ORI_TELEMETRY 0
     runHook postInstall
   '';
 

--- a/packages/ori/package.nix
+++ b/packages/ori/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  flake,
+  stdenv,
+  mkUpdater,
+  platformSource,
+}:
+
+let
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    };
+    urlTemplate = "https://github.com/OpenRouterLabs/ori-releases/releases/download/{version}/ori-{platform}";
+  };
+in
+stdenv.mkDerivation {
+  pname = "ori";
+  inherit (source) version src;
+
+  dontUnpack = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/ori
+    runHook postInstall
+  '';
+
+  passthru.category = "AI Coding Agents";
+  passthru.updater = mkUpdater (
+    source.updater
+    // {
+      versionSource = {
+        type = "github";
+        owner = "OpenRouterLabs";
+        repo = "ori-releases";
+      };
+    }
+  );
+
+  meta = with lib; {
+    description = "OpenRouter CLI for managing agent environments across coding tools";
+    homepage = "https://openrouter.ai/labs/ori";
+    changelog = "https://github.com/OpenRouterLabs/ori-releases/releases";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ shzhng ];
+    mainProgram = "ori";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/packages/ori/package.nix
+++ b/packages/ori/package.nix
@@ -4,6 +4,7 @@
   stdenv,
   mkUpdater,
   platformSource,
+  wrapBuddy,
 }:
 
 let
@@ -14,7 +15,7 @@ let
       aarch64-linux = "linux-arm64";
       aarch64-darwin = "darwin-arm64";
     };
-    urlTemplate = "https://github.com/OpenRouterLabs/ori-releases/releases/download/{version}/ori-{platform}";
+    urlTemplate = "https://github.com/OpenRouterLabs/ori-releases/releases/download/cli-{version}/ori-{platform}";
   };
 in
 stdenv.mkDerivation {
@@ -24,20 +25,37 @@ stdenv.mkDerivation {
   dontUnpack = true;
   dontStrip = true;
 
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
   installPhase = ''
     runHook preInstall
     install -Dm755 $src $out/bin/ori
     runHook postInstall
   '';
 
+  doInstallCheck = true;
+  # ori prints the build hash with '+' (0.10.2+d7b2684) while the release tag
+  # spells it with '-', so the stock versionCheckHook grep can never match.
+  installCheckPhase = ''
+    runHook preInstallCheck
+    HOME=$(mktemp -d) $out/bin/ori --version | grep -F "${
+      lib.replaceStrings [ "-" ] [ "+" ] source.version
+    }"
+    runHook postInstallCheck
+  '';
+
   passthru.category = "AI Coding Agents";
   passthru.updater = mkUpdater (
     source.updater
     // {
+      # Release tags are 'cli-<semver>-<hash>'; capture past the constant
+      # prefix so stored versions stay numerically comparable (the raw tag
+      # falls back to lexicographic ordering, which wedges at 0.10.9 -> 0.10.10
+      # and permits downgrades).
       versionSource = {
-        type = "github";
-        owner = "OpenRouterLabs";
-        repo = "ori-releases";
+        type = "text";
+        url = "https://api.github.com/repos/OpenRouterLabs/ori-releases/releases/latest";
+        regex = "\"tag_name\": *\"cli-([^\"]+)\"";
       };
     }
   );
@@ -45,15 +63,11 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "OpenRouter CLI for managing agent environments across coding tools";
     homepage = "https://openrouter.ai/labs/ori";
-    changelog = "https://github.com/OpenRouterLabs/ori-releases/releases";
+    changelog = "https://github.com/OpenRouterLabs/ori-releases/releases/tag/cli-${source.version}";
     license = flake.lib.licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with flake.lib.maintainers; [ shzhng ];
     mainProgram = "ori";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
+    platforms = source.platforms;
   };
 }


### PR DESCRIPTION
## Summary

Adds [OpenRouterLabs/ori-releases](https://github.com/OpenRouterLabs/ori-releases) at 0.11.0 — the OpenRouter CLI for managing agent environments across coding tools (env setup, API key management, agent CLI wrapping). Category: **AI Coding Agents**.

Packaged as a prebuilt binary via `platformSource`, with per-platform SHA256 hashes pinned in `hashes.json` for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.

- `sourceProvenance = [ binaryNativeCode ]`
- `license = unfree` (via the repo's free-unfree alias)
- Maintainer: `shzhng` (added to `lib/default.nix`)
- README regenerated with `./scripts/generate-package-docs.nu`
- Linux binaries get their ELF loader patched via `wrapBuddy`
- Telemetry is off by default (`wrapProgram --set-default ORI_TELEMETRY 0`), overridable by the user
- Declarative `passthru.updater` (`kind = "platform"`): release tags are `cli-<semver>-<hash>`, so the version source captures past the constant `cli-` prefix (`"tag_name": *"cli-([^"]+)"`), keeping stored versions numerically comparable (the raw tag would order lexicographically, wedging at `0.10.9 -> 0.10.10` and permitting downgrades). The `urlTemplate` re-adds the prefix (`.../download/cli-{version}/...`).
- Version check: `ori --version` reports the build hash with `+` (`0.11.0+fe98906`) while the tag spells it with `-`, so `installCheckPhase` greps for the `+` form explicitly instead of using the stock `versionCheckHook`.

## Test plan

- [x] `nix build .#packages.aarch64-darwin.ori` succeeds
- [x] `./result/bin/ori --version` reports `0.11.0+fe98906` (verified by the derivation's `installCheckPhase`)
- [x] `nix build .#checks.aarch64-darwin.pkgs-ori` passes
- [x] Declarative updater verified end-to-end: `scripts/updater` ran the `passthru.updater` config to bump 0.10.2 → 0.11.0 and refresh all three platform hashes
