### PR TITLE
sub2api: init at 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1606,6 +1606,17 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>sub2api</strong> - AI API gateway platform for distributing and managing AI subscription API quotas</summary>
+
+- **Source**: source
+- **License**: LGPL-3.0-or-later
+- **Homepage**: https://github.com/Wei-Shaw/sub2api
+- **Usage**: `nix run github:numtide/llm-agents.nix#sub2api -- --help`
+- **Nix**: [packages/sub2api/package.nix](packages/sub2api/package.nix)
+- **Documentation**: See [packages/sub2api/README.md](packages/sub2api/README.md) for detailed usage
+
+</details>
+<details>
 <summary><strong>terminal-use</strong> - Headless virtual terminal for AI agents</summary>
 
 - **Source**: source

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -39,6 +39,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 41877062;
         name = "DanCodes";
       };
+      _27Aaron = {
+        github = "27Aaron";
+        githubId = 85681241;
+        name = "Aaron";
+      };
       ypares = {
         github = "YPares";
         githubId = 1377233;

--- a/packages/sub2api/README.md
+++ b/packages/sub2api/README.md
@@ -1,0 +1,14 @@
+# sub2api
+
+`sub2api` is a self-hosted AI API gateway for distributing and managing
+subscription quotas across services such as Claude, OpenAI, and Gemini.
+
+This package provides the server binary and its embedded web frontend. It does
+not provision a database, cache, or service manager. A working deployment also
+requires PostgreSQL and Redis; see the [upstream deployment
+documentation](https://github.com/Wei-Shaw/sub2api/blob/main/deploy/README.md)
+for configuration and deployment examples.
+
+The upstream project warns that some uses may conflict with upstream provider
+terms of service. Use it only in compliance with the applicable terms and
+local laws.

--- a/packages/sub2api/hashes.json
+++ b/packages/sub2api/hashes.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.185",
+  "hash": "sha256-6603gIrlClgBI/3Yu1fOmNKLyaHISsomCLGIJ0FoTeI=",
+  "pnpmDepsHash": "sha256-D6lEnYH90wrum1mYHWYJZ2vGOghADxKnNcYxgKz2/10=",
+  "vendorHash": "sha256-Bnvqp698BPhBYqSlBZ5p7bw+zkA1B/lo58iDAi2Q0nY="
+}

--- a/packages/sub2api/hashes.json
+++ b/packages/sub2api/hashes.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.185",
-  "hash": "sha256-6603gIrlClgBI/3Yu1fOmNKLyaHISsomCLGIJ0FoTeI=",
+  "version": "0.2.0",
+  "hash": "sha256-KG7S5SPVh3sN8uH4TlSmRNZfBwt8D2/mQ5Njuo+Ge1Y=",
   "pnpmDepsHash": "sha256-D6lEnYH90wrum1mYHWYJZ2vGOghADxKnNcYxgKz2/10=",
   "vendorHash": "sha256-Bnvqp698BPhBYqSlBZ5p7bw+zkA1B/lo58iDAi2Q0nY="
 }

--- a/packages/sub2api/package.nix
+++ b/packages/sub2api/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  flake,
+  buildGo127Module,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nodejs_24,
+  pnpm_10,
+  pnpmConfigHook,
+  stdenvNoCC,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  versionData = lib.importJSON ./hashes.json;
+  inherit (versionData)
+    version
+    hash
+    vendorHash
+    pnpmDepsHash
+    ;
+in
+buildGo127Module (finalAttrs: {
+  pname = "sub2api";
+  inherit version;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Wei-Shaw";
+    repo = "sub2api";
+    tag = "v${finalAttrs.version}";
+    inherit hash;
+  };
+
+  modRoot = "backend";
+  subPackages = [ "cmd/server" ];
+  inherit vendorHash;
+
+  frontend = stdenvNoCC.mkDerivation (frontendAttrs: {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${frontendAttrs.src.name}/frontend";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (frontendAttrs)
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = pnpmDepsHash;
+    };
+
+    nativeBuildInputs = [
+      nodejs_24
+      pnpmConfigHook
+      pnpm_10
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm exec vue-tsc -b
+      pnpm exec vite build --outDir "$TMPDIR/dist"
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r "$TMPDIR/dist" $out
+      runHook postInstall
+    '';
+  });
+
+  tags = [ "embed" ];
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.BuildType=release"
+  ];
+
+  preBuild = ''
+    cp -r ${finalAttrs.frontend} internal/web/dist
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/sub2api
+
+    mkdir -p $out/share/sub2api
+    cp -r resources $out/share/sub2api/
+
+    wrapProgram $out/bin/sub2api \
+      --set-default PRICING_FALLBACK_FILE \
+        "$out/share/sub2api/resources/model-pricing/model_prices_and_context_window.json"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.category = "Utilities";
+
+  meta = {
+    description = "AI API gateway platform for distributing and managing AI subscription API quotas";
+    homepage = "https://github.com/Wei-Shaw/sub2api";
+    changelog = "https://github.com/Wei-Shaw/sub2api/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ _27Aaron ];
+    mainProgram = "sub2api";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/packages/sub2api/update.py
+++ b/packages/sub2api/update.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+
+"""Update the sub2api source and dependency hashes."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from updater import (
+    calculate_url_hash,
+    fetch_github_latest_release,
+    load_hashes,
+    save_hashes,
+    should_update,
+    update_dependency_hash,
+)
+from updater.hash import DUMMY_SHA256_HASH
+
+HASHES_FILE = Path(__file__).parent / "hashes.json"
+OWNER = "Wei-Shaw"
+REPO = "sub2api"
+
+
+def main() -> None:
+    """Update the sub2api hashes.json file."""
+    data = load_hashes(HASHES_FILE)
+    current = data["version"]
+    latest = fetch_github_latest_release(OWNER, REPO)
+
+    print(f"Current: {current}, Latest: {latest}")
+    if not should_update(current, latest):
+        print("Already up to date")
+        return
+
+    source_url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz"
+    new_data = {
+        "version": latest,
+        "hash": calculate_url_hash(source_url, unpack=True),
+        "pnpmDepsHash": DUMMY_SHA256_HASH,
+        "vendorHash": DUMMY_SHA256_HASH,
+    }
+    save_hashes(HASHES_FILE, new_data)
+
+    # Build the frontend dependency FOD first so the backend build can reuse it
+    # when calculating vendorHash.
+    update_dependency_hash(
+        ".#sub2api.frontend.pnpmDeps",
+        "pnpmDepsHash",
+        HASHES_FILE,
+        new_data,
+    )
+    update_dependency_hash(".#sub2api", "vendorHash", HASHES_FILE, new_data)
+
+    print(f"Updated to {latest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add sub2api 0.2.0 as a source-built AI API gateway package.
- Build the Go 1.27 backend and embed the Vue frontend.
- Keep the source, frontend, and Go dependency hashes in hashes.json.
- Add a hashes.json-driven updater and package documentation.
- Register the package under Utilities and add the package maintainer.

This package provides the server binary and embedded frontend; it does not provision PostgreSQL, Redis, or a service manager.

## Test plan

- [x] nix build --accept-flake-config --print-build-logs path:.#sub2api (aarch64-darwin)
- [x] nix run --accept-flake-config path:.#sub2api -- --version
- [x] nix flake check --accept-flake-config --no-build path:.
- [x] updater-tests (87 tests)
- [x] ast-grep scan packages/sub2api
- [x] nix build --accept-flake-config .#sub2api with the version check passing for 0.2.0
