### PR TITLE
chatgpt: patch downloaded codex runtime for NixOS at launch

### DIFF
--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -1,12 +1,39 @@
 {
   lib,
+  stdenv,
   callPackage,
   stdenvNoCC,
   makeShellWrapper,
+  replaceVars,
+  formatelf,
+  inotify-tools,
+  curl,
+  libxcrypt-legacy,
+  nspr,
+  nss,
+  zlib,
   chatgpt-unwrapped ? callPackage ./unwrapped.nix { },
   commandLineArgs ? "",
 }:
 
+let
+  # Libraries the downloaded codex-primary-runtime expects from the host.
+  runtimeLibs = [
+    stdenv.cc.cc.lib
+    zlib
+    libxcrypt-legacy
+    curl
+    nss
+    nspr
+  ];
+  patchRuntime = replaceVars ./patch-runtime.sh {
+    autoFormatelf = "${formatelf.bin}/bin/auto-formatelf";
+    inotifywait = "${inotify-tools}/bin/inotifywait";
+    dynamicLinker = "${stdenv.cc.bintools}/nix-support/dynamic-linker";
+    libc = "${stdenv.cc.libc}/lib";
+    libs = lib.concatMapStringsSep " " (p: "${lib.getLib p}/lib") runtimeLibs;
+  };
+in
 stdenvNoCC.mkDerivation {
   pname = "chatgpt";
   inherit (chatgpt-unwrapped) version;
@@ -20,6 +47,7 @@ stdenvNoCC.mkDerivation {
 
     mkdir -p "$out/bin"
     makeShellWrapper ${chatgpt-unwrapped}/bin/chatgpt "$out/bin/chatgpt" \
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--run '. ${patchRuntime}' --set-default DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1"} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
     ln -s ${chatgpt-unwrapped}/share "$out/share"
@@ -30,6 +58,7 @@ stdenvNoCC.mkDerivation {
   passthru = {
     category = "AI Coding Agents";
     unwrapped = chatgpt-unwrapped;
+    inherit patchRuntime;
   };
 
   inherit (chatgpt-unwrapped) meta;

--- a/packages/chatgpt/patch-runtime.sh
+++ b/packages/chatgpt/patch-runtime.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=bash
+# Sourced by the chatgpt wrapper on Linux. The app downloads a generic-linux
+# "codex-primary-runtime" (python, node, git, libreoffice, ...) into
+# ~/.cache/codex-runtimes and execs binaries from it. Rewrite their ELF
+# interpreter/RPATH in place whenever the bundle changes so they run on NixOS.
+
+chatgpt_patch_runtimes() {
+  local root="$HOME/.cache/codex-runtimes" dir stamp want interp
+  interp=$(<@dynamicLinker@)
+  for dir in "$root"/*/; do
+    [[ -f "$dir/runtime.json" ]] || continue
+    # Re-patch when either the bundle or our toolchain (store paths) changed.
+    want=$(
+      cat "$dir/runtime.json"
+      echo "$interp @libs@"
+    )
+    stamp="$dir/.nix-patched"
+    [[ -f $stamp && "$(<"$stamp")" == "$want" ]] && continue
+    echo "chatgpt: patching $dir for NixOS" >&2
+    # libpython3.so carries a bogus $ORIGIN NEEDED entry. The bundled fallback
+    # git wants Debian's libcurl-gnutls ABI; the app prefers git from PATH.
+    # shellcheck disable=SC2016
+    @autoFormatelf@ -j 0 \
+      --interpreter "$interp" --libc @libc@ \
+      --paths "$dir" --libs @libs@ \
+      --ignore-missing '$ORIGIN/*' 'libcurl-gnutls.so.4' >&2 || continue
+    printf '%s' "$want" >"$stamp"
+  done
+}
+
+# The installer extracts into a staging dir and rename()s it into place, so a
+# moved_to event on the parent is the signal that a new runtime has landed.
+if [[ -n ${HOME:-} ]]; then
+  mkdir -p "$HOME/.cache/codex-runtimes"
+  chatgpt_patch_runtimes
+  app_pid=$$
+  (
+    while kill -0 "$app_pid" 2>/dev/null; do
+      @inotifywait@ -qq -t 60 -e moved_to "$HOME/.cache/codex-runtimes" || continue
+      chatgpt_patch_runtimes
+    done
+  ) &
+  unset app_pid
+fi

--- a/packages/formatelf/package.nix
+++ b/packages/formatelf/package.nix
@@ -52,6 +52,8 @@ let
       stdenv.cc.bintools
     ];
     passthru.hideFromDocs = true;
+    # Standalone binary for patching ELFs outside a build (e.g. at runtime).
+    passthru.bin = formatelf;
     meta = {
       description = "Setup hook that patches ELF binaries via formatelf";
       license = lib.licenses.mit;


### PR DESCRIPTION
Alternative to #8340.

The ChatGPT app downloads a generic-linux `codex-primary-runtime` (Python 3.12 + site-packages, Node, LibreOffice headless, poppler, libheif, git) into `~/.cache/codex-runtimes` and execs binaries from it. On NixOS these fail to start.

Rather than vendoring the ~1 GB proprietary bundle as a derivation and patching four more minified functions in `app.asar`, the wrapper now sources a small script that runs `auto-formatelf` (our autoPatchelf replacement) over the cache directory. It rewrites interpreter/RPATH in place against glibc, libstdc++, zlib, libxcrypt-legacy, curl, nss/nspr. A stamp file keyed on `runtime.json` + the store paths makes it a ~10 ms no-op after the first ~1 s run, and re-triggers when OpenAI ships a new runtime or nixpkgs bumps. A short-lived background loop catches the initial download during the first session.

Tested against runtime 26.819.11345: python (numpy, lxml, pydantic-core), node, soffice, pdftoppm, heif-convert and git-credential-manager all run. Known gap: the bundled *fallback* git's HTTP helpers want Debian's `libcurl-gnutls.so.4` (`CURL_GNUTLS_3`), which nixpkgs does not provide; the app prefers git from `PATH` anyway.

No asar changes, nothing redistributed, survives minifier renames.

Also exposes `formatelf.bin` for use outside build hooks.