### PR TITLE
feat(zcode): add aarch64-darwin support

### DIFF
--- a/packages/zcode/hashes.json
+++ b/packages/zcode/hashes.json
@@ -1,7 +1,8 @@
 {
   "version": "3.11.2",
   "hashes": {
-    "x86_64-linux": "sha256-fRO4OGMTAs9h4bgEDLZ/NJ7CNWZ5WJfxdGQyxcXXfVs=",
-    "aarch64-linux": "sha256-3jFIe5eq3hNlvb8cOhYkM2zRY9uJlkFqT4lG9JHu7bA="
+    "aarch64-darwin": "sha256-z6Q7kOx0cy7j7hJigD13VlijyVTMTMCpob7A+cbcv5g=",
+    "aarch64-linux": "sha256-3jFIe5eq3hNlvb8cOhYkM2zRY9uJlkFqT4lG9JHu7bA=",
+    "x86_64-linux": "sha256-fRO4OGMTAs9h4bgEDLZ/NJ7CNWZ5WJfxdGQyxcXXfVs="
   }
 }

--- a/packages/zcode/package.nix
+++ b/packages/zcode/package.nix
@@ -9,6 +9,7 @@
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
+  undmg,
 
   alsa-lib,
   at-spi2-atk,
@@ -56,10 +57,20 @@ let
   source = platformSource {
     hashesFile = ./hashes.json;
     platforms = {
-      x86_64-linux = "linux-x64";
-      aarch64-linux = "linux-arm64";
+      x86_64-linux = {
+        dir = "linux-x64";
+        file = "linux-x64.deb";
+      };
+      aarch64-linux = {
+        dir = "linux-arm64";
+        file = "linux-arm64.deb";
+      };
+      aarch64-darwin = {
+        dir = "macos-arm64";
+        file = "mac-arm64.dmg";
+      };
     };
-    urlTemplate = "https://cdn-zcode.z.ai/zcode/electron/releases/{version}/{platform}/ZCode-{version}-{platform}.deb";
+    urlTemplate = "https://cdn-zcode.z.ai/zcode/electron/releases/{version}/{dir}/ZCode-{version}-{file}";
   };
 
   desktopItem = makeDesktopItem {
@@ -73,18 +84,21 @@ let
     startupWMClass = "ZCode";
     mimeTypes = [ "x-scheme-handler/zcode" ];
   };
+  inherit (stdenvNoCC.hostPlatform) isLinux;
 in
 stdenvNoCC.mkDerivation {
   pname = "zcode";
   inherit (source) version src;
 
-  nativeBuildInputs = [
-    formatelf
-    copyDesktopItems
-    makeWrapper
-  ];
+  nativeBuildInputs =
+    lib.optionals isLinux [
+      formatelf
+      copyDesktopItems
+      makeWrapper
+    ]
+    ++ lib.optionals (!isLinux) [ undmg ];
 
-  buildInputs = [
+  buildInputs = lib.optionals isLinux [
     adwaita-icon-theme
     alsa-lib
     at-spi2-atk
@@ -115,7 +129,7 @@ stdenvNoCC.mkDerivation {
 
   # dlopen()ed at runtime, so not discoverable from DT_NEEDED; list them
   # here to put them on the RUNPATH.
-  runtimeDependencies = [
+  runtimeDependencies = lib.optionals isLinux [
     libayatana-appindicator
     libglvnd
     libnotify
@@ -128,31 +142,43 @@ stdenvNoCC.mkDerivation {
 
   desktopItems = [ desktopItem ];
 
-  unpackPhase = ''
+  sourceRoot = lib.optionalString (!isLinux) ".";
+
+  unpackPhase = lib.optionalString isLinux ''
     runHook preUnpack
     ${lib.getExe' bintools "ar"} x $src
     tar xf data.tar.xz
     runHook postUnpack
   '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    if isLinux then
+      ''
+        runHook preInstall
 
-    # Keep the upstream opt/ZCode layout so bundled libs (e.g. libffmpeg.so)
-    # resolve next to the main binary.
-    mkdir -p $out/lib $out/bin $out/share
-    cp -a opt/ZCode $out/lib/ZCode
-    cp -a usr/share/icons $out/share/icons
+        # Keep the upstream opt/ZCode layout so bundled libs (e.g. libffmpeg.so)
+        # resolve next to the main binary.
+        mkdir -p $out/lib $out/bin $out/share
+        cp -a opt/ZCode $out/lib/ZCode
+        cp -a usr/share/icons $out/share/icons
 
-    chmod +x $out/lib/ZCode/zcode
+        chmod +x $out/lib/ZCode/zcode
 
-    makeWrapper "$out/lib/ZCode/zcode" "$out/bin/zcode" \
-      --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        makeWrapper "$out/lib/ZCode/zcode" "$out/bin/zcode" \
+          --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
+          --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
-    runHook postInstall
-  '';
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+        mkdir -p $out/Applications $out/bin
+        cp -R ZCode.app $out/Applications/
+        ln -s $out/Applications/ZCode.app/Contents/MacOS/ZCode $out/bin/zcode
+        runHook postInstall
+      '';
 
   passthru = {
     category = "AI Coding Agents";
@@ -182,6 +208,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
   };
 }


### PR DESCRIPTION
Add aarch64-darwin to zcode by repackaging the upstream dmg. `platformSource` now uses `{dir}`/`{file}` template vars since the macOS URL layout differs; Linux URLs and hashes are unchanged.