### PR TITLE
chatgpt: tidy the darwin support

### DIFF
--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -50,7 +50,9 @@ stdenvNoCC.mkDerivation {
       ${lib.optionalString stdenv.hostPlatform.isLinux "--run '. ${patchRuntime}' --set-default DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1"} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
-    ${lib.optionalString stdenv.hostPlatform.isLinux "ln -s ${chatgpt-unwrapped}/share \"\$out/share\""}
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      ln -s ${chatgpt-unwrapped}/share "$out/share"
+    ''}
 
     runHook postInstall
   '';

--- a/packages/chatgpt/patch-asar.py
+++ b/packages/chatgpt/patch-asar.py
@@ -6,12 +6,12 @@ spaces to the original's exact byte length instead of re-packing the archive.
 Minified identifiers change between releases, so patterns are regexes that
 capture the identifiers they need instead of hard-coding them.
 
-The second argument selects the platform patch set ("linux" by default,
-"darwin" otherwise): the NixOS-only process.report guard is absent from the
+Patch sets are per platform: the process.report guard is absent from the
 macOS build, and the writable plugin copy fix lands in whichever branch of
-the copy helper actually runs on that platform.
+the copy helper runs on that platform.
 """
 
+import argparse
 import re
 import sys
 from collections.abc import Callable
@@ -41,9 +41,7 @@ COPY_PLUGINS_WRITABLE = re.compile(
 )
 
 
-def _copy_writable_linux(match: re.Match[bytes]) -> bytes:
-    """Linux: rewrite the non-darwin branch (the one that runs on Linux)."""
-    m = match
+def _copy_writable_linux(m: re.Match[bytes]) -> bytes:
     return (
         m["fn"]
         + b"let r="
@@ -58,15 +56,9 @@ def _copy_writable_linux(match: re.Match[bytes]) -> bytes:
     )
 
 
-def _copy_writable_darwin(match: re.Match[bytes]) -> bytes:
-    """Darwin: the ``ditto`` branch is the one that runs on macOS.
-
-    ``ditto --noqtn`` preserves the source's read-only mode bits, so 444
-    store files would land read-only in ~/.codex and block the manifest
-    rewrite. Bytes are stolen from the dead branches, which can never run on
-    macOS (``ditto`` always returns first).
-    """
-    m = match
+def _copy_writable_darwin(m: re.Match[bytes]) -> bytes:
+    # the chmod bytes are stolen from the non-darwin branch, which is dead on
+    # macOS because the ditto branch always returns first
     return (
         m["fn"]
         + b"let r="
@@ -94,23 +86,17 @@ PATCHES: dict[
     ],
 }
 
-# argv index of the optional platform argument.
-PLATFORM_ARGV_INDEX = 2
-
 
 def main() -> None:
-    """Patch the asar archive (argv[1]) for the given platform (argv[2])."""
-    asar = Path(sys.argv[1])
-    platform = (
-        sys.argv[PLATFORM_ARGV_INDEX]
-        if len(sys.argv) > PLATFORM_ARGV_INDEX
-        else "linux"
-    )
-    if platform not in PATCHES:
-        sys.exit(f"unknown platform {platform!r} (known: {', '.join(PATCHES)})")
+    """Patch the asar archive in place."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asar", type=Path)
+    parser.add_argument("platform", nargs="?", default="linux", choices=PATCHES)
+    args = parser.parse_args()
+    asar: Path = args.asar
 
     data = asar.read_bytes()
-    for pattern, build in PATCHES[platform]:
+    for pattern, build in PATCHES[args.platform]:
         matches = list(pattern.finditer(data))
         if len(matches) != 1:
             sys.exit(

--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -67,20 +67,18 @@ stdenv.mkDerivation {
   dontStrip = true;
   dontWrapGApps = true;
 
-  nativeBuildInputs =
-    lib.optionals isLinux [
-      formatelf
-      dpkg
-      makeWrapper
-      wrapGAppsHook3
-    ]
-    ++ [
-      # patch-asar.py runs on both platforms.
-      python3
-    ]
-    ++ lib.optionals isDarwin [
-      unzip
-    ];
+  nativeBuildInputs = [
+    python3
+  ]
+  ++ lib.optionals isLinux [
+    formatelf
+    dpkg
+    makeWrapper
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals isDarwin [
+    unzip
+  ];
 
   buildInputs = lib.optionals isLinux [
     alsa-lib
@@ -159,7 +157,6 @@ stdenv.mkDerivation {
     else
       ''
         runHook preUnpack
-        # The darwin distribution is a zip of the ChatGPT.app bundle.
         unzip -q "$src"
         runHook postUnpack
       '';
@@ -196,7 +193,6 @@ stdenv.mkDerivation {
         mv ChatGPT.app "$out/Applications/"
         ln -s ../Applications/ChatGPT.app/Contents/MacOS/ChatGPT "$out/bin/chatgpt"
 
-        # See patch-asar.py for the darwin store-mode patches.
         python3 ${./patch-asar.py} "$out/Applications/ChatGPT.app/Contents/Resources/app.asar" darwin
 
         runHook postInstall

--- a/packages/chatgpt/update.py
+++ b/packages/chatgpt/update.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 import urllib.request
-import xml.etree.ElementTree as ET  # conventional stdlib alias
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
@@ -204,9 +204,8 @@ def darwin_source(current: dict[str, str] | None) -> dict[str, str]:
     zip is downloaded and hashed. The existing entry is reused unchanged to
     avoid re-downloading the ~600MB archive on every run.
     """
-    # The appcast is served over HTTPS from the pinned static host and only
-    # version/url pairings are extracted; the artifact's authenticity is
-    # enforced by the pinned hash in review (see S314).
+    # S314: the appcast only yields a version/url pair; the pinned hash on the
+    # downloaded artifact is what carries trust
     root = ET.fromstring(fetch_url(APPCAST_URL))  # noqa: S314
     for item in root.iter("item"):
         version = (item.findtext("title") or "").strip()


### PR DESCRIPTION
Follow-up to #8976.

- parse patch-asar.py arguments with argparse; drop the argv index constant and the manual platform check
- drop comments that restate the code
- flatten the nativeBuildInputs list and the share symlink in package.nix

Tested: patch-asar.py applied both the linux and darwin patch sets to the 26.901.51231 app.asar from the Linux deb; nix fmt is clean. The darwin build is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7DZjWq3M7Q9A1dxMbCSvc