### PR TITLE
jcode: init at 0.81.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>jcode</strong> - RAM-efficient coding agent TUI with multi-model support and swarm coordination</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/1jehuang/jcode
+- **Usage**: `nix run github:numtide/llm-agents.nix#jcode -- --help`
+- **Nix**: [packages/jcode/package.nix](packages/jcode/package.nix)
+
+</details>
+<details>
 <summary><strong>jules</strong> - Jules, the asynchronous coding agent from Google, in the terminal</summary>
 
 - **Source**: binary

--- a/packages/jcode/package.nix
+++ b/packages/jcode/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  flake,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jcode";
+  version = "0.81.4";
+
+  src = fetchFromGitHub {
+    owner = "1jehuang";
+    repo = "jcode";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wdTod5iEcpLqQ1mTdYBtyovxEo4NUa/Hv9mIPXvGeWk=";
+  };
+
+  cargoHash = "sha256-BQZG31o0WInz5QC1R8yJNmQRYb6x4ylMHI1i3l+FA8k=";
+
+  # .cargo/config.toml caps builds at 4 jobs; let Nix parallelism decide.
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  # aws-lc-sys (rustls provider) needs cmake; imap's default native-tls
+  # backend links against system openssl.
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ];
+
+  # Make the embedded version string a release one ("vX.Y.Z") instead of a
+  # dev one; the build script falls back to "unknown" git metadata, which is
+  # fine for tarball builds.
+  env.JCODE_RELEASE_BUILD = "1";
+
+  # Test suite needs network access, provider credentials and a TTY.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = with lib; {
+    description = "RAM-efficient coding agent TUI with multi-model support and swarm coordination";
+    homepage = "https://github.com/1jehuang/jcode";
+    changelog = "https://github.com/1jehuang/jcode/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "jcode";
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Summary

- Add [jcode](https://github.com/1jehuang/jcode) 0.81.4, a RAM-efficient coding agent TUI with multi-model support and swarm coordination, built from source with `buildRustPackage`.
- aws-lc-sys needs cmake; the imap default native-tls backend links against system openssl. Upstream's `.cargo/config.toml` job cap is dropped so Nix parallelism applies. Tests are disabled (need network, provider credentials, and a TTY); `versionCheckHook` + `versionCheckHomeHook` cover the install check.
- Registered under **AI Coding Agents** with the generated README entry.

## Test plan

- [x] `nix build .#jcode` succeeds
- [x] `nix run .#jcode -- --version` → `jcode v0.81.4`
- [x] Package updates via `nix-update` (verified 0.81.3 → 0.81.4 round-trip)
- [x] `nix fmt` clean, `ast-grep scan packages/jcode` clean