### PR TITLE
bernstein: update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
-<summary><strong>bernstein</strong> - Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents</summary>
+<summary><strong>bernstein</strong> - Governance layer for AI agents — deterministic scheduling, isolated git worktrees, signed audit trail</summary>
 
 - **Source**: source
 - **License**: Apache-2.0

--- a/packages/bernstein/package.nix
+++ b/packages/bernstein/package.nix
@@ -135,7 +135,7 @@ python3.pkgs.buildPythonApplication rec {
   passthru.category = "Workflow & Project Management";
 
   meta = with lib; {
-    description = "Multi-agent orchestrator for CLI coding agents — spawn, coordinate, and manage parallel AI agents";
+    description = "Governance layer for AI agents — deterministic scheduling, isolated git worktrees, signed audit trail";
     homepage = "https://github.com/sipyourdrink-ltd/bernstein";
     changelog = "https://github.com/sipyourdrink-ltd/bernstein/releases/tag/v${version}";
     license = licenses.asl20;


### PR DESCRIPTION
Bernstein's upstream project description changed, and `meta.description` still carried the previous wording. The generated README summary line is regenerated to match, so no other package or metadata field is touched.