### PR TITLE
opencode2: follow npm beta channel

### DIFF
--- a/packages/opencode2/hashes.json
+++ b/packages/opencode2/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.0.0-next-17444",
+  "version": "0.0.0-beta-18684",
   "hashes": {
-    "aarch64-darwin": "sha256-kJEZ6dwUayg4qfbGPB1kBX03hqLMpjh/saHcodMRYzs=",
-    "x86_64-linux": "sha256-54iGtij74Sck19YItCjrww8PHPhBPrMbHt2d4FZzms8=",
-    "aarch64-linux": "sha256-u9m94vtXFmSu5bKcZ3HdbRD9Xlmo7bXtJ3N/8vVSviU="
+    "aarch64-darwin": "sha256-FEhbtAKyo1tdxqLC/1N+tQ9re96MOd35zzGryup5jso=",
+    "aarch64-linux": "sha256-YPImGIn6g5D9KWpRMXq4216vq5AzChScchl7ivnzm1I=",
+    "x86_64-linux": "sha256-/b/gLxUZ6t5mailCZrgqycio6vly4x+J4nbIPNqqgFk="
   }
 }

--- a/packages/opencode2/package.nix
+++ b/packages/opencode2/package.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  # OpenCode 2 ships as platform-specific Bun executables on npm's next channel
+  # OpenCode 2 ships as platform-specific Bun executables on npm's beta channel
   # (@opencode-ai/cli-<platform>).
   source = platformSource {
     hashesFile = ./hashes.json;
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
       versionSource = {
         type = "npm";
         package = "@opencode-ai/cli";
-        tag = "next";
+        tag = "beta";
       };
     }
   );


### PR DESCRIPTION
upstream retired the \`next\` dist-tag as the moving v2 preview channel in august (anomalyco/opencode@9e22c40ff and follow-ups); \`beta\` is the successor, and \`next\` is now frozen at a hand repoint to 0.0.0-beta-17823.

that left opencode2 stuck at 0.0.0-next-17444: every \`0.0.0-beta-*\` sorts below \`0.0.0-next-17444\` in the updater's comparator (equal numeric parts, then prerelease suffix lexically), so the updater declines every beta as an apparent downgrade — a tag flip alone never lands.

- versionSource tag next -> beta
- versionPolicy = "follow_pointer" so channel resets that sort lower aren't skipped. this also wires allow_downgrade through the platform flow, which previously ignored versionPolicy (only manifest-checksums honored it), so the flag isn't a silent no-op here
- hashes.json reseeded to the current beta 0.0.0-beta-18269 via \`nix run .#opencode2.updateScript\`