### PR TITLE
hax: init at 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>hax</strong> - Minimalist, terminal-native coding agent written in C</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://usehax.dev
+- **Usage**: `nix run github:numtide/llm-agents.nix#hax -- --help`
+- **Nix**: [packages/hax/package.nix](packages/hax/package.nix)
+
+</details>
+<details>
 <summary><strong>jules</strong> - Jules, the asynchronous coding agent from Google, in the terminal</summary>
 
 - **Source**: binary

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -249,6 +249,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 8622519;
         name = "Shuo Zheng";
       };
+      vidhanio = {
+        github = "vidhanio";
+        githubId = 41439633;
+        name = "Vidhan Bhatt";
+      };
     };
   }
 )

--- a/packages/hax/package.nix
+++ b/packages/hax/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  curl,
+  jansson,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hax";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "OleksandrChekhovskyi";
+    repo = "hax";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/eX2l+BtjcmKsFM/w353i9iUPV+GOp1ZGBU06phNQ2o=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    jansson
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Minimalist, terminal-native coding agent written in C";
+    homepage = "https://usehax.dev";
+    changelog = "https://github.com/OleksandrChekhovskyi/hax/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ vidhanio ];
+    mainProgram = "hax";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Summary

adds hax 0.4.0.

## Test plan

- [x] `nix build .#hax` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update does not work