### PR TITLE
fix(apm): add missing websockets dependency

### DIFF
--- a/packages/apm/package.nix
+++ b/packages/apm/package.nix
@@ -111,6 +111,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tomlkit
     truststore
     watchdog
+    websockets
   ];
 
   pythonImportsCheck = [ "apm_cli" ];


### PR DESCRIPTION
## Summary

- add `websockets` to APM's runtime dependencies
- align the Nix closure with APM 0.28.0's `websockets>=12,<17` requirement

## Why

`pythonRuntimeDepsCheckHook` rejects the package with `websockets not installed`. This is a real runtime dependency: APM's Copilot App integration imports `websockets.sync.client.connect`.

## Testing

- `nix build .#apm`