### PR TITLE
fix: add missing libnotify runtime dep

### DIFF
--- a/packages/chatgpt/unwrapped.nix
+++ b/packages/chatgpt/unwrapped.nix
@@ -123,6 +123,7 @@ stdenv.mkDerivation {
   runtimeDependencies = lib.optionals isLinux [
     libGL
     libgbm
+    libnotify
     libsecret
     libpulseaudio
     pipewire


### PR DESCRIPTION
## Summary

this patch just adds libnotify to the runtime.
initialy I was getting this message in the logs:

```
[desktop-notifications] Notification API not supported on this host
```


## Test plan

nix run /path/to/llm-agents#chatgpt -- --ozone-platform=wayland

______________________________________________________________________
