### PR TITLE
hunk: compile against unmodified bun 1.4.2 runtime

### DIFF
--- a/packages/bun-bin/hashes.json
+++ b/packages/bun-bin/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.4.2",
+  "hashes": {
+    "aarch64-darwin": "sha256-kJh6OhbX21VtiGrD1VHnttPt8KHPQ6yu1iLoZ2vh0S8=",
+    "aarch64-linux": "sha256-VDKLvC2cjgyfiSxUTWbFeoO4QTnjSQnl7oF1jxrI/ac=",
+    "x86_64-linux": "sha256-xngEDxT+BEDrg503y9DOTAUaMtpygGrJfeamqra/co8="
+  }
+}

--- a/packages/bun-bin/package.nix
+++ b/packages/bun-bin/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  platformSource,
+  mkUpdater,
+  unzip,
+}:
+
+# Unmodified upstream bun to be used as `bun build --compile --target` runtime.
+# A patchelf'd bun >= 1.3.14 embeds its runtime twice and the result segfaults
+# (see 7ef80847), so packages that need a newer runtime than nixpkgs' bun seed
+# the cross-compile cache with this instead.
+let
+  triples = {
+    x86_64-linux = "linux-x64-baseline";
+    aarch64-linux = "linux-aarch64";
+    aarch64-darwin = "darwin-aarch64";
+  };
+  source = platformSource {
+    hashesFile = ./hashes.json;
+    platforms = triples;
+    urlTemplate = "https://github.com/oven-sh/bun/releases/download/bun-v{version}/bun-{platform}.zip";
+  };
+  target = "bun-${triples.${stdenvNoCC.hostPlatform.system}}-v${source.version}";
+in
+stdenvNoCC.mkDerivation {
+  pname = "bun-bin";
+  inherit (source) version src;
+
+  nativeBuildInputs = [ unzip ];
+
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bun $out/share/bun-bin/${target}
+    runHook postInstall
+  '';
+
+  passthru = {
+    hideFromDocs = true;
+    # Copy share/bun-bin/* into $BUN_INSTALL_CACHE_DIR and pass --target.
+    inherit target;
+    updater = mkUpdater (
+      source.updater
+      // {
+        versionSource = {
+          type = "text";
+          url = "https://api.github.com/repos/oven-sh/bun/releases/latest";
+          regex = ''"tag_name": *"bun-v([^"]+)"'';
+        };
+      }
+    );
+  };
+
+  meta = {
+    description = "Upstream bun binary for use as a bun --compile runtime";
+    homepage = "https://bun.sh";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit (source) platforms;
+  };
+}

--- a/packages/hunk/package.nix
+++ b/packages/hunk/package.nix
@@ -5,6 +5,8 @@
   fetchFromGitHub,
   bun2nixLib,
   bun,
+  bun-bin,
+  wrapBuddy,
   versionCheckHook,
   versionCheckHomeHook,
 }:
@@ -27,7 +29,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     bun2nixLib.hook
     bun
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapBuddy ];
 
   bunDeps = bun2nixLib.fetchBunDeps {
     bunNix = ./bun.nix;
@@ -55,10 +58,12 @@ stdenv.mkDerivation {
   buildPhase = ''
     runHook preBuild
 
+    # --watch needs a bun >= 1.3.14 runtime (modem-dev/hunk src/core/watch/runtime.ts).
     mkdir -p .bun-tmp .bun-install
+    cp ${bun-bin}/share/bun-bin/* "$BUN_INSTALL_CACHE_DIR"/
     BUN_TMPDIR=$PWD/.bun-tmp \
     BUN_INSTALL=$PWD/.bun-install \
-    ${lib.getExe bun} build --compile "./src/main.tsx" --outfile "hunk-bin"
+    ${lib.getExe bun} build --compile --target=${bun-bin.target} "./src/main.tsx" --outfile "hunk-bin"
 
     runHook postBuild
   '';


### PR DESCRIPTION
hunk >= 0.21 refuses `--watch` when the embedded Bun is older than 1.3.14 because of the PathWatcher deadlock (oven-sh/bun#31166). nixpkgs is still on 1.3.13, and a patchelf'd newer bun cannot be used for `bun build --compile` (7ef80847).

Add `bun-bin`, the untouched upstream release binary, and seed it into bun's cross-compile cache so nixpkgs' bun does the bundling while the emitted executable carries the stock 1.4.2 runtime. The result has a /lib64 interpreter on Linux, so run it through wrapBuddy.

Fixes #8867