### PR TITLE
site: add explicit GitHub link

### DIFF
--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -16,6 +16,9 @@
           <a href="https://numtide.com"><img src="numtide.svg" alt="" />Numtide</a>
           <span class="sep" aria-hidden="true">/</span>
           <a href="https://github.com/numtide/llm-agents.nix">llm-agents.nix</a>
+          <a class="gh" href="https://github.com/numtide/llm-agents.nix" aria-label="GitHub repository" title="GitHub">
+            <svg viewBox="0 0 16 16" width="24" height="24" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.540 2.29 6.530 5.470 7.590.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.490-2.010.37-2.530-.49-2.690-.94-.09-.23-.48-.94-.82-1.130-.28-.15-.68-.52-.01-.53.63-.01 1.080.58 1.230.82.72 1.210 1.870.87 2.330.66.07-.52.28-.87.51-1.070-1.780-.2-3.640-.89-3.640-3.950 0-.87.31-1.590.82-2.150-.08-.2-.36-1.020.08-2.120 0 0 .67-.21 2.200.82.64-.18 1.320-.27 2-.27s1.360.09 2 .27c1.530-1.040 2.200-.82 2.200-.82.44 1.100.16 1.920.08 2.120.51.56.82 1.270.82 2.150 0 3.070-1.870 3.750-3.650 3.950.29.25.54.73.54 1.480 0 1.070-.01 1.930-.01 2.200 0 .21.15.46.55.38A8.010 8.010 0 0 0 16 8c0-4.420-3.580-8-8-8z"/></svg>
+          </a>
         </nav>
         <h1>AI coding agents <span class="accent">packaged with Nix.</span></h1>
         <p class="tagline muted">Auto-updated daily. Prebuilt from the Numtide binary cache for Linux and macOS.</p>
@@ -48,6 +51,7 @@
     <footer class="wrap muted">
       <p>
         <code>nix run github:numtide/llm-agents.nix#&lt;name&gt;</code> ·
+        <a href="https://github.com/numtide/llm-agents.nix">GitHub</a> ·
         <a href="https://github.com/numtide/llm-agents.nix#installation">Installation</a> ·
         <a href="packages.json">packages.json</a> ·
         by <a href="https://numtide.com">Numtide</a>

--- a/packages/site/src/style.css
+++ b/packages/site/src/style.css
@@ -35,6 +35,8 @@ header { padding: 1.5rem 0 1.25rem; border-bottom: 1px solid var(--border); }
 .brand img { height: 34px; width: 34px; vertical-align: middle; margin-right: 0.6rem; }
 .brand a { color: var(--white); font-size: 1.35rem; font-weight: 500; letter-spacing: 0.01em; }
 .brand .sep { color: var(--gray); }
+.brand .gh { margin-left: auto; display: inline-flex; color: var(--gray); }
+.brand .gh:hover { color: var(--white); }
 header h1 { margin: 0; font-size: 2.6rem; line-height: 1.1; font-weight: 500; }
 header h1 .accent { color: var(--primary); display: block; }
 .tagline { margin: 0.75rem 0 1.5rem; max-width: 42rem; }


### PR DESCRIPTION
The only link to the repository was the breadcrumb text, which is not
recognisable as a repo link. Add a GitHub icon in the header and a
text link in the footer so visitors can find the source and issues.
