### PR TITLE
tui-test: init at 0.1.0-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1736,6 +1736,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 - **Nix**: [packages/toon/package.nix](packages/toon/package.nix)
 
 </details>
+<details>
+<summary><strong>tui-test</strong> - Control, inspect, test, and record any TUI app or CLI in a headless terminal</summary>
+
+- **Source**: binary
+- **License**: MIT
+- **Homepage**: https://github.com/microsoft/tui-test
+- **Usage**: `nix run github:numtide/llm-agents.nix#tui-test -- --help`
+- **Nix**: [packages/tui-test/package.nix](packages/tui-test/package.nix)
+
+</details>
 <!-- END GENERATED PACKAGE DOCS -->
 
 ## Installation

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -264,6 +264,11 @@ inputs."nixpkgs".lib.extend (
         githubId = 42895613;
         name = "Adithya Balasubramani";
       };
+      willenbug = {
+        github = "willenbug";
+        githubId = 76489193;
+        name = "Brayden Willenborg";
+      };
     };
   }
 )

--- a/packages/tui-test/hashes.json
+++ b/packages/tui-test/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1.0-beta.3",
+  "hashes": {
+    "aarch64-darwin": "sha256-wZArk4jV5sSOtmde/sojBa/UzWxRhFX5OGBEHyi9zX0=",
+    "aarch64-linux": "sha256-MSYTRq81Qsv0JbH2YXQ9tim4+dqi7et1RN1NtLrhnno=",
+    "x86_64-linux": "sha256-NdDP/xs9bP66OrsO6udTfFciw2QUEGyiixQuXkgjWjc="
+  }
+}

--- a/packages/tui-test/package.nix
+++ b/packages/tui-test/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  flake,
+  formatelf,
+  platformSource,
+  versionCheckHook,
+  mkUpdater,
+}:
+
+let
+  # Prebuilt: building from source needs Zig for the vendored libghostty-vt.
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = {
+      x86_64-linux = "x86_64-unknown-linux-gnu";
+      aarch64-linux = "aarch64-unknown-linux-gnu";
+      aarch64-darwin = "aarch64-apple-darwin";
+    };
+    urlTemplate = "https://github.com/microsoft/tui-test/releases/download/{version}/tui-test-{platform}.tar.gz";
+  };
+in
+stdenv.mkDerivation {
+  pname = "tui-test";
+  inherit (source) version src;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ formatelf ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 tui-test $out/bin/tui-test
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  passthru.category = "Utilities";
+  passthru.updater = mkUpdater (
+    source.updater
+    // {
+      # All releases with binaries are prereleases, /releases/latest skips them.
+      versionSource = {
+        type = "text";
+        url = "https://api.github.com/repos/microsoft/tui-test/releases?per_page=1";
+        regex = ''"tag_name": *"([^"]+)"'';
+      };
+    }
+  );
+
+  meta = {
+    description = "Control, inspect, test, and record any TUI app or CLI in a headless terminal";
+    homepage = "https://github.com/microsoft/tui-test";
+    changelog = "https://github.com/microsoft/tui-test/releases/tag/${source.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ willenbug ];
+    mainProgram = "tui-test";
+    platforms = source.platforms;
+  };
+}


### PR DESCRIPTION
Adds [tui-test](https://github.com/microsoft/tui-test), a headless terminal CLI from Microsoft. It lets agents control, inspect, and record any TUI app or CLI. Filed under Utilities.

## Packaging notes

- Uses upstream's prebuilt release binaries through `platformSource`. Covers x86_64 and aarch64 on Linux and macOS.
- Building from source needs `libghostty-vt`, a Zig-built git dependency. That does not fit the cargo vendor step. Upstream's Homebrew formula ships the same binaries.
- Linux binaries only need `libstdc++` and `libgcc_s`, handled by `formatelf`.
- Uses the declarative `platform` updater. Every release with binaries is a prerelease, so `/releases/latest` points at 0.0.4, which has no assets. The version source reads the newest published release from the GitHub API instead.
- Adds me as a custom maintainer in `lib/default.nix`.

## Testing

- `nix build .#tui-test` on x86_64-linux. The version check passes.
- `nix fmt` is clean. The `meta-completeness`, `meta-maintainers`, `treefmt`, `pkgs-tui-test`, and `updater-tests` checks pass.
- Updater: I set `hashes.json` to 0.1.0-beta.2 with a bad hash and ran `nix run .#tui-test.updateScript`. It restored 0.1.0-beta.3 and all four hashes.
- I could not build Darwin or aarch64-linux locally. The hashes are prefetched and each tarball holds a single `tui-test` binary.

```
$ nix run .#tui-test -- --version
tui-test 0.1.0-beta.3

$ nix run .#tui-test -- --help | head -8
Headless terminal cli + daemon

Usage: tui-test [OPTIONS] [COMMAND]

Commands:
  open           Spawn a shell session (auto-starts the daemon)
  run            Spawn a session running a program directly
  close          Close the current session (or all sessions)
```
