### PR TITLE
feat(tgrab): add package at 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,6 +1596,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>tgrab</strong> - Fetch text content from YouTube, Twitter/X, and Bluesky</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/ryoppippi/tgrab
+- **Usage**: `nix run github:numtide/llm-agents.nix#tgrab -- --help`
+- **Nix**: [packages/tgrab/package.nix](packages/tgrab/package.nix)
+
+</details>
+<details>
 <summary><strong>toon</strong> - Rust implementation of TOON - Token-Oriented Object Notation for LLM prompts</summary>
 
 - **Source**: source

--- a/packages/tgrab/package.nix
+++ b/packages/tgrab/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  flake,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tgrab";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ryoppippi";
+    repo = "tgrab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QXLHZ0HztxUcANgzGlQ8Wg9nOnTB7Lk8cCBVH6f5a8E=";
+  };
+
+  cargoHash = "sha256-9/wVARIR2nsiNotxFifYkzbVf8P2oAxz13jx86DAVrk=";
+
+  env.RUSTFLAGS = "--cfg reqwest_unstable";
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/tgrab --help > /dev/null
+    runHook postInstallCheck
+  '';
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "Fetch text content from YouTube, Twitter/X, and Bluesky";
+    homepage = "https://github.com/ryoppippi/tgrab";
+    changelog = "https://github.com/ryoppippi/tgrab/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ ryoppippi ];
+    mainProgram = "tgrab";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
## Summary

Add tgrab v0.1.0 as a source-built Rust package. The package includes the compiler flag required by its reqwest HTTP/3 dependency, an install-time help smoke test, and generated README catalogue metadata.

## Test plan

- [x] `nix build --accept-flake-config .#tgrab --no-link`
- [x] `nix run --accept-flake-config .#tgrab -- --help`
- [x] `nix flake check --accept-flake-config --no-build`
- [x] `ast-grep scan packages`
- [x] `nix-update` check (`v0.1.0` is already current)

Repository-wide `nix fmt` still reports existing Ruff `CPY001` errors in unrelated Python files; the package file passes targeted formatting.
