### PR TITLE
chatgpt: support aarch64-darwin

### DIFF
--- a/packages/chatgpt/hashes.json
+++ b/packages/chatgpt/hashes.json
@@ -1,5 +1,10 @@
 {
   "sources": {
+    "aarch64-darwin": {
+      "version": "26.901.51231",
+      "url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.901.51231.zip",
+      "hash": "sha256-jdxODw58gCTWQWn4TPVMVEd40di/6h/9PCsNLj6oWTQ="
+    },
     "aarch64-linux": {
       "version": "26.901.51231",
       "url": "https://persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_26.901.51231_arm64.deb",

--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -50,7 +50,7 @@ stdenvNoCC.mkDerivation {
       ${lib.optionalString stdenv.hostPlatform.isLinux "--run '. ${patchRuntime}' --set-default DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1"} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
-    ln -s ${chatgpt-unwrapped}/share "$out/share"
+    ${lib.optionalString stdenv.hostPlatform.isLinux "ln -s ${chatgpt-unwrapped}/share \"\$out/share\""}
 
     runHook postInstall
   '';

--- a/packages/chatgpt/patch-asar.py
+++ b/packages/chatgpt/patch-asar.py
@@ -5,6 +5,11 @@ The asar header records file offsets, so every replacement is padded with
 spaces to the original's exact byte length instead of re-packing the archive.
 Minified identifiers change between releases, so patterns are regexes that
 capture the identifiers they need instead of hard-coding them.
+
+The second argument selects the platform patch set ("linux" by default,
+"darwin" otherwise): the NixOS-only process.report guard is absent from the
+macOS build, and the writable plugin copy fix lands in whichever branch of
+the copy helper actually runs on that platform.
 """
 
 import re
@@ -21,19 +26,25 @@ SKIP_PROCESS_REPORT = (
 )
 
 # The app materializes bundled plugins in ~/.codex and rewrites selected
-# manifests there. Node's fs.cp preserves the Nix store's read-only modes,
-# so copy with coreutils and make only the user-owned destination writable.
-# `exec` is the promisified execFile helper already used for the darwin
-# `ditto` branch. Hoisting `platform` into a local buys the bytes needed.
-COPY_PLUGINS_WRITABLE = (
-    re.compile(
-        rb"(?P<fn>async function [\w$]+\(e,t\)\{)"
-        rb"if\((?P<plat>[\w$]+\.default\.platform)===`darwin`\)"
-        rb"(?P<ditto>\{await (?P<exec>[\w$]+)\(`/usr/bin/ditto`,\[`--noqtn`,e,t\]\);return\})"
-        rb"if\((?P=plat)!==`win32`\)\{"
-        rb"await [\w$]+\.default\.cp\(e,t,\{recursive:!0,verbatimSymlinks:!0\}\);return\}"
-    ),
-    lambda m: (
+# manifests there. The Nix store is read-only (444/555 files), so whatever
+# copy helper runs - Node fs.cp on Linux, /usr/bin/ditto on macOS - preserves
+# those modes in the destination, and the manifest rewrite fails. Make the
+# destination writable after the copy. `exec` is the promisified execFile
+# helper already used for the darwin `ditto` branch. Hoisting `platform` into
+# a local buys the bytes needed to stay inside the original byte budget.
+COPY_PLUGINS_WRITABLE = re.compile(
+    rb"(?P<fn>async function [\w$]+\(e,t\)\{)"
+    rb"if\((?P<plat>[\w$]+\.default\.platform)===`darwin`\)"
+    rb"(?P<ditto>\{await (?P<exec>[\w$]+)\(`/usr/bin/ditto`,\[`--noqtn`,e,t\]\);return\})"
+    rb"if\((?P=plat)!==`win32`\)\{"
+    rb"await [\w$]+\.default\.cp\(e,t,\{recursive:!0,verbatimSymlinks:!0\}\);return\}"
+)
+
+
+def _copy_writable_linux(match: re.Match[bytes]) -> bytes:
+    """Linux: rewrite the non-darwin branch (the one that runs on Linux)."""
+    m = match
+    return (
         m["fn"]
         + b"let r="
         + m["plat"]
@@ -44,20 +55,62 @@ COPY_PLUGINS_WRITABLE = (
         + b"(`cp`,[`-r`,e+`/.`,t]);await "
         + m["exec"]
         + b"(`chmod`,[`-R`,`u+w`,t]);return}"
-    ),
-)
+    )
 
-PATCHES: list[tuple[re.Pattern[bytes], Callable[[re.Match[bytes]], bytes]]] = [
-    SKIP_PROCESS_REPORT,
-    COPY_PLUGINS_WRITABLE,
-]
+
+def _copy_writable_darwin(match: re.Match[bytes]) -> bytes:
+    """Darwin: the ``ditto`` branch is the one that runs on macOS.
+
+    ``ditto --noqtn`` preserves the source's read-only mode bits, so 444
+    store files would land read-only in ~/.codex and block the manifest
+    rewrite. Bytes are stolen from the dead branches, which can never run on
+    macOS (``ditto`` always returns first).
+    """
+    m = match
+    return (
+        m["fn"]
+        + b"let r="
+        + m["plat"]
+        + b";if(r===`darwin`)"
+        + m["ditto"][: -len(b"return}")]
+        + b"await "
+        + m["exec"]
+        + b"(`chmod`,[`-R`,`u+w`,t]);return}"
+        + b"if(r!==`win32`){await "
+        + m["exec"]
+        + b"(`cp`,[`-r`,e+`/.`,t]);return}"
+    )
+
+
+PATCHES: dict[
+    str, list[tuple[re.Pattern[bytes], Callable[[re.Match[bytes]], bytes]]]
+] = {
+    "linux": [
+        SKIP_PROCESS_REPORT,
+        (COPY_PLUGINS_WRITABLE, _copy_writable_linux),
+    ],
+    "darwin": [
+        (COPY_PLUGINS_WRITABLE, _copy_writable_darwin),
+    ],
+}
+
+# argv index of the optional platform argument.
+PLATFORM_ARGV_INDEX = 2
 
 
 def main() -> None:
-    """Patch the asar archive given as the only argument."""
+    """Patch the asar archive (argv[1]) for the given platform (argv[2])."""
     asar = Path(sys.argv[1])
+    platform = (
+        sys.argv[PLATFORM_ARGV_INDEX]
+        if len(sys.argv) > PLATFORM_ARGV_INDEX
+        else "linux"
+    )
+    if platform not in PATCHES:
+        sys.exit(f"unknown platform {platform!r} (known: {', '.join(PATCHES)})")
+
     data = asar.read_bytes()
-    for pattern, build in PATCHES:
+    for pattern, build in PATCHES[platform]:
         matches = list(pattern.finditer(data))
         if len(matches) != 1:
             sys.exit(

--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -8,6 +8,7 @@
   formatelf,
   makeWrapper,
   python3,
+  unzip,
   wrapGAppsHook3,
   alsa-lib,
   at-spi2-atk,
@@ -51,6 +52,8 @@
 let
   sourceData = builtins.fromJSON (builtins.readFile ./hashes.json);
   platform = stdenv.hostPlatform.system;
+  isLinux = stdenv.hostPlatform.isLinux;
+  isDarwin = stdenv.hostPlatform.isDarwin;
   source = sourceData.sources.${platform} or (throw "Unsupported system: ${platform}");
 in
 stdenv.mkDerivation {
@@ -64,15 +67,22 @@ stdenv.mkDerivation {
   dontStrip = true;
   dontWrapGApps = true;
 
-  nativeBuildInputs = [
-    formatelf
-    dpkg
-    makeWrapper
-    python3
-    wrapGAppsHook3
-  ];
+  nativeBuildInputs =
+    lib.optionals isLinux [
+      formatelf
+      dpkg
+      makeWrapper
+      wrapGAppsHook3
+    ]
+    ++ [
+      # patch-asar.py runs on both platforms.
+      python3
+    ]
+    ++ lib.optionals isDarwin [
+      unzip
+    ];
 
-  buildInputs = [
+  buildInputs = lib.optionals isLinux [
     alsa-lib
     at-spi2-atk
     at-spi2-core
@@ -112,7 +122,7 @@ stdenv.mkDerivation {
   # Electron loads these at runtime rather than linking them directly. Put
   # them on each ELF object's RPATH without leaking a broad LD_LIBRARY_PATH
   # into Electron's Node and Chromium children.
-  runtimeDependencies = [
+  runtimeDependencies = lib.optionals isLinux [
     libGL
     libgbm
     libsecret
@@ -127,7 +137,7 @@ stdenv.mkDerivation {
   # The Qt shims are optional and selected dynamically, so autoPatchelf cannot
   # resolve both of their runtimes during its direct dependency pass. Their
   # version-specific RPATHs are added in postFixup below.
-  autoPatchelfIgnoreMissingDeps = [
+  autoPatchelfIgnoreMissingDeps = lib.optionals isLinux [
     "libc++_shared.so"
     "libc.musl-x86_64.so.1"
     "liblog.so"
@@ -139,36 +149,60 @@ stdenv.mkDerivation {
     "libQt6Widgets.so.6"
   ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    dpkg-deb -x "$src" .
-    runHook postUnpack
-  '';
+  unpackPhase =
+    if isLinux then
+      ''
+        runHook preUnpack
+        dpkg-deb -x "$src" .
+        runHook postUnpack
+      ''
+    else
+      ''
+        runHook preUnpack
+        # The darwin distribution is a zip of the ChatGPT.app bundle.
+        unzip -q "$src"
+        runHook postUnpack
+      '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    if isLinux then
+      ''
+        runHook preInstall
 
-    mkdir -p "$out/bin" "$out/lib" "$out/share"
-    cp -r usr/lib/chatgpt "$out/lib/"
-    cp -r usr/share/applications usr/share/pixmaps "$out/share/"
-    ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
+        mkdir -p "$out/bin" "$out/lib" "$out/share"
+        cp -r usr/lib/chatgpt "$out/lib/"
+        cp -r usr/share/applications usr/share/pixmaps "$out/share/"
+        ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
 
-    # See patch-asar.py for the NixOS-specific source patches.
-    python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
+        # See patch-asar.py for the NixOS-specific source patches.
+        python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
 
-    wrapProgram "$out/lib/chatgpt/ChatGPT" \
-      "''${gappsWrapperArgs[@]}" \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          coreutils
-          xdg-utils
-        ]
-      }
+        wrapProgram "$out/lib/chatgpt/ChatGPT" \
+          "''${gappsWrapperArgs[@]}" \
+          --prefix PATH : ${
+            lib.makeBinPath [
+              coreutils
+              xdg-utils
+            ]
+          }
 
-    runHook postInstall
-  '';
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
 
-  postFixup = ''
+        mkdir -p "$out/Applications" "$out/bin"
+        mv ChatGPT.app "$out/Applications/"
+        ln -s ../Applications/ChatGPT.app/Contents/MacOS/ChatGPT "$out/bin/chatgpt"
+
+        # See patch-asar.py for the darwin store-mode patches.
+        python3 ${./patch-asar.py} "$out/Applications/ChatGPT.app/Contents/Resources/app.asar" darwin
+
+        runHook postInstall
+      '';
+
+  postFixup = lib.optionalString isLinux ''
     patchelf --add-rpath ${lib.makeLibraryPath [ qt5.qtbase ]} \
       "$out/lib/chatgpt/libqt5_shim.so"
     patchelf --add-rpath ${lib.makeLibraryPath [ qt6.qtbase ]} \
@@ -186,6 +220,7 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
   };
 }

--- a/packages/chatgpt/update.py
+++ b/packages/chatgpt/update.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from .# nixpkgs#gnupg nixpkgs#python3 --command python3
-"""Update ChatGPT from OpenAI's signed Debian repository."""
+"""Update ChatGPT from OpenAI's signed Debian repository and Sparkle appcast."""
 
 import hashlib
+import re
 import subprocess
 import sys
 import tempfile
 import urllib.request
+import xml.etree.ElementTree as ET  # conventional stdlib alias
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
@@ -20,23 +22,30 @@ KEY_FILE = PACKAGE_DIR / "openai-archive-key.asc"
 KEY_FINGERPRINT = "3BFA0E4AE8B8CC16A2D9BA684A3B4A566C4660E4"
 REPO_BASE = "https://persistent.oaistatic.com/codex-app-prod/linux/deb"
 INRELEASE_PATH = "dists/stable/InRelease"
+APPCAST_URL = "https://persistent.oaistatic.com/codex-app-prod/appcast.xml"
 PLATFORMS = {
     "aarch64-linux": "arm64",
     "x86_64-linux": "amd64",
 }
+DARWIN_PLATFORM = "aarch64-darwin"
 USER_AGENT = (
     "llm-agents.nix package updater (+https://github.com/numtide/llm-agents.nix)"
 )
 
 
-def fetch(path: str) -> bytes:
-    """Fetch one path from OpenAI's Debian repository."""
+def fetch_url(url: str) -> bytes:
+    """Fetch one absolute URL from OpenAI's static hosting."""
     request = urllib.request.Request(
-        f"{REPO_BASE}/{path}",
+        url,
         headers={"User-Agent": USER_AGENT},
     )
     with urllib.request.urlopen(request) as response:
         return bytes(response.read())
+
+
+def fetch(path: str) -> bytes:
+    """Fetch one path from OpenAI's Debian repository."""
+    return fetch_url(f"{REPO_BASE}/{path}")
 
 
 def verify_inrelease(inrelease: bytes) -> str:
@@ -178,21 +187,63 @@ def source_from_index(platform: str, architecture: str, release: str) -> dict[st
     }
 
 
+def fetch_sha256(url: str) -> str:
+    """Stream a file and return its hex sha256."""
+    hasher = hashlib.sha256()
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request) as response:
+        while chunk := response.read(1 << 20):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def darwin_source(current: dict[str, str] | None) -> dict[str, str]:
+    """Return the arm64 darwin source advertised by OpenAI's Sparkle appcast.
+
+    The appcast carries only an EdDSA signature, not a content hash, so the
+    zip is downloaded and hashed. The existing entry is reused unchanged to
+    avoid re-downloading the ~600MB archive on every run.
+    """
+    # The appcast is served over HTTPS from the pinned static host and only
+    # version/url pairings are extracted; the artifact's authenticity is
+    # enforced by the pinned hash in review (see S314).
+    root = ET.fromstring(fetch_url(APPCAST_URL))  # noqa: S314
+    for item in root.iter("item"):
+        version = (item.findtext("title") or "").strip()
+        enclosure = item.find("enclosure")
+        url = (enclosure.get("url") if enclosure is not None else "") or ""
+        if not version or not re.search(r"-arm64-[\w.]+\.zip$", url):
+            continue
+        if current and current.get("version") == version and current.get("url") == url:
+            return current
+        print(f"chatgpt: downloading {url} to compute its hash")
+        return {
+            "version": version,
+            "url": url,
+            "hash": hex_to_sri(fetch_sha256(url)),
+        }
+
+    msg = "no arm64 darwin release found in OpenAI appcast"
+    raise ValueError(msg)
+
+
 def main() -> None:
-    """Refresh all sources from OpenAI's signed APT metadata."""
+    """Refresh all sources from OpenAI's signed APT metadata and appcast."""
     release = verify_inrelease(fetch(INRELEASE_PATH))
+
+    current = load_hashes(HASHES_FILE)
+    current_sources = current.get("sources", {})
+
     sources = {
         platform: source_from_index(platform, architecture, release)
         for platform, architecture in PLATFORMS.items()
     }
+    sources[DARWIN_PLATFORM] = darwin_source(current_sources.get(DARWIN_PLATFORM))
 
     versions = {source["version"] for source in sources.values()}
     if len(versions) != 1:
-        msg = f"OpenAI architecture versions differ: {sorted(versions)}"
+        msg = f"OpenAI platform versions differ: {sorted(versions)}"
         raise ValueError(msg)
-
-    current = load_hashes(HASHES_FILE)
-    current_sources = current.get("sources", {})
     for platform, source in sources.items():
         current_version = current_sources.get(platform, {}).get("version", "")
         if (


### PR DESCRIPTION
## Summary

Adds a darwin (Apple Silicon only, per OpenAI's `hardwareRequirements`) build of the ChatGPT/Codex desktop app to `packages/chatgpt`, which is currently Linux-only.

- **`unwrapped.nix`** branches on `stdenv.hostPlatform.isDarwin`: the darwin distribution is a zip of the `ChatGPT.app` bundle (`ChatGPT-darwin-arm64-<version>.zip`), so it is unzipped into `$out/Applications` with a `bin/chatgpt` launcher symlink. All dpkg/patchelf/GApps/formatelf machinery is gated to Linux, keeping the darwin closure clean.
- **`hashes.json`** adds the `aarch64-darwin` source, pinned at the same version as the Linux builds (26.901.51231). Verified by downloading + hashing the 594 MB zip.
- **`patch-asar.py`** gains a platform-selected patch set. The NixOS-only `process.report` guard is absent from the macOS build, and the writable plugin-copy fix lands in the darwin `ditto` branch: `ditto --noqtn` preserves the store's read-only mode bits, so 444 files would land read-only in `~/.codex` and block the plugin-manifest rewrite (same failure the Linux patch fixes). Byte budget verified against the real app.asar.
- **`update.py`** now also refreshes the darwin entry from OpenAI's Sparkle appcast (`codex-app-prod/appcast.xml`), streaming the zip's sha256 only when the version changes. The existing lockstep check now requires the darwin and Linux versions to match (they are released in lockstep).
- **`package.nix`** gates the `share` symlink to Linux.

## Test plan

- [x] `nix build .#chatgpt` succeeds on aarch64-darwin (Apple M2), and the built app launches, spawning its Electron/Codex helper processes and creating its data dirs.
- [x] `nix build .#checks.aarch64-darwin.pkgs-chatgpt` plus meta-completeness / meta-maintainers / updater-tests checks pass; `nix fmt` clean.
- [x] `packages/chatgpt/update.py` runs end-to-end and reports "already up to date" (GPG-verified APT flow unchanged). The version-change path was exercised with a stubbed downloader.
- [x] Linux derivation still evaluates (`packages/` and `checks` drvPaths on x86_64-linux); the Linux install/unpack commands are byte-identical to before.

Notes:
- The app copies itself into `/Applications` on first run (OpenAI's built-in `moveToApplicationsFolder` behavior — identical to the nixpkgs darwin package) and falls back gracefully when `/Applications` is not writable.
- Locally I run Lix, whose `nix` binary does not implement the `#!/usr/bin/env nix` shebang-script feature CI relies on, so `update.py` was tested via its `nix shell ... --command python3` shebang line directly.