### PR TITLE
go-bin: enable auto update; 1.26.5 -> 1.26.7

### DIFF
--- a/packages/go-bin/hashes.json
+++ b/packages/go-bin/hashes.json
@@ -1,9 +1,9 @@
 {
-  "version": "1.26.5",
+  "version": "1.26.7",
   "hashes": {
-    "darwin-amd64": "sha256-YjHY07j1VS7Gy/bWhb3VSC4ecDIUsSDomzvw178e9yU=",
-    "darwin-arm64": "sha256-77h/8or5oYjQU2711C5j3VK6gmPNc0Spk8xI3RHe22o=",
-    "linux-amd64": "sha256-XCw7FsrvodloqUwdrKBKfKMBpJbZsIbhetd7uBOT8FM=",
-    "linux-arm64": "sha256-/keJ6SsfMzWGgIZLvocEKJ57tfwgfYBiPDCJNb1pbUk="
+    "darwin-amd64": "sha256-kuizS/88iasWQExZVmmsjLAEzC9nbcvR9bh6a43vO0c=",
+    "darwin-arm64": "sha256-AgoegiSBG+dRY+kgvHfgkmoTkKau6hm9zyP3S510n20=",
+    "linux-amd64": "sha256-/7X43hDGJVDf3atms2tXAwch4KRKMhjp4Rgde1nxIco=",
+    "linux-arm64": "sha256-Wk7IgzedUe6c4QQNXof4014gOHV03YyUf+sB6rw8Gzc="
   }
 }

--- a/packages/go-bin/package.nix
+++ b/packages/go-bin/package.nix
@@ -35,7 +35,10 @@ stdenv.mkDerivation {
   inherit (stdenv.hostPlatform.go) GOOS GOARCH;
   CGO_ENABLED = 1;
 
-  passthru.hideFromDocs = true;
+  passthru = {
+    hideFromDocs = true;
+    updateEvenIfHidden = true;
+  };
 
   meta = {
     description = "Latest Go toolchain (prebuilt binary) for building packages that need a newer patch release than nixpkgs ships";


### PR DESCRIPTION
## Summary

- Enable auto update for `go-bin`
- Update 1.26.5 -> 1.26.7

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
