### PR TITLE
chatgpt: fix darwin launch

### DIFF
--- a/packages/chatgpt/package.nix
+++ b/packages/chatgpt/package.nix
@@ -26,6 +26,11 @@ let
     nss
     nspr
   ];
+  executable =
+    if stdenv.hostPlatform.isDarwin then
+      "${chatgpt-unwrapped}/Applications/ChatGPT.app/Contents/MacOS/ChatGPT"
+    else
+      "${chatgpt-unwrapped}/bin/chatgpt";
   patchRuntime = replaceVars ./patch-runtime.sh {
     autoFormatelf = "${formatelf.bin}/bin/auto-formatelf";
     inotifywait = "${inotify-tools}/bin/inotifywait";
@@ -46,12 +51,17 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
 
     mkdir -p "$out/bin"
-    makeShellWrapper ${chatgpt-unwrapped}/bin/chatgpt "$out/bin/chatgpt" \
+    makeShellWrapper ${executable} "$out/bin/chatgpt" \
       ${lib.optionalString stdenv.hostPlatform.isLinux "--run '. ${patchRuntime}' --set-default DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1"} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       ln -s ${chatgpt-unwrapped}/share "$out/share"
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p "$out/Applications"
+      ln -s ${chatgpt-unwrapped}/Applications/ChatGPT.app \
+        "$out/Applications/ChatGPT.app"
     ''}
 
     runHook postInstall

--- a/packages/chatgpt/patch-asar.py
+++ b/packages/chatgpt/patch-asar.py
@@ -12,7 +12,11 @@ the copy helper runs on that platform.
 """
 
 import argparse
+import hashlib
+import json
+import plistlib
 import re
+import struct
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -74,6 +78,68 @@ def _copy_writable_darwin(m: re.Match[bytes]) -> bytes:
     )
 
 
+def _refresh_asar_integrity(data: bytes) -> tuple[bytes, str]:
+    """Refresh per-file hashes and return data plus the ASAR header hash."""
+    header_pickle_size = struct.unpack_from("<I", data, 4)[0]
+    header_size = struct.unpack_from("<I", data, 12)[0]
+    header_start = 16
+    content_start = 8 + header_pickle_size
+    raw_header = data[header_start : header_start + header_size]
+    header = json.loads(raw_header)
+
+    def refresh_files(files: dict[str, dict[str, object]]) -> None:
+        for entry in files.values():
+            nested = entry.get("files")
+            if isinstance(nested, dict):
+                refresh_files(nested)
+                continue
+
+            integrity = entry.get("integrity")
+            offset = entry.get("offset")
+            size = entry.get("size")
+            if (
+                not isinstance(integrity, dict)
+                or offset is None
+                or not isinstance(size, int)
+            ):
+                continue
+
+            start = content_start + int(str(offset))
+            content = data[start : start + size]
+            block_size = integrity.get("blockSize")
+            if not isinstance(block_size, int):
+                sys.exit("invalid ASAR integrity block size")
+            integrity["hash"] = hashlib.sha256(content).hexdigest()
+            blocks = [
+                hashlib.sha256(content[index : index + block_size]).hexdigest()
+                for index in range(0, len(content), block_size)
+            ]
+            integrity["blocks"] = blocks or [hashlib.sha256(b"").hexdigest()]
+
+    files = header.get("files")
+    if not isinstance(files, dict):
+        sys.exit("invalid ASAR header")
+    refresh_files(files)
+
+    encoded_header = json.dumps(header, separators=(",", ":")).encode()
+    if len(encoded_header) != header_size:
+        sys.exit(
+            f"ASAR header size changed: expected {header_size}, got {len(encoded_header)}"
+        )
+    updated = data[:header_start] + encoded_header + data[header_start + header_size :]
+    return updated, hashlib.sha256(encoded_header).hexdigest()
+
+
+def _update_darwin_asar_integrity(asar: Path, header_hash: str) -> None:
+    """Update Electron's top-level ASAR header hash in Info.plist."""
+    info_plist = asar.parent.parent / "Info.plist"
+    raw_plist = info_plist.read_bytes()
+    plist = plistlib.loads(raw_plist)
+    plist["ElectronAsarIntegrity"]["Resources/app.asar"]["hash"] = header_hash
+    fmt = plistlib.FMT_BINARY if raw_plist.startswith(b"bplist") else plistlib.FMT_XML
+    info_plist.write_bytes(plistlib.dumps(plist, fmt=fmt, sort_keys=False))
+
+
 PATCHES: dict[
     str, list[tuple[re.Pattern[bytes], Callable[[re.Match[bytes]], bytes]]]
 ] = {
@@ -110,7 +176,10 @@ def main() -> None:
         data = (
             data[: m.start()] + replacement.ljust(len(original), b" ") + data[m.end() :]
         )
+    data, header_hash = _refresh_asar_integrity(data)
     asar.write_bytes(data)
+    if args.platform == "darwin":
+        _update_darwin_asar_integrity(asar, header_hash)
 
 
 if __name__ == "__main__":

--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -189,21 +189,29 @@ stdenv.mkDerivation {
       ''
         runHook preInstall
 
-        mkdir -p "$out/Applications" "$out/bin"
+        mkdir -p "$out/Applications"
         mv ChatGPT.app "$out/Applications/"
-        ln -s ../Applications/ChatGPT.app/Contents/MacOS/ChatGPT "$out/bin/chatgpt"
 
         python3 ${./patch-asar.py} "$out/Applications/ChatGPT.app/Contents/Resources/app.asar" darwin
 
         runHook postInstall
       '';
 
-  postFixup = lib.optionalString isLinux ''
-    patchelf --add-rpath ${lib.makeLibraryPath [ qt5.qtbase ]} \
-      "$out/lib/chatgpt/libqt5_shim.so"
-    patchelf --add-rpath ${lib.makeLibraryPath [ qt6.qtbase ]} \
-      "$out/lib/chatgpt/libqt6_shim.so"
-  '';
+  postFixup =
+    lib.optionalString isLinux ''
+      patchelf --add-rpath ${lib.makeLibraryPath [ qt5.qtbase ]} \
+        "$out/lib/chatgpt/libqt5_shim.so"
+      patchelf --add-rpath ${lib.makeLibraryPath [ qt6.qtbase ]} \
+        "$out/lib/chatgpt/libqt6_shim.so"
+    ''
+    + lib.optionalString isDarwin ''
+      # Patching app.asar and script shebangs invalidates OpenAI's signature.
+      # An invalid signature makes macOS refuse to launch the application.
+      /usr/bin/codesign --force --deep --sign - \
+        "$out/Applications/ChatGPT.app"
+      /usr/bin/codesign --verify --deep --strict \
+        "$out/Applications/ChatGPT.app"
+    '';
 
   meta = with lib; {
     description = "Desktop application for ChatGPT and Codex";


### PR DESCRIPTION
## Summary

Fix ChatGPT launch failures on aarch64-darwin caused by build-time bundle changes, stale Electron ASAR integrity metadata, and a launcher symlink that made Electron resolve Frameworks outside the app bundle. This refreshes per-file and top-level ASAR hashes after patching, invokes the executable through its real bundle path, and ad-hoc signs and verifies the completed application after fixups. Fixes #9046.

## Test plan

<!-- How did you test this change? -->

- [x] `nix build .#<package>` succeeds
- [ ] Package updates via `nix-update` or has a custom `update.py` if nix-update doesn't work

______________________________________________________________________

> [!NOTE]
> **MCP Servers:** Please submit MCP server packages to [natsukium/mcp-servers-nix](https://github.com/natsukium/mcp-servers-nix) instead.
> That project has the infrastructure to integrate MCP servers into various agents.
