### PR TITLE
tokscale: init at 4.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/mindwalk/package.nix](packages/mindwalk/package.nix)
 
 </details>
+<details>
+<summary><strong>tokscale</strong> - CLI and TUI for AI token usage analytics</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/junhoyeo/tokscale
+- **Usage**: `nix run github:numtide/llm-agents.nix#tokscale -- --help`
+- **Nix**: [packages/tokscale/package.nix](packages/tokscale/package.nix)
+
+</details>
 
 ### Workflow & Project Management
 

--- a/packages/tokscale/nix-update-args
+++ b/packages/tokscale/nix-update-args
@@ -1,0 +1,3 @@
+--use-github-releases
+--version-regex
+^v([0-9]+\.[0-9]+\.[0-9]+)$

--- a/packages/tokscale/package.nix
+++ b/packages/tokscale/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  flake,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tokscale";
+  version = "4.15.0";
+
+  src = fetchFromGitHub {
+    owner = "junhoyeo";
+    repo = "tokscale";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-abug+ZOnW8zl0xG1C+cwQcp6UOi48mOct4klSdwgR/w=";
+  };
+
+  cargoHash = "sha256-nvgvVFDthLYLb20huX4iNxyeRDVPP5PyxUhrk3DvJhI=";
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # Tests need network access.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "Usage Analytics";
+
+  meta = {
+    description = "CLI and TUI for AI token usage analytics";
+    homepage = "https://github.com/junhoyeo/tokscale";
+    changelog = "https://github.com/junhoyeo/tokscale/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "tokscale";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add [tokscale](https://github.com/junhoyeo/tokscale) 4.15.0, a CLI and TUI for AI token usage analytics, built from source.