### PR TITLE
agentty: init at 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 ### AI Coding Agents
 
 <details>
+<summary><strong>agentty</strong> - Terminal AI pair programmer written in C++</summary>
+
+- **Source**: source
+- **License**: MIT
+- **Homepage**: https://github.com/1ay1/agentty
+- **Usage**: `nix run github:numtide/llm-agents.nix#agentty -- --help`
+- **Nix**: [packages/agentty/package.nix](packages/agentty/package.nix)
+
+</details>
+<details>
 <summary><strong>amp</strong> - CLI for Amp, an agentic coding tool in research preview from Sourcegraph</summary>
 
 - **Source**: binary

--- a/packages/agentty/package.nix
+++ b/packages/agentty/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  flake,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  openssl,
+  nghttp2,
+  nlohmann_json,
+  simdjson,
+  versionCheckHook,
+  versionCheckHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "agentty";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "1ay1";
+    repo = "agentty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rkBt663EJ6WQJR75X6yRAE7/6T8IMTClFQyxrDLIbFg=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    nghttp2
+    nlohmann_json
+    simdjson
+  ];
+
+  cmakeFlags = [
+    # Resolve FetchContent deps (nlohmann_json, simdjson) from buildInputs.
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
+    (lib.cmakeBool "AGENTTY_USE_MIMALLOC" false)
+    # maya defaults to -march=native.
+    (lib.cmakeBool "MAYA_NATIVE_TUNING" false)
+  ];
+
+  # No install() rules upstream.
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 agentty $out/bin/agentty
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    versionCheckHomeHook
+  ];
+
+  passthru.category = "AI Coding Agents";
+
+  meta = {
+    description = "Terminal AI pair programmer written in C++";
+    homepage = "https://github.com/1ay1/agentty";
+    changelog = "https://github.com/1ay1/agentty/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with flake.lib.maintainers; [ smdex ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "agentty";
+  };
+})


### PR DESCRIPTION
Add [agentty](https://github.com/1ay1/agentty) 0.5.0, a terminal AI pair programmer written in C++, built from source with CMake. Linux only for now.