### PR TITLE
site: accessibility pass

### DIFF
--- a/lib/hercules-ci.nix
+++ b/lib/hercules-ci.nix
@@ -1,5 +1,4 @@
-# nixbot (hercules-ci-effects compatible) effects. mkEffect is inlined so the
-# flake does not grow a nixbot/hercules-ci-effects input just for CI.
+# nixbot effects. mkEffect is inlined to avoid a nixbot flake input.
 { pkgs, site }:
 let
   inherit (pkgs) lib;
@@ -9,7 +8,7 @@ let
       name,
       effectScript,
       inputs ? [ ],
-      # nixbot mounts a pushable clone at /build/checkout, see nixbot docs/EFFECTS.md.
+      # Pushable clone at $NIXBOT_EFFECT_CHECKOUT, see nixbot docs/EFFECTS.md.
       checkout ? false,
     }:
     pkgs.stdenvNoCC.mkDerivation {
@@ -58,7 +57,7 @@ in
       cd "$NIXBOT_EFFECT_CHECKOUT"
       git config user.email "nixbot@numtide.com"
       git config user.name "nixbot"
-      # Orphan commit: history of generated files is not worth keeping.
+      # History of generated files is not worth keeping.
       git checkout -q --orphan gh-pages
       git rm -rfq .
       cp -r --no-preserve=mode,ownership ${site}/. .

--- a/packages/site/package.nix
+++ b/packages/site/package.nix
@@ -53,7 +53,7 @@ let
         hasReadme = builtins.pathExists (../. + "/${name}/README.md");
       };
 
-  # `site` itself is part of allPackages; skip it to avoid infinite recursion.
+  # Skip `site` itself to avoid infinite recursion.
   packagesJson = builtins.toJSON (
     lib.filter (m: m != null) (lib.mapAttrsToList metadata (removeAttrs allPackages [ "site" ]))
   );
@@ -76,8 +76,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Static package search site for llm-agents.nix";
     license = lib.licenses.mit;
-    # Some packages throw for unsupported systems when their attributes are
-    # forced; the metadata is system-independent and CI deploys from Linux.
+    # Some packages throw "Unsupported system" when evaluated on darwin.
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/packages/site/src/app.js
+++ b/packages/site/src/app.js
@@ -43,7 +43,7 @@ function writeUrl() {
   history.replaceState(null, "", s ? `?${s}` : location.pathname);
 }
 
-// Rank name matches above description matches; all terms must match.
+// Name matches rank above description matches. All terms must match.
 function score(pkg, terms) {
   let total = 0;
   for (const t of terms) {
@@ -99,7 +99,7 @@ function link(href, text, label) {
   return a;
 }
 
-// aria-label is not allowed on plain spans; prefix visually hidden text instead.
+// aria-label is not allowed on plain spans.
 function described(prefix, text) {
   const s = document.createElement("span");
   const sr = document.createElement("span");
@@ -120,12 +120,12 @@ function card(p) {
   li.querySelector(".desc").textContent = p.description;
   const badges = li.querySelector(".badges");
   badges.append(badge(p.source, p.source));
-  // flake.lib marks unfree licenses `free = true` to skip allowUnfree, so go by name.
+  // flake.lib sets `free = true` on unfree licenses, so match by name.
   if (/unfree/i.test(p.license)) badges.append(badge("unfree", "unfree"));
   const cmd = `nix run ${REPO}#${p.name}`;
   const code = li.querySelector(".cmd code");
   code.textContent = cmd;
-  // Horizontally scrollable on narrow screens, so must be keyboard reachable.
+  // Scrollable on narrow screens, so it must be focusable.
   code.tabIndex = 0;
   const copy = li.querySelector(".copy");
   copy.setAttribute("aria-label", `Copy nix run command for ${p.name}`);

--- a/packages/site/src/app.js
+++ b/packages/site/src/app.js
@@ -76,50 +76,76 @@ function render() {
   writeUrl();
 }
 
+const BADGE_TITLES = {
+  source: "Built from source",
+  binary: "Prebuilt upstream binary",
+  bytecode: "Prebuilt bytecode",
+  unfree: "Unfree license",
+};
+
 function badge(text, cls) {
   const s = document.createElement("span");
   s.className = `badge ${cls}`;
   s.textContent = text;
+  s.title = BADGE_TITLES[text] ?? text;
   return s;
 }
 
-function link(href, text) {
+function link(href, text, label) {
   const a = document.createElement("a");
   a.href = href;
   a.textContent = text;
+  if (label) a.setAttribute("aria-label", label);
   return a;
+}
+
+// aria-label is not allowed on plain spans; prefix visually hidden text instead.
+function described(prefix, text) {
+  const s = document.createElement("span");
+  const sr = document.createElement("span");
+  sr.className = "sr-only";
+  sr.textContent = `${prefix} `;
+  s.append(sr, text);
+  return s;
+}
+
+function announce(msg) {
+  $("#announce").textContent = msg;
 }
 
 function card(p) {
   const li = tpl.content.firstElementChild.cloneNode(true);
-  const name = li.querySelector(".name");
-  name.textContent = p.name;
-  name.href = `?q=${encodeURIComponent(p.name)}`;
-  li.querySelector(".version").textContent = p.version;
+  li.querySelector(".name").textContent = p.name;
+  li.querySelector(".version").replaceChildren(described("version", p.version));
   li.querySelector(".desc").textContent = p.description;
   const badges = li.querySelector(".badges");
   badges.append(badge(p.source, p.source));
   // flake.lib marks unfree licenses `free = true` to skip allowUnfree, so go by name.
   if (/unfree/i.test(p.license)) badges.append(badge("unfree", "unfree"));
   const cmd = `nix run ${REPO}#${p.name}`;
-  li.querySelector(".cmd code").textContent = cmd;
-  li.querySelector(".copy").addEventListener("click", (e) => {
-    navigator.clipboard.writeText(cmd);
-    e.target.textContent = "Copied";
-    setTimeout(() => (e.target.textContent = "Copy"), 1200);
+  const code = li.querySelector(".cmd code");
+  code.textContent = cmd;
+  // Horizontally scrollable on narrow screens, so must be keyboard reachable.
+  code.tabIndex = 0;
+  const copy = li.querySelector(".copy");
+  copy.setAttribute("aria-label", `Copy nix run command for ${p.name}`);
+  copy.addEventListener("click", async () => {
+    await navigator.clipboard.writeText(cmd);
+    copy.textContent = "Copied";
+    announce(`Copied: ${cmd}`);
+    setTimeout(() => (copy.textContent = "Copy"), 1500);
   });
   const links = li.querySelector(".links");
-  const parts = [];
-  if (p.homepage) parts.push(link(p.homepage, "Homepage"));
-  parts.push(link(`${SRC}/${p.name}/package.nix`, "package.nix"));
-  if (p.hasReadme) parts.push(link(`${SRC}/${p.name}/README.md`, "README"));
-  parts.push(document.createTextNode(p.license));
-  parts.push(document.createTextNode(p.platforms.join(", ")));
-  parts.forEach((el, i) => {
-    if (i) links.append(" · ");
+  const item = (...nodes) => {
+    const el = document.createElement("li");
+    el.append(...nodes);
     links.append(el);
-  });
-  li.title = p.category;
+  };
+  if (p.homepage) item(link(p.homepage, "Homepage", `${p.name} homepage`));
+  item(link(`${SRC}/${p.name}/package.nix`, "package.nix", `Nix source for ${p.name}`));
+  if (p.hasReadme) item(link(`${SRC}/${p.name}/README.md`, "README", `README for ${p.name}`));
+  item(described("license", p.license));
+  item(described("platforms", p.platforms.join(", ")));
   return li;
 }
 
@@ -135,7 +161,8 @@ function buildChips() {
     b.type = "button";
     b.className = "chip";
     b.dataset.value = value;
-    b.innerHTML = `${label} <span class="n">${n}</span>`;
+    b.setAttribute("aria-label", `${label}, ${n} packages`);
+    b.innerHTML = `${label} <span class="n" aria-hidden="true">${n}</span>`;
     b.addEventListener("click", () => {
       state.category = state.category === value ? "" : value;
       render();

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -9,19 +9,21 @@
     <link rel="icon" href="numtide.svg" />
   </head>
   <body>
+    <a class="skip" href="#q">Skip to search</a>
     <header>
       <div class="wrap">
-        <div class="brand">
-          <a href="https://numtide.com"><img src="numtide.svg" alt="Numtide" /></a>
-          <a href="https://numtide.com">Numtide</a>
-          <span class="sep">/</span>
+        <nav class="brand" aria-label="Project">
+          <a href="https://numtide.com"><img src="numtide.svg" alt="" />Numtide</a>
+          <span class="sep" aria-hidden="true">/</span>
           <a href="https://github.com/numtide/llm-agents.nix">llm-agents.nix</a>
-        </div>
+        </nav>
         <h1>AI coding agents <span class="accent">packaged with Nix.</span></h1>
         <p class="tagline muted">Auto-updated daily. Prebuilt from the Numtide binary cache for Linux and macOS.</p>
-        <input id="q" type="search" placeholder="Search packages…" autofocus autocomplete="off" spellcheck="false" />
+        <search>
+        <label for="q" class="sr-only">Search packages</label>
+        <input id="q" type="search" placeholder="Search packages…" autocomplete="off" spellcheck="false" aria-controls="results" aria-describedby="count" />
         <div class="filters">
-          <div id="categories" class="chips" role="group" aria-label="Category"></div>
+          <div id="categories" class="chips" role="group" aria-label="Filter by category"></div>
           <div class="row">
             <select id="platform" aria-label="Platform">
               <option value="">All platforms</option>
@@ -34,15 +36,18 @@
               <option value="source">Built from source</option>
               <option value="binary">Prebuilt binary</option>
             </select>
-            <span id="count" class="muted"></span>
+            <span id="count" class="muted" role="status" aria-live="polite"></span>
           </div>
         </div>
+        </search>
       </div>
     </header>
     <main>
       <div class="wrap">
-        <ul id="results"></ul>
+        <h2 class="sr-only" id="results-heading">Packages</h2>
+        <ul id="results" aria-labelledby="results-heading"></ul>
         <p id="empty" hidden>No packages match.</p>
+        <div id="announce" class="sr-only" role="status" aria-live="polite"></div>
       </div>
     </main>
     <footer class="wrap muted">
@@ -56,16 +61,16 @@
     <template id="card">
       <li class="card">
         <div class="head">
-          <a class="name"></a>
+          <h3 class="name"></h3>
           <span class="version muted"></span>
           <span class="badges"></span>
         </div>
         <p class="desc"></p>
         <div class="cmd">
           <code></code>
-          <button type="button" class="copy" title="Copy">Copy</button>
+          <button type="button" class="copy">Copy</button>
         </div>
-        <div class="links muted"></div>
+        <ul class="links muted"></ul>
       </li>
     </template>
     <script src="app.js" type="module"></script>

--- a/packages/site/src/style.css
+++ b/packages/site/src/style.css
@@ -21,10 +21,18 @@ a:hover { color: var(--primary-dark); text-decoration: underline; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.88em; }
 .wrap { max-width: 1000px; margin: 0 auto; padding: 0 1.25rem; }
 .muted { color: var(--gray); }
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+.skip { position: absolute; left: 0.5rem; top: -3rem; background: var(--primary); color: var(--black); padding: 0.4rem 0.8rem; border-radius: var(--radius); z-index: 2; }
+.skip:focus { top: 0.5rem; }
+:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+search { display: block; }
 
 header { padding: 1.5rem 0 1.25rem; border-bottom: 1px solid var(--border); }
 .brand { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 1.25rem; }
-.brand img { height: 34px; width: 34px; }
+.brand img { height: 34px; width: 34px; vertical-align: middle; margin-right: 0.6rem; }
 .brand a { color: var(--white); font-size: 1.35rem; font-weight: 500; letter-spacing: 0.01em; }
 .brand .sep { color: var(--gray); }
 header h1 { margin: 0; font-size: 2.6rem; line-height: 1.1; font-weight: 500; }
@@ -36,7 +44,7 @@ header h1 .accent { color: var(--primary); display: block; }
   background: transparent; color: var(--white);
 }
 #q::placeholder { color: var(--gray); }
-#q:focus { outline: none; border-color: var(--primary); }
+#q:focus-visible { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px #f5822055; }
 .filters { margin-top: 1rem; display: grid; gap: 0.6rem; }
 .row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
 .row #count { margin-left: auto; font-size: 0.9rem; }
@@ -54,7 +62,7 @@ select {
 .chip:hover { border-color: var(--primary); }
 .chip .n { color: var(--gray); }
 .chip[aria-pressed="true"] { background: var(--primary); border-color: var(--primary); color: var(--black); }
-.chip[aria-pressed="true"] .n { color: #0009; }
+.chip[aria-pressed="true"] .n { color: var(--black); }
 
 main { background: var(--lightgray); color: var(--black); padding: 1.5rem 0 2rem; }
 #results {
@@ -68,7 +76,7 @@ main { background: var(--lightgray); color: var(--black); padding: 1.5rem 0 2rem
   display: flex; flex-direction: column;
 }
 .card .head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
-.card .name { font-weight: 500; font-size: 1.15rem; color: var(--primary); }
+.card .name { margin: 0; font-weight: 500; font-size: 1.15rem; color: var(--primary); }
 .card .version { font-size: 0.8rem; font-family: ui-monospace, monospace; }
 .card .badges { margin-left: auto; display: flex; gap: 0.3rem; }
 .badge {
@@ -88,9 +96,13 @@ main { background: var(--lightgray); color: var(--black); padding: 1.5rem 0 2rem
   border: 1px solid var(--white); border-radius: 999px; background: transparent; color: var(--white);
 }
 .copy:hover { border-color: var(--primary); color: var(--primary); }
-.links { font-size: 0.8rem; margin-top: 0.6rem; color: var(--gray); }
+.links { font-size: 0.8rem; margin: 0.6rem 0 0; padding: 0; list-style: none; color: var(--gray); }
+.links li { display: inline; }
+.links li + li::before { content: " · "; }
+.links a { text-decoration: underline; text-underline-offset: 2px; }
 #empty { color: var(--black); }
 footer { padding: 1.25rem; font-size: 0.85rem; text-align: center; }
+footer a { text-decoration: underline; text-underline-offset: 2px; }
 footer code { color: var(--white); }
 
 @media (max-width: 600px) {

--- a/packages/site/src/style.css
+++ b/packages/site/src/style.css
@@ -1,4 +1,4 @@
-/* Palette and type follow numtide.com: charcoal, #f58220 orange, GT Pressura. */
+/* Palette and type follow numtide.com. */
 :root {
   --black: #1c1c1c;
   --ink: #232323;
@@ -113,7 +113,7 @@ footer code { color: var(--white); }
   header h1 .accent { display: inline; }
   .tagline { display: none; }
   #results { grid-template-columns: 1fr; }
-  /* Category chips would push results below the fold; scroll them sideways instead. */
+  /* Scroll chips sideways so results stay above the fold. */
   .chips { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; }
   .chip { white-space: nowrap; }
   .card .badges { margin-left: 0; }


### PR DESCRIPTION
Follow-up to #8923.

axe-core reported unlabeled controls, aria-label on plain spans, low contrast on the active chip count, links distinguishable only by color and non-focusable scroll regions. Adds a skip link, a real label and live result count for the search, per-package headings, descriptive link/button names, visible focus rings and a copy announcement. axe now reports zero violations. Also shortens comments.
