### PR TITLE
executor: init at 1.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1506,6 +1506,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>executor</strong> - MCP gateway that gives coding agents one interface to many tools</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://executor.sh
+- **Usage**: `nix run github:numtide/llm-agents.nix#executor -- --help`
+- **Nix**: [packages/executor/package.nix](packages/executor/package.nix)
+
+</details>
+<details>
 <summary><strong>git-ai</strong> - Git extension for tracking AI-generated code in repositories</summary>
 
 - **Source**: source

--- a/packages/executor/hashes.json
+++ b/packages/executor/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.6.7",
+  "hashes": {
+    "x86_64-linux": "sha256-m/ViiCXBWU+ejS5Ht/ClKCmtdzyK8s9v+foVPKMpTyg=",
+    "aarch64-linux": "sha256-50Mq2fmPMpjECFLB6T6bq0BNUQjoIYcf2k/ReOG8x8k=",
+    "aarch64-darwin": "sha256-pek71JyMKm8pmAiKLuief1sFwni/1xpHvqkARxD/vKs="
+  }
+}

--- a/packages/executor/package.nix
+++ b/packages/executor/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  flake,
+  mkUpdater,
+  stdenv,
+  platformSource,
+  makeWrapper,
+  wrapBuddy,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+let
+  # The per-platform builds are dist-tagged versions of `executor` itself, so
+  # the platform token is part of the version rather than the package name.
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    };
+    urlTemplate = "https://registry.npmjs.org/executor/-/executor-{version}-{platform}.tgz";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "executor";
+  inherit (source) version src;
+
+  sourceRoot = "package";
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  dontBuild = true;
+
+  # bun --compile binary: its payload trailer must stay at EOF, so nothing may
+  # strip or resize it. wrapBuddy patches the entry point in place; patchelf and
+  # autoPatchelfHook both grow the file and the CLI then silently degrades to
+  # bun's own command line.
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/${finalAttrs.pname}
+    cp -r . $out/lib/${finalAttrs.pname}
+
+    # The .node addons are dlopen'd, so wrapBuddy leaves them alone and they
+    # resolve through LD_LIBRARY_PATH.
+    makeWrapper $out/lib/${finalAttrs.pname}/bin/executor $out/bin/executor \
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''--prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [ stdenv.cc.cc.lib ]
+      }"''}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.category = "Utilities";
+  passthru.updater = mkUpdater (
+    source.updater
+    // {
+      versionSource = {
+        type = "npm";
+        package = "executor";
+      };
+    }
+  );
+
+  meta = {
+    description = "MCP gateway that gives coding agents one interface to many tools";
+    longDescription = ''
+      Executor presents MCP servers, OpenAPI services and scripts to coding
+      agents as one tool abstraction. It stores credentials, separates safe and
+      unsafe API semantics, and runs tool calls in isolated JavaScript
+      sandboxes. It ships a CLI, a local API server and a web UI.
+    '';
+    homepage = "https://executor.sh";
+    changelog = "https://github.com/UsefulSoftwareCo/executor/releases";
+    downloadPage = "https://www.npmjs.com/package/executor?activeTab=versions";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ zimbatm ];
+    mainProgram = "executor";
+    platforms = source.platforms;
+  };
+})


### PR DESCRIPTION
Adds [Executor](https://executor.sh), an MCP gateway that presents MCP servers, OpenAPI services and scripts to coding agents as one tool abstraction. Ships a CLI, a local API server and a web UI.

## Notes

- The per-platform builds are dist-tagged versions of the `executor` npm package itself (`executor-1.6.7-linux-arm64.tgz`), not separate package names, so the platform token is part of the version.
- The whole tree is installed to `$out/lib/executor`: the CLI needs `workerd`, `keyring.node`, `libsql.node`, the wasm blobs and `worker-bundler/`.
- `bin/executor` is a bun `--compile` binary whose payload trailer sits at EOF, so it has to be patched **in place**. `autoPatchelfHook` and plain `patchelf` both resize the file, and the CLI then silently degrades to bun's own command line (bun's help text, `bun --version` output) rather than failing loudly. `patchelf` happens to survive on x86_64, where it inserts a single 4K page, but segfaults on aarch64, where the page is 64K — reproduced under `qemu-aarch64`, which is what the first push's `checks.aarch64-linux.pkgs-executor` failure was. `wrapBuddy` overwrites the entry point without changing the file size, so the trailer stays put on every arch.
- The `.node` addons are dlopen'd, so `wrapBuddy` leaves them alone and the wrapper adds `LD_LIBRARY_PATH`.
- Declarative `passthru.updater` (`kind = "platform"`, npm `versionSource`), built from `source.updater`.

## Testing

- `nix build .#executor` on x86_64-linux
- `versionCheckHook` passes: `executor v1.6.7`
- `executor --help` and `executor tools --help` list the real subcommands; `workerd --version` runs
- aarch64: the upstream binary and the `wrapBuddy`-style in-place patch were checked under `qemu-aarch64` against a cross-built glibc
- `nix fmt`, `ast-grep scan packages/executor`, `check_maintainers.py`, and the `meta-completeness` check are clean
- README package section regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01644CgYZh3Xgh2oGvmUMo9w