### PR TITLE
muse-code: init at 1.0.2-R2040.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,16 @@ Nix packages for AI coding agents and development tools. Automatically updated d
 
 </details>
 <details>
+<summary><strong>muse-code</strong> - Meta's terminal coding agent</summary>
+
+- **Source**: binary
+- **License**: unfree
+- **Homepage**: https://dev.meta.ai/
+- **Usage**: `nix run github:numtide/llm-agents.nix#muse-code -- --help`
+- **Nix**: [packages/muse-code/package.nix](packages/muse-code/package.nix)
+
+</details>
+<details>
 <summary><strong>nanocoder</strong> - A beautiful local-first coding agent running in your terminal - built by the community for the community ⚒</summary>
 
 - **Source**: source

--- a/packages/muse-code/hashes.json
+++ b/packages/muse-code/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.2-R2040.1",
+  "hashes": {
+    "x86_64-linux": "sha256-byRiPW0aGTqKuNYQw98Rw4zIu1SqObZTL7Knop2F0ns=",
+    "aarch64-linux": "sha256-sNqr1goo2zDFMLAdvPQYVgDzurKGGSxXqzD2qigtIPQ=",
+    "aarch64-darwin": "sha256-QdN+SWDe8v4RdqlCkI9syqBPYC27ZlfFEceUq96hTMQ="
+  }
+}

--- a/packages/muse-code/package.nix
+++ b/packages/muse-code/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenvNoCC,
+  flake,
+  fetchurlTemplate,
+  versionCheckHook,
+  mkUpdater,
+}:
+
+let
+  versionData = lib.importJSON ./hashes.json;
+  inherit (versionData) version;
+
+  platforms = {
+    x86_64-linux = "x86-linux";
+    aarch64-linux = "aarch64-linux";
+    aarch64-darwin = "aarch64-macos";
+  };
+
+  system = stdenvNoCC.hostPlatform.system;
+  platform = platforms.${system} or (throw "Unsupported system: ${system}");
+
+  downloadBase = "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version={version}";
+in
+stdenvNoCC.mkDerivation {
+  pname = "muse-code";
+  inherit version;
+
+  src = fetchurlTemplate {
+    urlTemplate = "${downloadBase}&file=muse-{platform}";
+    vars = {
+      inherit version platform;
+    };
+    name = "muse-${version}-${platform}";
+    hash = versionData.hashes.${system};
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/muse
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "AI Coding Agents";
+  passthru.updater = mkUpdater {
+    kind = "manifest-checksums";
+    versionSource = {
+      type = "text";
+      url = "https://api.meta.ai/muse-code/channels/muse-stable";
+      regex = ''"version": *"([^"]+)"'';
+    };
+    manifestUrl = "${downloadBase}&file=manifest.json";
+    checksumPath = "artifacts.{platform}.checksum";
+    # Manifest keys use x86_linux instead of x86-linux.
+    platforms = lib.mapAttrs (_: lib.replaceStrings [ "-" ] [ "_" ]) platforms;
+  };
+
+  meta = {
+    description = "Meta's terminal coding agent";
+    homepage = "https://dev.meta.ai/";
+    changelog = "https://dev.meta.ai/docs/muse-code/changelog";
+    license = flake.lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with flake.lib.maintainers; [ willenbug ];
+    mainProgram = "muse";
+    platforms = builtins.attrNames platforms;
+  };
+}


### PR DESCRIPTION
Adds [Muse Code](https://dev.meta.ai/), Meta's multi-agent terminal coding agent. Filed under AI Coding Agents.

## Packaging notes

- Uses upstream's prebuilt static binaries. Covers x86_64 and aarch64 on Linux and macOS. Upstream's install script and Homebrew cask ship the same files.
- The download URL ends in a query string, so the fetch sets an explicit store name. The package uses `fetchurlTemplate` directly for that reason.
- Installs the binary as `muse`, matching upstream and the Homebrew cask.
- Uses the `manifest-checksums` updater. Upstream publishes a stable channel JSON with the current version and a per-version `manifest.json` with sha256 checksums. No downloads are needed to update.
- License is unfree.
- Adds me as a custom maintainer in `lib/default.nix`. The same entry is in #8814. Whichever merges second will need a trivial rebase.

## Testing

- `nix build .#muse-code` on x86_64-linux. The version check passes.
- `nix fmt` is clean. The `meta-completeness`, `meta-maintainers`, `treefmt`, `pkgs-muse-code`, and `updater-tests` checks pass.
- Updater: I set `hashes.json` to a lower version with a bad hash and ran the `manifest-checksums` flow. It restored 1.0.2-R2040.1 and all four hashes.
- I could not build Darwin or aarch64-linux locally. The hashes match upstream's manifest and the Homebrew cask.

```
$ nix run .#muse-code -- --version
Muse Code 1.0.2 (1.0.2-R2040.1)

$ nix run .#muse-code -- --help | head -12
muse — interactive terminal coding agent

If no subcommand is given, options run the interactive TUI; pass a prompt to start
a session, or use a command below.

Usage: muse [OPTIONS] [PROMPT]
       muse [OPTIONS] <COMMAND>

Commands:
  resume           Resume a previous session (--last or <session-uuid>)
  exec             Run one prompt non-interactively (headless)
  config           Validate enterprise configuration documents
```
