### PR TITLE
multica, multica-desktop: init at 0.4.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,26 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>multica</strong> - Command-line interface for the Multica platform</summary>
+
+- **Source**: source
+- **License**: unfree
+- **Homepage**: https://github.com/multica-ai/multica
+- **Usage**: `nix run github:numtide/llm-agents.nix#multica -- --help`
+- **Nix**: [packages/multica/package.nix](packages/multica/package.nix)
+
+</details>
+<details>
+<summary><strong>multica-desktop</strong> - Desktop client for the Multica platform</summary>
+
+- **Source**: source
+- **License**: unfree
+- **Homepage**: https://github.com/multica-ai/multica
+- **Usage**: `nix run github:numtide/llm-agents.nix#multica-desktop -- --help`
+- **Nix**: [packages/multica-desktop/package.nix](packages/multica-desktop/package.nix)
+
+</details>
+<details>
 <summary><strong>openclaw</strong> - Your own personal AI assistant. Any OS. Any Platform. The lobster way</summary>
 
 - **Source**: source

--- a/packages/multica-desktop/package.nix
+++ b/packages/multica-desktop/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchPnpmDeps,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  electron_41,
+  multica,
+}:
+
+let
+  electron = electron_41;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "multica-desktop";
+  inherit (multica) version src;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    hash = "sha256-gbC1gnlgzwV7aMNJf0hH8xwkcxQb3qbBScsLhkM1tvw=";
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_10
+    pnpmConfigHook
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # Bundle main-process deps so no node_modules is needed at runtime.
+  postPatch = ''
+    substituteInPlace apps/desktop/electron.vite.config.ts \
+      --replace-fail "plugins: [externalizeDepsPlugin()]," "build: { externalizeDeps: false },"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm --filter @multica/desktop exec electron-vite build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    app=$out/share/multica-desktop
+    mkdir -p $app/resources/bin
+    cp -r apps/desktop/out $app/
+    cp -r apps/desktop/resources/. $app/resources/
+    ln -s ${lib.getExe multica} $app/resources/bin/multica
+    # app.getAppPath() is out/main when started on the bundle directly.
+    ln -s ../../resources $app/out/main/resources
+
+    install -Dm644 apps/desktop/build/icon.png \
+      $out/share/icons/hicolor/512x512/apps/multica.png
+
+    makeWrapper ${lib.getExe electron} $out/bin/multica-desktop \
+      --add-flags $app/out/main/index.js \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "multica-desktop";
+      desktopName = "Multica";
+      exec = "multica-desktop %U";
+      icon = "multica";
+      categories = [ "Utility" ];
+      startupWMClass = "Multica";
+      mimeTypes = [ "x-scheme-handler/multica" ];
+    })
+  ];
+
+  passthru.category = "AI Assistants";
+
+  meta = {
+    description = "Desktop client for the Multica platform";
+    homepage = "https://github.com/multica-ai/multica";
+    changelog = "https://github.com/multica-ai/multica/releases/tag/v${finalAttrs.version}";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    platforms = lib.platforms.linux;
+    mainProgram = "multica-desktop";
+  };
+})

--- a/packages/multica/package.nix
+++ b/packages/multica/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  flake,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "multica";
+  version = "0.4.38";
+
+  src = fetchFromGitHub {
+    owner = "multica-ai";
+    repo = "multica";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dtHAlV0uLO6ZJH5lfFc91yEbF8ICr/MBYBmEqrGNNYQ=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/server";
+  subPackages = [ "cmd/multica" ];
+
+  vendorHash = "sha256-QwVYfMtRL4eSRvQ9TuuVQyRXUHWPQXoAzdd9KX+D8lQ=";
+
+  ldflags = [ "-X main.version=${finalAttrs.version}" ];
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "AI Assistants";
+
+  meta = {
+    description = "Command-line interface for the Multica platform";
+    homepage = "https://github.com/multica-ai/multica";
+    changelog = "https://github.com/multica-ai/multica/releases/tag/v${finalAttrs.version}";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    mainProgram = "multica";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add [multica](https://github.com/multica-ai/multica) 0.4.38 (Go CLI) and multica-desktop (Electron client built from source against nixpkgs electron, main process deps bundled so no runtime node_modules is shipped). Unfree.