### PR TITLE
claude-code: 2.1.252 -> 2.1.257

### DIFF
--- a/packages/claude-code/hashes.json
+++ b/packages/claude-code/hashes.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.1.252",
+  "version": "2.1.257",
   "hashes": {
-    "aarch64-darwin": "sha256-tmHGoJT8wyZWv3wAccW0W/kAs01PChqz14/Vmuuiwsc=",
-    "aarch64-linux": "sha256-bAsy6qk2lUoPTUrSWV+EFq8ojZs8uvGePN2aldfIhT4=",
-    "x86_64-linux": "sha256-pxWkUQXlk/yYCNA113eB+ISAuYl5danfQYN/DFkb1LM="
+    "aarch64-darwin": "sha256-ZFkNfZ2cGJ0z+z36WMVAjq8qEP5Va9hBVdle+qtGtg4=",
+    "aarch64-linux": "sha256-IvfUjxcZOVLDwtC4vy8x2yzQj9X7CaN0+jIUlrcR0Bc=",
+    "x86_64-linux": "sha256-mmS9qdhyKh+gW++aWWHQfgMxuZWX7ani9qcy86D/fwU="
   }
 }


### PR DESCRIPTION
## Summary

Agent-generated update of `claude-code` from 2.1.252 to 2.1.257.

## Test plan

- [x] `nix build .#<package>` succeeds
- [x] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work
