### PR TITLE
cline: fix run_commands on systems without /bin/bash

### DIFF
--- a/packages/cline/package.nix
+++ b/packages/cline/package.nix
@@ -4,6 +4,7 @@
   stdenv,
   fetchurl,
   platformSource,
+  bash,
   cacert,
   makeWrapper,
   nodejs,
@@ -48,6 +49,14 @@ stdenv.mkDerivation {
 
     mkdir -p $out/lib/cline-platform $out/lib/cline-launcher
     cp -r . $out/lib/cline-platform
+  ''
+  # NixOS has no /bin/bash. Same-length patch so the Bun SEA stays valid.
+  # Not on darwin: editing the Mach-O breaks its code signature.
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    grep -qF '"/bin/bash"' $out/lib/cline-platform/bin/cline
+    sed -i 's|"/bin/bash"|"bash"     |g' $out/lib/cline-platform/bin/cline
+  ''
+  + ''
     tar -xzf ${launcher} --strip-components=1 -C $out/lib/cline-launcher package/bin
 
     # Use the official npm launcher so Cline retains its OS trust-store
@@ -57,6 +66,7 @@ stdenv.mkDerivation {
     patchShebangs $out/lib/cline-launcher/bin/cline
 
     makeWrapper $out/lib/cline-launcher/bin/cline $out/bin/cline \
+      --suffix PATH : ${lib.makeBinPath [ bash ]} \
       --set-default SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt \
       --set-default SSL_CERT_DIR ${cacert}/etc/ssl/certs
 


### PR DESCRIPTION
The Bun-compiled binary spawns a hardcoded "/bin/bash" for its
run_commands tool. On NixOS this fails with
  posix_spawn "/bin/bash": ENOENT
and the agent concludes that no shell is available.

Patch the embedded JS in place (same length, whitespace padded) to a
bare "bash" and append bash to PATH in the wrapper. Verified against a
mock OpenAI-compatible provider inside a bwrap sandbox with an empty
/bin: unpatched returns the ENOENT error, patched runs `uname -r`.

Fixes #8754
