### PR TITLE
feat: add greptile-cli at 3.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>greptile-cli</strong> - Greptile code review from your terminal</summary>
+
+- **Source**: bytecode
+- **License**: MIT
+- **Homepage**: https://www.greptile.com/cli
+- **Usage**: `nix run github:numtide/llm-agents.nix#greptile-cli -- --help`
+- **Nix**: [packages/greptile-cli/package.nix](packages/greptile-cli/package.nix)
+
+</details>
+<details>
 <summary><strong>hunk</strong> - Terminal diff viewer for agentic changesets</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,11 @@ inputs."nixpkgs".lib.extend (
     };
 
     maintainers = prev.maintainers // {
+      RestartDK = {
+        github = "RestartDK";
+        githubId = 58006998;
+        name = "Daniel Kumlin";
+      };
       ak2k = {
         github = "ak2k";
         githubId = 19240940;

--- a/packages/greptile-cli/hashes.json
+++ b/packages/greptile-cli/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "3.4.2",
+  "hashes": {
+    "aarch64-darwin": "sha256-mBOYdrNqtXGt/J/fsyIvUzEG/RW8Zn88t5ZaB3tQjxY=",
+    "aarch64-linux": "sha256-mBOYdrNqtXGt/J/fsyIvUzEG/RW8Zn88t5ZaB3tQjxY=",
+    "x86_64-linux": "sha256-mBOYdrNqtXGt/J/fsyIvUzEG/RW8Zn88t5ZaB3tQjxY="
+  }
+}

--- a/packages/greptile-cli/package.nix
+++ b/packages/greptile-cli/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  mkUpdater,
+  stdenv,
+  platformSource,
+  makeWrapper,
+  nodejs,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "greptile.js";
+      aarch64-linux = "greptile.js";
+      aarch64-darwin = "greptile.js";
+    };
+    urlTemplate = "https://github.com/greptileai/cli/releases/download/v{version}/{platform}";
+  };
+in
+stdenv.mkDerivation {
+  pname = "greptile-cli";
+  inherit (source) version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/libexec/greptile.js
+    makeWrapper ${lib.getExe nodejs} $out/bin/greptile \
+      --add-flags $out/libexec/greptile.js
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Code Review";
+  passthru.updater = mkUpdater (
+    source.updater
+    // {
+      versionSource = {
+        type = "github";
+        owner = "greptileai";
+        repo = "cli";
+      };
+    }
+  );
+
+  meta = with lib; {
+    description = "Greptile code review from your terminal";
+    homepage = "https://www.greptile.com/cli";
+    changelog = "https://github.com/greptileai/cli/releases/tag/v${source.version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    mainProgram = "greptile";
+    platforms = source.platforms;
+  };
+}

--- a/packages/greptile-cli/package.nix
+++ b/packages/greptile-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake,
   mkUpdater,
   stdenv,
   platformSource,
@@ -63,6 +64,7 @@ stdenv.mkDerivation {
     changelog = "https://github.com/greptileai/cli/releases/tag/v${source.version}";
     license = licenses.mit;
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    maintainers = with flake.lib.maintainers; [ RestartDK ];
     mainProgram = "greptile";
     platforms = source.platforms;
   };


### PR DESCRIPTION
Adds the Greptile code review CLI in its nix form.

Testing:
- `nix fmt`
- `nix build --accept-flake-config .#greptile-cli`
- `./result/bin/greptile --version`
- `nix flake check --accept-flake-config --no-build`