### PR TITLE
kilocode-cli: install tree-sitter binaries

### DIFF
--- a/packages/kilocode-cli/package.nix
+++ b/packages/kilocode-cli/package.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation {
 
     install -Dm755 bin/kilo $out/bin/kilocode
 
+    mkdir -p $out/bin/tree-sitter
+    cp -r bin/tree-sitter/. $out/bin/tree-sitter/
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
Add installation for tree-sitter binaries to fix indexing feature

Without tree-sitter indexing :
Error: ENOENT: no such file or directory, open '/home/runner/_work/kilocode/kilocode/node_modules/.bun/web-tree-sitter@0.25.10/node_modules/web-tree-sitter/tree-sitter.wasm'