### PR TITLE
site: cache-bust assets per build

### DIFF
--- a/packages/site/package.nix
+++ b/packages/site/package.nix
@@ -45,6 +45,10 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
     mkdir -p $out
     cp -r ./* $out/
+    # GitHub Pages caches assets for 10 minutes. Mismatched index.html and
+    # app.js after a deploy broke the page, so pin assets to this build.
+    v=$(basename $out | cut -c1-12)
+    sed -i -e "s|app.js|app.js?v=$v|" -e "s|style.css|style.css?v=$v|" $out/index.html
     jq -c 'sort_by(.name)' "$packagesJsonPath" > $out/packages.json
     touch $out/.nojekyll
     runHook postInstall

--- a/packages/site/src/app.js
+++ b/packages/site/src/app.js
@@ -249,7 +249,8 @@ function buildChips() {
   );
 }
 
-const res = await fetch("packages.json");
+// Reuse the cache-busting query from our own URL for packages.json.
+const res = await fetch(`packages.json${new URL(import.meta.url).search}`);
 state.pkgs = (await res.json()).map((p) => ({
   ...p,
   _hay: `${p.name} ${p.description} ${p.category} ${p.mainProgram}`.toLowerCase(),


### PR DESCRIPTION
GitHub Pages serves with max-age=600. After the last deploy browsers combined the new index.html with a cached app.js that still looked up the removed `#source` select and rendered nothing. Version asset URLs with the store hash so each deploy is self-consistent.