### PR TITLE
hermes-agent: prune case-colliding contributors/ from src

### DIFF
--- a/packages/hermes-agent/package.nix
+++ b/packages/hermes-agent/package.nix
@@ -179,7 +179,14 @@ let
     owner = "NousResearch";
     repo = "hermes-agent";
     tag = "v${version}";
-    hash = "sha256-Ii9xP2fKUpvCcwWZuxJ0g3CZ+IL2UZH14pUNvBfdclc=";
+    hash = "sha256-vT5ZhN2NUd0Iv5YplUQfwdHEOVM8yoy94MqJjLvXOJ8=";
+    # contributors/emails/ holds paths differing only in case; they collapse
+    # on case-insensitive stores (APFS) so the NAR hash diverges between
+    # Linux and darwin. Unused at build/runtime. Upstream:
+    # NousResearch/hermes-agent#88257
+    postFetch = ''
+      rm -rf "$out/contributors"
+    '';
   };
 
   # Upstream moved ui-tui/ and web/ into npm workspaces with a single root


### PR DESCRIPTION
The v2026.8.31 tree ships contributors/emails/agent@Agents-Mac-mini.local
and .../agent@agents-Mac-mini.local. On case-insensitive stores (APFS)
they collapse into one file, so the unpacked NAR never matches the hash
pinned from Linux CI and hermes-agent/hermes-desktop fail on darwin with
a FOD hash mismatch. Nothing reads contributors/ at build or runtime, so
drop it in postFetch to get a filesystem-independent hash.

Fixes #8755
