### PR TITLE
chatgpt: add libpulseaudio to runtimeDependencies

### DIFF
--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -116,6 +116,7 @@ stdenv.mkDerivation {
     libGL
     libgbm
     libsecret
+    libpulseaudio
     pipewire
     wayland
   ];


### PR DESCRIPTION
## Summary

Fixes microphone dictation in the `chatgpt` app by explicitly adding `libpulseaudio` to `runtimeDependencies` (similar to how it's handled in `claude-desktop` ).
https://github.com/numtide/llm-agents.nix/blob/5b91b9d64920e305641829efed8ea37b2fb59629/packages/claude-desktop/package.nix#L193
Without this, Chromium's WebRTC engine fails to `dlopen` PulseAudio at runtime.
Fixing the dependency is required for dictation to work properly when the app is sandboxed (`bwrap`)

## Test plan

Tested locally by overriding the derivation downstream in my NixOS configuration. The microphone now successfully routes through PipeWire and dictation works.

- [x] `nix build .#chatgpt` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work