### PR TITLE
hermes-agent: bundle ddgs web_search backend

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -315,6 +315,8 @@ let
       boto3
       # [modal]
       modal
+      # web_search backend hermes would otherwise try to pip-install (#8259)
+      ddgs
     ];
   };
 


### PR DESCRIPTION
hermes tries to pip-install it at runtime, which cannot work here.
Closes #8259.
