### PR TITLE
site: install instructions instead of license/source badges

### DIFF
--- a/packages/site/package.nix
+++ b/packages/site/package.nix
@@ -6,27 +6,6 @@
 }:
 
 let
-  formatLicense =
-    l:
-    if builtins.isList l then
-      lib.concatMapStringsSep " / " formatLicense l
-    else
-      l.spdxId or l.shortName or (if builtins.isString l then l else "unknown");
-
-  sourceType =
-    pkg:
-    let
-      names = map (s: s.shortName or "") (lib.toList (pkg.meta.sourceProvenance or [ ]));
-    in
-    if lib.elem "fromSource" names then
-      "source"
-    else if lib.elem "binaryNativeCode" names then
-      "binary"
-    else if lib.elem "binaryBytecode" names then
-      "bytecode"
-    else
-      "source";
-
   supportedSystems = [
     "x86_64-linux"
     "aarch64-linux"
@@ -43,8 +22,6 @@ let
         version = pkg.version or "";
         description = pkg.meta.description or "";
         homepage = pkg.meta.homepage or null;
-        license = formatLicense (pkg.meta.license or "unknown");
-        source = sourceType pkg;
         category = pkg.passthru.category or "Uncategorized";
         mainProgram = pkg.meta.mainProgram;
         platforms = lib.filter (

--- a/packages/site/src/app.js
+++ b/packages/site/src/app.js
@@ -19,18 +19,17 @@ const CATEGORY_ORDER = [
 const $ = (s) => document.querySelector(s);
 const q = $("#q");
 const platform = $("#platform");
-const source = $("#source");
 const results = $("#results");
 const tpl = $("#card");
 
-const state = { category: "", pkgs: [] };
+const state = { category: "", open: "", pkgs: [] };
 
 function readUrl() {
   const p = new URLSearchParams(location.search);
   q.value = p.get("q") ?? "";
   state.category = p.get("category") ?? "";
   platform.value = p.get("platform") ?? "";
-  source.value = p.get("source") ?? "";
+  state.open = p.get("pkg") ?? "";
 }
 
 function writeUrl() {
@@ -38,7 +37,7 @@ function writeUrl() {
   if (q.value) p.set("q", q.value);
   if (state.category) p.set("category", state.category);
   if (platform.value) p.set("platform", platform.value);
-  if (source.value) p.set("source", source.value);
+  if (state.open) p.set("pkg", state.open);
   const s = p.toString();
   history.replaceState(null, "", s ? `?${s}` : location.pathname);
 }
@@ -62,7 +61,6 @@ function render() {
   const rows = state.pkgs
     .filter((p) => !state.category || p.category === state.category)
     .filter((p) => !platform.value || p.platforms.includes(platform.value))
-    .filter((p) => !source.value || p.source === source.value)
     .map((p) => [score(p, terms), p])
     .filter(([s]) => s >= 0)
     .sort((a, b) => b[0] - a[0] || a[1].name.localeCompare(b[1].name));
@@ -74,21 +72,6 @@ function render() {
     b.setAttribute("aria-pressed", b.dataset.value === state.category);
   }
   writeUrl();
-}
-
-const BADGE_TITLES = {
-  source: "Built from source",
-  binary: "Prebuilt upstream binary",
-  bytecode: "Prebuilt bytecode",
-  unfree: "Unfree license",
-};
-
-function badge(text, cls) {
-  const s = document.createElement("span");
-  s.className = `badge ${cls}`;
-  s.textContent = text;
-  s.title = BADGE_TITLES[text] ?? text;
-  return s;
 }
 
 function link(href, text, label) {
@@ -113,28 +96,100 @@ function announce(msg) {
   $("#announce").textContent = msg;
 }
 
-function card(p) {
-  const li = tpl.content.firstElementChild.cloneNode(true);
-  li.querySelector(".name").textContent = p.name;
-  li.querySelector(".version").replaceChildren(described("version", p.version));
-  li.querySelector(".desc").textContent = p.description;
-  const badges = li.querySelector(".badges");
-  badges.append(badge(p.source, p.source));
-  // flake.lib sets `free = true` on unfree licenses, so match by name.
-  if (/unfree/i.test(p.license)) badges.append(badge("unfree", "unfree"));
-  const cmd = `nix run ${REPO}#${p.name}`;
-  const code = li.querySelector(".cmd code");
-  code.textContent = cmd;
-  // Scrollable on narrow screens, so it must be focusable.
+const moduleSnippet = (attr, name) => `# flake.nix
+inputs.llm-agents.url = "${REPO}";
+
+# configuration module
+{ inputs, pkgs, ... }:
+{
+  ${attr} = [
+    inputs.llm-agents.packages.\${pkgs.stdenv.hostPlatform.system}.${name}
+  ];
+}`;
+
+const INSTALL = [
+  { id: "run", label: "Run", snippet: (n) => `nix run ${REPO}#${n}` },
+  { id: "shell", label: "Shell", snippet: (n) => `nix shell ${REPO}#${n}` },
+  { id: "nixos", label: "NixOS", snippet: (n) => moduleSnippet("environment.systemPackages", n) },
+  { id: "hm", label: "Home Manager", snippet: (n) => moduleSnippet("home.packages", n) },
+];
+
+// Same method across all cards, like search.nixos.org.
+let method = INSTALL.some((i) => i.id === localStorage.getItem("install-method"))
+  ? localStorage.getItem("install-method")
+  : "run";
+
+function installPanel(p) {
+  const box = document.createElement("div");
+  box.className = "install";
+  const tabs = document.createElement("div");
+  tabs.setAttribute("role", "tablist");
+  tabs.setAttribute("aria-label", `Install ${p.name}`);
+  const pre = document.createElement("pre");
+  const code = document.createElement("code");
+  // Scrollable, so it must be focusable.
   code.tabIndex = 0;
-  const copy = li.querySelector(".copy");
-  copy.setAttribute("aria-label", `Copy nix run command for ${p.name}`);
+  pre.append(code);
+  pre.setAttribute("role", "tabpanel");
+  const copy = document.createElement("button");
+  copy.type = "button";
+  copy.className = "copy";
+  copy.textContent = "Copy";
+
+  const select = (id) => {
+    method = id;
+    localStorage.setItem("install-method", id);
+    const m = INSTALL.find((i) => i.id === id);
+    code.textContent = m.snippet(p.name);
+    copy.setAttribute("aria-label", `Copy ${m.label} instructions for ${p.name}`);
+    for (const b of tabs.children) {
+      const on = b.dataset.id === id;
+      b.setAttribute("aria-selected", on);
+      b.tabIndex = on ? 0 : -1;
+    }
+  };
+  for (const m of INSTALL) {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.setAttribute("role", "tab");
+    b.dataset.id = m.id;
+    b.textContent = m.label;
+    b.addEventListener("click", () => {
+      // Switch every open card so the choice sticks visibly.
+      document.querySelectorAll(".install").forEach((el) => el._select(m.id));
+    });
+    b.addEventListener("keydown", (e) => {
+      const i = INSTALL.findIndex((x) => x.id === method);
+      const d = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
+      if (!d) return;
+      e.preventDefault();
+      const next = INSTALL[(i + d + INSTALL.length) % INSTALL.length].id;
+      document.querySelectorAll(".install").forEach((el) => el._select(next));
+      tabs.querySelector(`[data-id="${next}"]`).focus();
+    });
+    tabs.append(b);
+  }
   copy.addEventListener("click", async () => {
-    await navigator.clipboard.writeText(cmd);
+    await navigator.clipboard.writeText(code.textContent);
     copy.textContent = "Copied";
-    announce(`Copied: ${cmd}`);
+    announce(`Copied ${INSTALL.find((i) => i.id === method).label} instructions for ${p.name}`);
     setTimeout(() => (copy.textContent = "Copy"), 1500);
   });
+  box._select = select;
+  select(method);
+  const bar = document.createElement("div");
+  bar.className = "bar";
+  bar.append(tabs, copy);
+  box.append(bar, pre);
+  return box;
+}
+
+function card(p) {
+  const li = tpl.content.firstElementChild.cloneNode(true);
+  const toggle = li.querySelector(".name button");
+  toggle.textContent = p.name;
+  li.querySelector(".version").replaceChildren(described("version", p.version));
+  li.querySelector(".desc").textContent = p.description;
   const links = li.querySelector(".links");
   const item = (...nodes) => {
     const el = document.createElement("li");
@@ -144,8 +199,27 @@ function card(p) {
   if (p.homepage) item(link(p.homepage, "Homepage", `${p.name} homepage`));
   item(link(`${SRC}/${p.name}/package.nix`, "package.nix", `Nix source for ${p.name}`));
   if (p.hasReadme) item(link(`${SRC}/${p.name}/README.md`, "README", `README for ${p.name}`));
-  item(described("license", p.license));
   item(described("platforms", p.platforms.join(", ")));
+
+  let panel = null;
+  const open = (on) => {
+    toggle.setAttribute("aria-expanded", on);
+    li.classList.toggle("open", on);
+    if (on && !panel) {
+      panel = installPanel(p);
+      panel.id = `install-${p.name}`;
+      toggle.setAttribute("aria-controls", panel.id);
+      li.append(panel);
+    }
+    if (panel) panel.hidden = !on;
+  };
+  toggle.addEventListener("click", () => {
+    const on = toggle.getAttribute("aria-expanded") !== "true";
+    state.open = on ? p.name : "";
+    open(on);
+    writeUrl();
+  });
+  open(state.open === p.name);
   return li;
 }
 
@@ -183,7 +257,7 @@ state.pkgs = (await res.json()).map((p) => ({
 readUrl();
 buildChips();
 render();
-for (const el of [q, platform, source]) el.addEventListener("input", render);
+for (const el of [q, platform]) el.addEventListener("input", render);
 addEventListener("keydown", (e) => {
   if (e.key === "/" && document.activeElement !== q) {
     e.preventDefault();

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -31,11 +31,6 @@
               <option value="aarch64-linux">aarch64-linux</option>
               <option value="aarch64-darwin">aarch64-darwin</option>
             </select>
-            <select id="source" aria-label="Source type">
-              <option value="">Any build</option>
-              <option value="source">Built from source</option>
-              <option value="binary">Prebuilt binary</option>
-            </select>
             <span id="count" class="muted" role="status" aria-live="polite"></span>
           </div>
         </div>
@@ -61,15 +56,10 @@
     <template id="card">
       <li class="card">
         <div class="head">
-          <h3 class="name"></h3>
+          <h3 class="name"><button type="button" aria-expanded="false"></button></h3>
           <span class="version muted"></span>
-          <span class="badges"></span>
         </div>
         <p class="desc"></p>
-        <div class="cmd">
-          <code></code>
-          <button type="button" class="copy">Copy</button>
-        </div>
         <ul class="links muted"></ul>
       </li>
     </template>

--- a/packages/site/src/style.css
+++ b/packages/site/src/style.css
@@ -76,30 +76,38 @@ main { background: var(--lightgray); color: var(--black); padding: 1.5rem 0 2rem
   display: flex; flex-direction: column;
 }
 .card .head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
-.card .name { margin: 0; font-weight: 600; font-size: 1.2rem; color: var(--white); letter-spacing: 0.01em; }
+.card .name { margin: 0; font-size: 1.2rem; }
+.card .name button {
+  font: inherit; font-weight: 600; letter-spacing: 0.01em; color: var(--white);
+  background: none; border: 0; padding: 0; cursor: pointer; text-align: left;
+}
+.card .name button::after { content: " +"; color: var(--primary); font-weight: 400; }
+.card .name button[aria-expanded="true"]::after { content: " \2212"; }
+.card .name button:hover { color: var(--primary); }
 .card .version { font-size: 0.8rem; font-family: ui-monospace, monospace; }
-.card .badges { margin-left: auto; display: flex; gap: 0.3rem; }
-.badge {
-  font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em;
-  padding: 0.05rem 0.4rem; border-radius: 3px; border: 1px solid var(--border); color: var(--gray);
+.card .desc { margin: 0.4rem 0 0.6rem; font-size: 0.92rem; flex: 1; }
+.links { font-size: 0.8rem; margin: 0; padding: 0; list-style: none; color: var(--gray); }
+.links li { display: inline; }
+.links li + li::before { content: " \b7 "; }
+.links a { text-decoration: underline; text-underline-offset: 2px; }
+.card.open { grid-column: 1 / -1; }
+.install { margin-top: 0.8rem; border-top: 1px solid var(--border); padding-top: 0.7rem; }
+.install .bar { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+[role="tablist"] { display: flex; gap: 0.25rem; flex-wrap: wrap; flex: 1; }
+[role="tab"] {
+  font: inherit; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em;
+  padding: 0.2rem 0.55rem; border: 1px solid var(--border); border-radius: 999px;
+  background: transparent; color: var(--gray); cursor: pointer;
 }
-.badge.unfree { color: var(--primary); border-color: var(--primary-dark); }
-.card .desc { margin: 0.4rem 0 0.8rem; font-size: 0.92rem; flex: 1; }
-.cmd {
-  display: flex; align-items: center; gap: 0.5rem;
-  background: var(--ink); border-radius: 4px; padding: 0.35rem 0.4rem 0.35rem 0.7rem;
-}
-.cmd code { flex: 1; min-width: 0; overflow-x: auto; white-space: nowrap; font-size: 0.78rem; }
+[role="tab"][aria-selected="true"] { color: var(--black); background: var(--primary); border-color: var(--primary); }
+.install pre { margin: 0.6rem 0 0; background: var(--ink); border-radius: 4px; padding: 0.6rem 0.7rem; overflow-x: auto; }
+.install pre code { font-size: 0.78rem; white-space: pre; display: block; }
 .copy {
   font: inherit; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em;
   padding: 0.15rem 0.5rem; cursor: pointer;
   border: 1px solid var(--white); border-radius: 999px; background: transparent; color: var(--white);
 }
 .copy:hover { border-color: var(--primary); color: var(--primary); }
-.links { font-size: 0.8rem; margin: 0.6rem 0 0; padding: 0; list-style: none; color: var(--gray); }
-.links li { display: inline; }
-.links li + li::before { content: " · "; }
-.links a { text-decoration: underline; text-underline-offset: 2px; }
 #empty { color: var(--black); }
 footer { padding: 1.25rem; font-size: 0.85rem; text-align: center; }
 footer a { text-decoration: underline; text-underline-offset: 2px; }
@@ -116,5 +124,4 @@ footer code { color: var(--white); }
   /* Scroll chips sideways so results stay above the fold. */
   .chips { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; }
   .chip { white-space: nowrap; }
-  .card .badges { margin-left: 0; }
 }


### PR DESCRIPTION
License and build provenance are noise when picking a tool. Clicking a package now expands Run / Shell / NixOS / Home Manager snippets with a copy button; the chosen method sticks across cards like on search.nixos.org. `?pkg=` links to an expanded card.